### PR TITLE
make pytorch version detection more robust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ print('-- Building version ' + VERSION)
 pytorch_package_version = os.getenv('PYTORCH_VERSION')
 
 pytorch_package_dep = 'torch'
-if pytorch_package_version is not None:
+if pytorch_package_version:
     pytorch_package_dep += "==" + pytorch_package_version
 
 


### PR DESCRIPTION
Without this and if the environment variable `PYTORCH_VERSION` exists but is unset,  

https://github.com/pytorch/data/blob/116443308b60409084ad8f97e10ced082efb9123/setup.py#L44-L45

is triggered, which leads the setup to look for `torch==`, which fails.