### PR TITLE
Fixes an issue where TarArchiveReader closes stream when read into a buffer

### DIFF
--- a/torchdata/datapipes/iter/util/tararchivereader.py
+++ b/torchdata/datapipes/iter/util/tararchivereader.py
@@ -59,8 +59,6 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
                     "Unable to extract files from corrupted tarfile stream {} due to: {}, abort!".format(pathname, e)
                 )
                 raise e
-            finally:
-                data_stream.close()
 
     def __len__(self):
         if self.length == -1:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #24

See [this issue](https://github.com/pytorch/pytorch/issues/65808) for details.

Differential Revision: [D31296100](https://our.internmc.facebook.com/intern/diff/D31296100)