### PR TITLE
expose native PyTorch datapipes

### DIFF
--- a/examples/text/CC100.ipynb
+++ b/examples/text/CC100.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "import torch\n",
     "import os\n",
-    "from torchdata.datapipes.iter FileLoader\n",
     "\n",
     "from torchdata.datapipes.iter import (\n",
+    "    FileLoader,\n",
     "    HttpReader,\n",
     "    IterableWrapper,\n",
     "    SampleMultiplexer,\n",

--- a/examples/text/CC100.ipynb
+++ b/examples/text/CC100.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "import torch\n",
     "import os\n",
-    "from torch.utils.data.datapipes.iter import FileLoader\n",
+    "from torchdata.datapipes.iter FileLoader\n",
     "\n",
     "from torchdata.datapipes.iter import (\n",
     "    HttpReader,\n",

--- a/examples/text/squad1.py
+++ b/examples/text/squad1.py
@@ -5,7 +5,7 @@ from torchdata.datapipes.iter import (
     HttpReader,
     IterableWrapper,
 )
-from torch.utils.data import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe
 from .utils import (
     _wrap_split_argument,
     _add_docstring_header,

--- a/examples/text/squad1.py
+++ b/examples/text/squad1.py
@@ -2,10 +2,10 @@
 import os
 
 from torchdata.datapipes.iter import (
+    IterDataPipe,
     HttpReader,
     IterableWrapper,
 )
-from torchdata.datapipes.iter import IterDataPipe
 from .utils import (
     _wrap_split_argument,
     _add_docstring_header,

--- a/examples/text/squad2.py
+++ b/examples/text/squad2.py
@@ -5,7 +5,7 @@ from torchdata.datapipes.iter import (
     HttpReader,
     IterableWrapper,
 )
-from torch.utils.data import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe
 from .utils import (
     _wrap_split_argument,
     _add_docstring_header,

--- a/examples/text/squad2.py
+++ b/examples/text/squad2.py
@@ -2,10 +2,10 @@
 import os
 
 from torchdata.datapipes.iter import (
+    IterDataPipe,
     HttpReader,
     IterableWrapper,
 )
-from torchdata.datapipes.iter import IterDataPipe
 from .utils import (
     _wrap_split_argument,
     _add_docstring_header,

--- a/examples/vision/caltech101.py
+++ b/examples/vision/caltech101.py
@@ -3,16 +3,16 @@ import os.path
 import re
 
 import torch
-from torchdata.datapipes.iter (
+from torchdata.datapipes.iter import (
     FileLoader,
     TarArchiveReader,
     Mapper,
     RoutedDecoder,
     Filter,
+    IterableWrapper,
+    KeyZipper,
 )
 from torch.utils.data.datapipes.utils.decoder import imagehandler, mathandler
-
-from torchdata.datapipes.iter import IterableWrapper, KeyZipper
 
 
 # Download size is ~150 MB so fake data is provided

--- a/examples/vision/caltech101.py
+++ b/examples/vision/caltech101.py
@@ -3,7 +3,7 @@ import os.path
 import re
 
 import torch
-from torch.utils.data.datapipes.iter import (
+from torchdata.datapipes.iter (
     FileLoader,
     TarArchiveReader,
     Mapper,

--- a/examples/vision/caltech256.py
+++ b/examples/vision/caltech256.py
@@ -1,15 +1,14 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os.path
 
-from torchdata.datapipes.iter (
+from torchdata.datapipes.iter import (
     FileLoader,
     TarArchiveReader,
     Mapper,
     RoutedDecoder,
+    IterableWrapper,
 )
 from torch.utils.data.datapipes.utils.decoder import imagehandler
-
-from torchdata.datapipes.iter import IterableWrapper
 
 
 # Download size is ~1.2 GB so fake data is provided

--- a/examples/vision/caltech256.py
+++ b/examples/vision/caltech256.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os.path
 
-from torch.utils.data.datapipes.iter import (
+from torchdata.datapipes.iter (
     FileLoader,
     TarArchiveReader,
     Mapper,

--- a/examples/vision/imagefolder.py
+++ b/examples/vision/imagefolder.py
@@ -10,8 +10,8 @@ import torchvision.datasets as datasets
 import torchvision.datasets.folder
 import torchvision.transforms as transforms
 from PIL import Image
-from torch.utils.data import DataLoader, IterDataPipe
-from torch.utils.data.datapipes.iter import HttpReader, FileLister
+from torch.utils.data import DataLoader
+from torchdata.datapipes.iter import HttpReader, FileLister, IterDataPipe
 
 IMAGES_ROOT = os.path.join("fakedata", "imagefolder")
 

--- a/test/_utils/_common_utils_for_test.py
+++ b/test/_utils/_common_utils_for_test.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 
-from torch.utils.data import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe
 from typing import Any, List, Tuple, TypeVar
 
 

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -13,10 +13,14 @@ import zipfile
 
 from collections import defaultdict
 from json.decoder import JSONDecodeError
-from torch.utils.data import IterDataPipe
-from torch.utils.data.datapipes.iter import FileLister, FileLoader, IterableWrapper
+import torch.utils.data.datapipes.iter
 from torch.testing._internal.common_utils import slowTest
+import torchdata
 from torchdata.datapipes.iter import (
+    IterDataPipe,
+    FileLister,
+    FileLoader,
+    IterableWrapper,
     InMemoryCacheHolder,
     KeyZipper,
     Cycler,
@@ -46,6 +50,26 @@ from _utils._common_utils_for_test import (
     get_name,
     reset_after_n_next_calls,
 )
+
+
+def test_torchdata_pytorch_consistency():
+    def extract_datapipe_names(module):
+        return {
+            name
+            for name, dp_type in module.__dict__.items()
+            if not name.startswith("_") and isinstance(dp_type, type) and issubclass(dp_type, IterDataPipe)
+        }
+
+    pytorch_datapipes = extract_datapipe_names(torch.utils.data.datapipes.iter)
+    torchdata_datapipes = extract_datapipe_names(torchdata.datapipes.iter)
+
+    missing_datapipes = pytorch_datapipes - torchdata_datapipes
+    if any(missing_datapipes):
+        msg = (
+            "The following datapipes are exposed under `torch.utils.data.datapipes.iter`, "
+            "but not under `torchdata.datapipes.iter`:\n"
+        )
+        raise AssertionError(msg + "\n".join(sorted(missing_datapipes)))
 
 
 class TestDataPipe(expecttest.TestCase):

--- a/torchdata/datapipes/__init__.py
+++ b/torchdata/datapipes/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from torch.utils.data import functional_datapipe
 from . import iter
 from . import map
 from . import utils
 
-__all__ = ["iter", "map", "utils"]
+__all__ = ["functional_datapipe", "iter", "map", "utils"]

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -1,4 +1,26 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+from torch.utils.data import IterDataPipe, functional_datapipe
+from torch.utils.data.datapipes.iter import (
+    Collator,
+    Mapper,
+    Sampler,
+    Shuffler,
+    Concater,
+    Demultiplexer,
+    Forker,
+    Multiplexer,
+    Zipper,
+    FileLister,
+    FileLoader,
+    Batcher,
+    Grouper,
+    UnBatcher,
+    RoutedDecoder,
+    Filter,
+    StreamReader,
+    IterableWrapper,
+)
+
 from torchdata.datapipes.iter.load.online import (
     OnlineReaderIterDataPipe as OnlineReader,
     HTTPReaderIterDataPipe as HttpReader,
@@ -35,14 +57,22 @@ from torchdata.datapipes.iter.util.ziparchivereader import ZipArchiveReaderIterD
 ###############################################################################
 # Reference From PyTorch Core
 ###############################################################################
-from torch.utils.data.datapipes.iter import IterableWrapper
 
 __all__ = [
+    "Batcher",
     "BucketBatcher",
     "CSVDictParser",
     "CSVParser",
+    "Collator",
+    "Concater",
     "Cycler",
+    "Demultiplexer",
+    "FileLister",
+    "FileLoader",
+    "Filter",
+    "Forker",
     "GDriveReader",
+    "Grouper",
     "HashChecker",
     "Header",
     "HttpReader",
@@ -50,19 +80,29 @@ __all__ = [
     "IndexAdder",
     "IoPathFileLister",
     "IoPathFileLoader",
+    "IterDataPipe",
     "IterableWrapper",
     "JsonParser",
     "KeyZipper",
     "LineReader",
+    "Mapper",
+    "Multiplexer",
     "OnDiskCacheHolder",
     "OnlineReader",
     "ParagraphAggregator",
+    "RoutedDecoder",
     "Rows2Columnar",
     "SampleMultiplexer",
+    "Sampler",
     "Saver",
+    "Shuffler",
+    "StreamReader",
     "TarArchiveReader",
+    "UnBatcher",
     "XzFileReader",
     "ZipArchiveReader",
+    "Zipper",
+    "functional_datapipe",
 ]
 
 # Please keep this list sorted

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torch.utils.data import IterDataPipe
 from torch.utils.data.datapipes.iter import (
     Collator,
     Mapper,
@@ -102,7 +102,6 @@ __all__ = [
     "XzFileReader",
     "ZipArchiveReader",
     "Zipper",
-    "functional_datapipe",
 ]
 
 # Please keep this list sorted

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 class IoPathFileListerIterDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 class IoPathFileListerIterDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -8,7 +8,7 @@ import re
 
 import requests
 
-from torch.utils.data import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe
 
 # TODO(VitalyFedyunin): This HTTP part is copy-pasted from the pytorch repo
 # nuke torch/utils/data/datapipes/iter/httpreader.py, when torchdata

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import random
 
-from torch.utils.data import IterDataPipe, functional_datapipe, DataChunk
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torch.utils.data import DataChunk
 from typing import Callable, Iterator, Optional, Sized, TypeVar
 
 T_co = TypeVar("T_co", covariant=True)

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import random
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 from torch.utils.data import DataChunk
 from typing import Callable, Iterator, Optional, Sized, TypeVar
 

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -5,7 +5,8 @@ from collections import deque
 from os import path
 from typing import Deque, Optional
 
-from torchdata.datapipes.iter import IterDataPipe, FileLoader, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, FileLoader
 from torchdata.datapipes.utils.common import _default_filepath_fn
 
 

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -5,8 +5,7 @@ from collections import deque
 from os import path
 from typing import Deque, Optional
 
-from torch.utils.data import IterDataPipe, functional_datapipe
-from torch.utils.data.datapipes.iter import FileLoader
+from torchdata.datapipes.iter import IterDataPipe, FileLoader, functional_datapipe
 from torchdata.datapipes.utils.common import _default_filepath_fn
 
 

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -2,7 +2,8 @@
 import warnings
 from collections import OrderedDict
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("zip_by_key")

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -2,7 +2,7 @@
 import warnings
 from collections import OrderedDict
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("zip_by_key")

--- a/torchdata/datapipes/iter/util/csvparser.py
+++ b/torchdata/datapipes/iter/util/csvparser.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import csv
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 class _CSVBaseParserIterDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/util/csvparser.py
+++ b/torchdata/datapipes/iter/util/csvparser.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import csv
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 class _CSVBaseParserIterDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/util/cycler.py
+++ b/torchdata/datapipes/iter/util/cycler.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 from typing import Optional
 
 

--- a/torchdata/datapipes/iter/util/cycler.py
+++ b/torchdata/datapipes/iter/util/cycler.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 from typing import Optional
 
 

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import hashlib
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("check_hash")

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import hashlib
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("check_hash")

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("header")

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("header")

--- a/torchdata/datapipes/iter/util/indexadder.py
+++ b/torchdata/datapipes/iter/util/indexadder.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("add_index")

--- a/torchdata/datapipes/iter/util/indexadder.py
+++ b/torchdata/datapipes/iter/util/indexadder.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("add_index")

--- a/torchdata/datapipes/iter/util/jsonparser.py
+++ b/torchdata/datapipes/iter/util/jsonparser.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import json
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("parse_json_files")

--- a/torchdata/datapipes/iter/util/jsonparser.py
+++ b/torchdata/datapipes/iter/util/jsonparser.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import json
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("parse_json_files")

--- a/torchdata/datapipes/iter/util/linereader.py
+++ b/torchdata/datapipes/iter/util/linereader.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from typing import Tuple
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("readlines")

--- a/torchdata/datapipes/iter/util/linereader.py
+++ b/torchdata/datapipes/iter/util/linereader.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 from typing import Tuple
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("readlines")

--- a/torchdata/datapipes/iter/util/paragraphaggregator.py
+++ b/torchdata/datapipes/iter/util/paragraphaggregator.py
@@ -1,5 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 def _default_line_join(lines):

--- a/torchdata/datapipes/iter/util/paragraphaggregator.py
+++ b/torchdata/datapipes/iter/util/paragraphaggregator.py
@@ -1,5 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 def _default_line_join(lines):

--- a/torchdata/datapipes/iter/util/rows2columnar.py
+++ b/torchdata/datapipes/iter/util/rows2columnar.py
@@ -2,7 +2,8 @@
 from collections import defaultdict
 from typing import List
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("rows2columnar")

--- a/torchdata/datapipes/iter/util/rows2columnar.py
+++ b/torchdata/datapipes/iter/util/rows2columnar.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import List
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("rows2columnar")

--- a/torchdata/datapipes/iter/util/samplemultiplexer.py
+++ b/torchdata/datapipes/iter/util/samplemultiplexer.py
@@ -2,7 +2,7 @@
 from typing import Dict, Optional, Sized
 import random
 
-from torch.utils.data import IterDataPipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 class SampleMultiplexerDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/util/saver.py
+++ b/torchdata/datapipes/iter/util/saver.py
@@ -2,7 +2,8 @@
 from io import IOBase
 from typing import Any, Callable, Tuple
 
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 from torchdata.datapipes.utils.common import _default_filepath_fn
 

--- a/torchdata/datapipes/iter/util/saver.py
+++ b/torchdata/datapipes/iter/util/saver.py
@@ -2,7 +2,7 @@
 from io import IOBase
 from typing import Any, Callable, Tuple
 
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 from torchdata.datapipes.utils.common import _default_filepath_fn
 

--- a/torchdata/datapipes/iter/util/tararchivereader.py
+++ b/torchdata/datapipes/iter/util/tararchivereader.py
@@ -6,7 +6,7 @@ from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Optional, Tuple, cast
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 # TODO(VitalyFedyunin): This file copy-pasted from the pytorch repo
 # nuke source class when repo is open-sourced

--- a/torchdata/datapipes/iter/util/tararchivereader.py
+++ b/torchdata/datapipes/iter/util/tararchivereader.py
@@ -6,7 +6,8 @@ from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Optional, Tuple, cast
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 # TODO(VitalyFedyunin): This file copy-pasted from the pytorch repo
 # nuke source class when repo is open-sourced

--- a/torchdata/datapipes/iter/util/xzfilereader.py
+++ b/torchdata/datapipes/iter/util/xzfilereader.py
@@ -5,7 +5,7 @@ from io import BufferedIOBase
 from typing import Iterable, Iterator, Tuple
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 
 @functional_datapipe("read_from_xz")

--- a/torchdata/datapipes/iter/util/xzfilereader.py
+++ b/torchdata/datapipes/iter/util/xzfilereader.py
@@ -5,7 +5,8 @@ from io import BufferedIOBase
 from typing import Iterable, Iterator, Tuple
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 
 @functional_datapipe("read_from_xz")

--- a/torchdata/datapipes/iter/util/ziparchivereader.py
+++ b/torchdata/datapipes/iter/util/ziparchivereader.py
@@ -7,7 +7,8 @@ from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Tuple, cast
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
 
 # TODO(VitalyFedyunin): This file copy-pasted from the pytorch repo
 # nuke source class when repo is open-sourced

--- a/torchdata/datapipes/iter/util/ziparchivereader.py
+++ b/torchdata/datapipes/iter/util/ziparchivereader.py
@@ -7,7 +7,7 @@ from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Tuple, cast
 
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
-from torch.utils.data import IterDataPipe, functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe, functional_datapipe
 
 # TODO(VitalyFedyunin): This file copy-pasted from the pytorch repo
 # nuke source class when repo is open-sourced


### PR DESCRIPTION
Closes #27. The following datapipes are exposed by both projects:

- `TarArchiveReader`
- `ZipArchiveReader`
- `IterableWrapper`
- `HttpReader`
- `LineReader`
- `BucketBatcher`