### PR TITLE
Cleaning unused codes from common.py

### DIFF
--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -1,59 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
-import fnmatch
 import tempfile
-import warnings
 
 from io import IOBase
-from typing import Iterable, List, Tuple, Union
-
-
-def match_masks(name: str, masks: Union[str, List[str]]) -> bool:
-    # empty mask matches any input name
-    if not masks:
-        return True
-
-    if isinstance(masks, str):
-        return fnmatch.fnmatch(name, masks)
-
-    for mask in masks:
-        if fnmatch.fnmatch(name, mask):
-            return True
-    return False
-
-
-def get_file_pathnames_from_root(
-    root: str, masks: Union[str, List[str]], recursive: bool = False, abspath: bool = False
-) -> Iterable[str]:
-
-    # print out an error message and raise the error out
-    def onerror(err: OSError):
-        warnings.warn(err.filename + " : " + err.strerror)
-        raise err
-
-    for path, _, files in os.walk(root, onerror=onerror):
-        if abspath:
-            path = os.path.abspath(path)
-        for f in files:
-            if match_masks(f, masks):
-                yield os.path.join(path, f)
-        if not recursive:
-            break
-
-
-def get_file_binaries_from_pathnames(pathnames: Iterable, mode: str):
-    if not isinstance(pathnames, Iterable):
-        pathnames = [
-            pathnames,
-        ]
-
-    if mode in ("b", "t"):
-        mode = "r" + mode
-
-    for pathname in pathnames:
-        if not isinstance(pathname, str):
-            raise TypeError("Expected string type for pathname, but got {}".format(type(pathname)))
-        yield (pathname, open(pathname, mode))
+from typing import Tuple
 
 
 def _default_filepath_fn(data):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #58
* __->__ #57

These code snippets were copied over from Core and used by `FileLoader` in Core. Since there is no plan to move that DataPipe to this repo. These code snippets can be removed.

Differential Revision: [D31659772](https://our.internmc.facebook.com/intern/diff/D31659772)