### PR TITLE
Using StreamWrapper for DataPipes that return a file object

### DIFF
--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -12,11 +12,11 @@ from torchdata.datapipes.iter import IterDataPipe
 
 def _get_response_from_http(url, *, timeout):
     try:
-        session = requests.Session()
-        if timeout is None:
-            r = session.get(url, stream=True)
-        else:
-            r = session.get(url, timeout=timeout, stream=True)
+        with requests.Session() as session:
+            if timeout is None:
+                r = session.get(url, stream=True)
+            else:
+                r = session.get(url, timeout=timeout, stream=True)
         return url, r.raw
     except HTTPError as e:
         raise Exception(f"Could not get the file. [HTTP Error] {e.response}.")

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -60,7 +60,7 @@ class HashCheckerIterDataPipe(IterDataPipe):
                     )
                 )
 
-            yield (file_name, stream)
+            yield file_name, stream
 
     def __len__(self):
         return len(self.source_datapipe)

--- a/torchdata/datapipes/iter/util/tararchivereader.py
+++ b/torchdata/datapipes/iter/util/tararchivereader.py
@@ -5,6 +5,7 @@ import warnings
 from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Optional, Tuple, cast
 
+from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
@@ -54,7 +55,7 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
                         warnings.warn("failed to extract file {} from source tarfile {}".format(tarinfo.name, pathname))
                         raise tarfile.ExtractError
                     inner_pathname = os.path.normpath(os.path.join(folder_name, tarinfo.name))
-                    yield (inner_pathname, extracted_fobj)  # type: ignore[misc]
+                    yield inner_pathname, StreamWrapper(extracted_fobj)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(
                     "Unable to extract files from corrupted tarfile stream {} due to: {}, abort!".format(pathname, e)

--- a/torchdata/datapipes/iter/util/xzfilereader.py
+++ b/torchdata/datapipes/iter/util/xzfilereader.py
@@ -4,6 +4,7 @@ import warnings
 from io import BufferedIOBase
 from typing import Iterable, Iterator, Tuple
 
+from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
@@ -37,7 +38,7 @@ class XzFileReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             try:
                 extracted_fobj = lzma.open(data_stream, mode="rb")  # type: ignore[call-overload]
                 new_pathname = pathname.rstrip(".xz")
-                yield new_pathname, extracted_fobj  # type: ignore[misc]
+                yield new_pathname, StreamWrapper(extracted_fobj)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted xz/lzma stream {pathname} due to: {e}, abort!")
                 raise e

--- a/torchdata/datapipes/iter/util/ziparchivereader.py
+++ b/torchdata/datapipes/iter/util/ziparchivereader.py
@@ -6,6 +6,7 @@ import zipfile
 from io import BufferedIOBase
 from typing import IO, Iterable, Iterator, Tuple, cast
 
+from torch.utils.data.datapipes.utils.common import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
@@ -54,7 +55,7 @@ class ZipArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
                         continue
                     extracted_fobj = zips.open(zipinfo)
                     inner_pathname = os.path.normpath(os.path.join(folder_name, zipinfo.filename))
-                    yield (inner_pathname, extracted_fobj)  # type: ignore[misc]
+                    yield inner_pathname, StreamWrapper(extracted_fobj)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted zipfile stream {pathname} due to: {e}, abort!")
                 raise e

--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from io import IOBase
+from torch.utils.data.datapipes.utils.common import StreamWrapper
 from typing import Tuple
 
 
@@ -20,7 +21,7 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
         raise TypeError(f"pathname binary stream tuple length should be 2, but got {len(data)}")
     if not isinstance(data[0], str):
         raise TypeError(f"pathname within the tuple should have string type pathname, but it is type {type(data[0])}")
-    if not isinstance(data[1], IOBase):
+    if not isinstance(data[1], IOBase) and not isinstance(data[1], StreamWrapper):
         raise TypeError(
             f"binary stream within the tuple should have IOBase or"
             f"its subclasses as type, but it is type {type(data[1])}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #58
* #57

This PR depends on [this PR in Core](https://github.com/pytorch/pytorch/pull/66559). There will be errors until that PR is landed in the nightly build.
