### PR TITLE
add CI job to run torchvision tests that use datapipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,32 @@ jobs:
           python setup.py develop --user
       - name: Run DataPipes tests with pytest
         run: pytest --no-header -v test
+
+  test-torchvision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python environment
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Install torch and torchvision from nightlies
+        run: pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+
+      - name: Check out torchdata repository
+        uses: actions/checkout@v2
+
+      - name: Install torchdata
+        run: python setup.py install
+
+      - name: Install test utilities
+        run: pip install pytest pytest-mock
+
+      - name: Check out torchvision repository
+        uses: actions/checkout@v2
+        with:
+          repository: pytorch/vision
+          path: vision
+
+      - name: Run torchvision datasets tests
+        run: pytest --no-header -v vision/test/test_prototype_datasets.py


### PR DESCRIPTION
As discussed in our last sync, this adds a CI workflow to run `torchvision` tests that use `torchdata` against each PR. This ensures that changes in `torchdata` don't break `torchvision` or at least we can get notified about them. 
