### PR TITLE
Use StreamWrapper for iopath, online readers, and hash checker IterDataPipes

### DIFF
--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -3,6 +3,7 @@ import os
 
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.utils import StreamWrapper
 
 
 class IoPathFileListerIterDataPipe(IterDataPipe):
@@ -69,7 +70,7 @@ class IoPathFileLoaderIterDataPipe(IterDataPipe):
     def __iter__(self):
         for file_uri in self.source_datapipe:
             with self.pathmgr.open(file_uri, self.mode) as file:
-                yield file_uri, file
+                yield file_uri, StreamWrapper(file)
 
     def __len__(self):
         return len(self.source_datapipe)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -8,6 +8,7 @@ import re
 import requests
 
 from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.utils import StreamWrapper
 
 
 def _get_response_from_http(url, *, timeout):
@@ -17,7 +18,7 @@ def _get_response_from_http(url, *, timeout):
                 r = session.get(url, stream=True)
             else:
                 r = session.get(url, timeout=timeout, stream=True)
-        return url, r.raw
+        return url, StreamWrapper(r.raw)
     except HTTPError as e:
         raise Exception(f"Could not get the file. [HTTP Error] {e.response}.")
     except RequestException as e:
@@ -75,7 +76,7 @@ def _get_response_from_google_drive(url):
         raise RuntimeError("Filename could not be autodetected")
     filename = filename[0]
 
-    return filename, response.raw
+    return filename, StreamWrapper(response.raw)
 
 
 class GDriveReaderDataPipe(IterDataPipe):

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -3,6 +3,7 @@ import hashlib
 
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.utils import StreamWrapper
 
 
 @functional_datapipe("check_hash")
@@ -58,7 +59,7 @@ class HashCheckerIterDataPipe(IterDataPipe):
                     )
                 )
 
-            yield file_name, stream
+            yield file_name, StreamWrapper(stream)
 
     def __len__(self):
         return len(self.source_datapipe)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #89
* __->__ #88

Remaking due to an issue with `ghstack`. For detailed discussions, see #87

Differential Revision: [D31964866](https://our.internmc.facebook.com/intern/diff/D31964866)