### PR TITLE
Refactor IoPath FileLister and FileLoader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           pip3 install -r requirements.txt
           pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
       - name: Install test requirements
-        run: pip3 install expecttest iopath numpy pytest
+        run: pip3 install expecttest iopath==0.1.9 numpy pytest
       - name: Build TorchData
         run: python setup.py develop
       - name: Run DataPipes tests with pytest

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -1,72 +1,107 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
 
+from typing import Iterator, List, Tuple, Union
+
+from torch.utils.data.datapipes.utils.common import match_masks
+
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 from torchdata.datapipes.utils import StreamWrapper
-from typing import Iterator, Tuple
+
+try:
+    import iopath
+
+except ImportError:
+    iopath = None
+
+
+def _create_default_pathmanager():
+    from iopath.common.file_io import HTTPURLHandler, OneDrivePathHandler, PathManager
+    pathmgr = PathManager()
+    pathmgr.register_handler(HTTPURLHandler(), allow_override=True)
+    pathmgr.register_handler(OneDrivePathHandler(), allow_override=True)
+    # S3PathHandler is not included in 0.1.8
+    try:
+        from iopath.common.s3 import S3PathHandler
+
+        pathmgr.register_handler(S3PathHandler(), allow_override=True)
+    except ImportError:
+        pass
+    return pathmgr
 
 
 class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     r""":class:`IoPathFileListerIterDataPipe`.
 
-    Iterable DataPipe to list the contents of the directory at the provided
-    `root` URI.
-    pathnames. This yields the full URI for each file within the directory.
+    Iterable DataPipe to list the contents of the directory at the provided `root` pathname or url,
+    and yields the full pathname or url for each file within the directory.
+
     Args:
-        root: The base URI directory to list files from
+        root: The root local filepath or url directory to list files from
+        masks: Unix style filter string or string list for filtering file name(s)
+
+    Note:
+        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        S3 url is supported only with `iopath`>=0.1.9.
     """
 
-    def __init__(self, *, root: str) -> None:
-        try:
-            from iopath.common.file_io import g_pathmgr
-        except ImportError:
+    def __init__(
+        self,
+        root: str,
+        masks: Union[str, List[str]] = "",
+    ) -> None:
+        if iopath is None:
             raise ModuleNotFoundError(
                 "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` or `conda install "
-                "iopath`"
-                "to install the package"
+                "datapipe. Please use `pip install iopath` to install the package"
             )
 
         self.root: str = root
-        self.pathmgr = g_pathmgr
+        self.pathmgr = _create_default_pathmanager()
+        self.masks = masks
+
+    def register_handler(self, handler, allow_override=False):
+        self.pathmgr.register_handler(handler, allow_override=allow_override)
 
     def __iter__(self) -> Iterator[str]:
         if self.pathmgr.isfile(self.root):
             yield self.root
         else:
             for file_name in self.pathmgr.ls(self.root):
-                yield os.path.join(self.root, file_name)
+                if match_masks(file_name, self.masks):
+                    yield os.path.join(self.root, file_name)
 
 
 @functional_datapipe("load_file_by_iopath")
 class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     r""":class:`IoPathFileLoaderIterDataPipe`.
 
-    Iterable DataPipe to load files from input datapipe which contains
-    URIs. This yields a tuple of pathname and an opened filestream.
+    Iterable DataPipe to open files from input datapipe which contains pathnames or URLs,
+    and yields a tuple of pathname and opened file stream.
+
     Args:
-        source_datapipe: Iterable DataPipe that provides the pathname
-        mode: Specifies the mode in which the file is opened. This arg will be
-            passed into `iopath.common.file_io.g_pathmgr.open` (internal only).
-            Check each subclass of `PathHandler` to determine which modes are
-            supported.
+        source_datapipe: Iterable DataPipe that provides the pathnames or urls
+        mode: An optional string that specifies the mode in which the file is opened ('r' by default)
+
+    Note:
+        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        S3 url is supported only with `iopath`>=0.1.9.
     """
 
     def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r") -> None:
-        try:
-            from iopath.common.file_io import g_pathmgr
-        except ImportError:
+        if iopath is None:
             raise ModuleNotFoundError(
                 "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` or `conda install "
-                "iopath`"
-                "to install the package"
+                "datapipe. Please use `pip install iopath` to install the package"
             )
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe
-        self.pathmgr = g_pathmgr
+        self.pathmgr = _create_default_pathmanager()
         self.mode: str = mode
+
+    def register_handler(self, handler, allow_override=False):
+        self.pathmgr.register_handler(handler, allow_override=allow_override)
 
     def __iter__(self) -> Iterator[Tuple[str, StreamWrapper]]:
         for file_uri in self.source_datapipe:


### PR DESCRIPTION
Fixes #52

This PR is going to add all existing `PathHandler`s from `iopath` to make sure it can handle the following data sources:
- Local File Path
- HTTP Url
- OneDrive Url
- S3 Url (will be included in `iopath` next release)

Before this PR, these two DataPipes only work with `NativePathHandler`, which would handle the local file.