### PR TITLE
fix IoPathFileLoader in conjunction with buffered datapipes

### DIFF
--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -522,6 +522,18 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         for _, f in datapipe2:
             self.assertEqual(f.read(), "0123456789abcdef")
 
+    @skipIfNoIOPath
+    def test_io_path_file_loader_iterdatapipe_with_tar(self):
+        self._write_test_tar_files()
+
+        dp = FileLister(self.temp_dir.name, "*.tar")
+        dp = IoPathFileLoader(dp, mode="rb")
+        # Can be any buffered datapipe that exhausts the previous one
+        dp = dp.shuffle()
+
+        for _, buffer in dp:
+            buffer.read()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -15,6 +15,7 @@ from torchdata.datapipes.iter import (
     FileLister,
     FileLoader,
     IterableWrapper,
+    IterDataPipe,
     IoPathFileLister,
     IoPathFileLoader,
     CSVParser,
@@ -526,7 +527,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
     def test_io_path_file_loader_iterdatapipe_with_tar(self):
         self._write_test_tar_files()
 
-        dp = FileLister(self.temp_dir.name, "*.tar")
+        dp: IterDataPipe = FileLister(self.temp_dir.name, "*.tar")
         dp = IoPathFileLoader(dp, mode="rb")
         # Can be any buffered datapipe that exhausts the previous one
         dp = dp.shuffle()

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -70,8 +70,8 @@ class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
     def __iter__(self) -> Iterator[Tuple[str, StreamWrapper]]:
         for file_uri in self.source_datapipe:
-            with self.pathmgr.open(file_uri, self.mode) as file:
-                yield file_uri, StreamWrapper(file)
+            file = self.pathmgr.open(file_uri, self.mode)
+            yield file_uri, StreamWrapper(file)
 
     def __len__(self) -> int:
         return len(self.source_datapipe)


### PR DESCRIPTION
If we keep the context manager, the file will be closed as soon as we hit the first `StopIteration`. This happens for example if a datapipe is loaded completely into a buffer.