### PR TITLE
Refactor IoPath FileLister and FileLoader

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,6 +3,7 @@ max-line-length = 120
 ignore = E203,E402,E501,F821,W503,W504,
 per-file-ignores =
     __init__.py: F401, F403, F405
+    test/*: F401
 exclude =
     ./.git,
     ./third_party,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           pip3 install -r requirements.txt
           pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
       - name: Install test requirements
-        run: pip3 install expecttest iopath numpy pytest
+        run: pip3 install expecttest iopath==0.1.9 numpy pytest
       - name: Build TorchData
         run: python setup.py develop
       - name: Run DataPipes tests with pytest

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -35,11 +35,11 @@ from _utils._common_utils_for_test import (
 )
 
 try:
-    import iopath  # type: ignore[import]  # noqa: F401
+    import iopath
     HAS_IOPATH = True
 except ImportError:
     HAS_IOPATH = False
-skipIfNoIOPath = unittest.skipIf(not HAS_IOPATH, "no iopath")
+skipIfNoIoPath = unittest.skipIf(not HAS_IOPATH, "no iopath")
 
 
 class TestDataPipeLocalIO(expecttest.TestCase):
@@ -505,7 +505,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
     # TODO (ejguan): this test currently only covers reading from local
     # filesystem. It needs to be modified once test data can be stored on
     # gdrive/s3/onedrive
-    @skipIfNoIOPath
+    @skipIfNoIoPath
     def test_io_path_file_lister_iterdatapipe(self):
         datapipe = IoPathFileLister(root=self.temp_sub_dir.name)
 
@@ -513,7 +513,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
 
-    @skipIfNoIOPath
+    @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):
         datapipe1 = IoPathFileLister(root=self.temp_sub_dir.name)
         datapipe2 = IoPathFileLoader(datapipe1)

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -57,8 +57,9 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     ) -> None:
         if iopath is None:
             raise ModuleNotFoundError(
-                "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` to install the package"
+                "Package `iopath` is required to be installed to use this datapipe."
+                "Please use `pip install iopath` or `conda install -c conda-forge iopath`"
+                "to install the package"
             )
 
         self.root: str = root
@@ -97,8 +98,9 @@ class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r", pathmgr=None) -> None:
         if iopath is None:
             raise ModuleNotFoundError(
-                "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` to install the package"
+                "Package `iopath` is required to be installed to use this datapipe."
+                "Please use `pip install iopath` or `conda install -c conda-forge iopath`"
+                "to install the package"
             )
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -18,6 +18,7 @@ except ImportError:
 
 def _create_default_pathmanager():
     from iopath.common.file_io import HTTPURLHandler, OneDrivePathHandler, PathManager
+
     pathmgr = PathManager()
     pathmgr.register_handler(HTTPURLHandler(), allow_override=True)
     pathmgr.register_handler(OneDrivePathHandler(), allow_override=True)
@@ -40,9 +41,10 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     Args:
         root: The root local filepath or url directory to list files from
         masks: Unix style filter string or string list for filtering file name(s)
+        pathmgr: Custom iopath PathManager. If not specified, a default PathManager is created.
 
     Note:
-        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        Default PathManager currently supports local file path, normal HTTP url and OneDrive url.
         S3 url is supported only with `iopath`>=0.1.9.
     """
 
@@ -50,6 +52,8 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
         self,
         root: str,
         masks: Union[str, List[str]] = "",
+        *,
+        pathmgr=None,
     ) -> None:
         if iopath is None:
             raise ModuleNotFoundError(
@@ -58,7 +62,7 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
             )
 
         self.root: str = root
-        self.pathmgr = _create_default_pathmanager()
+        self.pathmgr = _create_default_pathmanager() if pathmgr is None else pathmgr
         self.masks = masks
 
     def register_handler(self, handler, allow_override=False):
@@ -83,13 +87,14 @@ class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: Iterable DataPipe that provides the pathnames or urls
         mode: An optional string that specifies the mode in which the file is opened ('r' by default)
+        pathmgr: Custom iopath PathManager. If not specified, a default PathManager is created.
 
     Note:
-        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        Default PathManager currently supports local file path, normal HTTP url and OneDrive url.
         S3 url is supported only with `iopath`>=0.1.9.
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r") -> None:
+    def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r", pathmgr=None) -> None:
         if iopath is None:
             raise ModuleNotFoundError(
                 "Package `iopath` is required to be installed to use this "
@@ -97,7 +102,7 @@ class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
             )
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe
-        self.pathmgr = _create_default_pathmanager()
+        self.pathmgr = _create_default_pathmanager() if pathmgr is None else pathmgr
         self.mode: str = mode
 
     def register_handler(self, handler, allow_override=False):

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -1,72 +1,107 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 import os
 
+from typing import Iterator, List, Tuple, Union
+
+from torch.utils.data.datapipes.utils.common import match_masks
+
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 from torchdata.datapipes.utils import StreamWrapper
-from typing import Iterator, Tuple
+
+try:
+    import iopath
+
+except ImportError:
+    iopath = None
+
+
+def _create_default_pathmanager():
+    from iopath.common.file_io import HTTPURLHandler, OneDrivePathHandler, PathManager
+    pathmgr = PathManager()
+    pathmgr.register_handler(HTTPURLHandler(), allow_override=True)
+    pathmgr.register_handler(OneDrivePathHandler(), allow_override=True)
+    # S3PathHandler is not included in 0.1.8
+    try:
+        from iopath.common.s3 import S3PathHandler
+
+        pathmgr.register_handler(S3PathHandler(), allow_override=True)
+    except ImportError:
+        pass
+    return pathmgr
 
 
 class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     r""":class:`IoPathFileListerIterDataPipe`.
 
-    Iterable DataPipe to list the contents of the directory at the provided
-    `root` URI.
-    pathnames. This yields the full URI for each file within the directory.
+    Iterable DataPipe to list the contents of the directory at the provided `root` pathname or url,
+    and yields the full pathname or url for each file within the directory.
+
     Args:
-        root: The base URI directory to list files from
+        root: The root local filepath or url directory to list files from
+        masks: Unix style filter string or string list for filtering file name(s)
+
+    Note:
+        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        S3 url is supported only with `iopath`>=0.1.9.
     """
 
-    def __init__(self, *, root: str) -> None:
-        try:
-            from iopath.common.file_io import g_pathmgr
-        except ImportError:
+    def __init__(
+        self,
+        root: str,
+        masks: Union[str, List[str]] = "",
+    ) -> None:
+        if iopath is None:
             raise ModuleNotFoundError(
                 "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` or `conda install "
-                "iopath`"
-                "to install the package"
+                "datapipe. Please use `pip install iopath` to install the package"
             )
 
         self.root: str = root
-        self.pathmgr = g_pathmgr
+        self.pathmgr = _create_default_pathmanager()
+        self.masks = masks
+
+    def register_handler(self, handler, allow_override=False):
+        self.pathmgr.register_handler(handler, allow_override=allow_override)
 
     def __iter__(self) -> Iterator[str]:
         if self.pathmgr.isfile(self.root):
             yield self.root
         else:
             for file_name in self.pathmgr.ls(self.root):
-                yield os.path.join(self.root, file_name)
+                if match_masks(file_name, self.masks):
+                    yield os.path.join(self.root, file_name)
 
 
 @functional_datapipe("load_file_by_iopath")
 class IoPathFileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     r""":class:`IoPathFileLoaderIterDataPipe`.
 
-    Iterable DataPipe to load files from input datapipe which contains
-    URIs. This yields a tuple of pathname and an opened filestream.
+    Iterable DataPipe to open files from input datapipe which contains pathnames or URLs,
+    and yields a tuple of pathname and opened file stream.
+
     Args:
-        source_datapipe: Iterable DataPipe that provides the pathname
-        mode: Specifies the mode in which the file is opened. This arg will be
-            passed into `iopath.common.file_io.g_pathmgr.open` (internal only).
-            Check each subclass of `PathHandler` to determine which modes are
-            supported.
+        source_datapipe: Iterable DataPipe that provides the pathnames or urls
+        mode: An optional string that specifies the mode in which the file is opened ('r' by default)
+
+    Note:
+        This IterDataPipe currently supports local file path, normal HTTP url and OneDrive url.
+        S3 url is supported only with `iopath`>=0.1.9.
     """
 
     def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r") -> None:
-        try:
-            from iopath.common.file_io import g_pathmgr
-        except ImportError:
+        if iopath is None:
             raise ModuleNotFoundError(
                 "Package `iopath` is required to be installed to use this "
-                "datapipe. Please use `pip install iopath` or `conda install "
-                "iopath`"
-                "to install the package"
+                "datapipe. Please use `pip install iopath` to install the package"
             )
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe
-        self.pathmgr = g_pathmgr
+        self.pathmgr = _create_default_pathmanager()
         self.mode: str = mode
+
+    def register_handler(self, handler, allow_override=False):
+        self.pathmgr.register_handler(handler, allow_override=allow_override)
 
     def __iter__(self) -> Iterator[Tuple[str, StreamWrapper]]:
         for file_uri in self.source_datapipe:


### PR DESCRIPTION
Fixes #52

Stack from [ghstack](https://github.com/ezyang/ghstack):
* #105 Add IoPathSaver and unify the mode for Saver
* **#104 Refactor IoPath FileLister and FileLoader**

This PR is going to add all existing PathHandlers from iopath to make sure it can handle the following data sources:
- Local File Path
- HTTP Url
- OneDrive Url
- S3 Url (iopath 0.1.9)

Before this PR, these two DataPipes only work with NativePathHandler, which would handle the local file.

Differential Revision: [D32317605](https://our.internmc.facebook.com/intern/diff/D32317605)