### PR TITLE
add pycocotools to torchvision CI requirements

### DIFF
--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: python setup.py install
 
       - name: Install test requirements
-        run: pip install pytest pytest-mock scipy iopath
+        run: pip install pytest pytest-mock scipy iopath pycocotools
 
       - name: Extract torchvision ref
         id: torchvision


### PR DESCRIPTION
This is now a dependency to run the `torchvision` prototype tests. We are refactoring how dependencies are installed, so something like this should not happen anymore in the future.
