### PR TITLE
temporary fix ShardingFilter import

### DIFF
--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -19,8 +19,10 @@ from torch.utils.data.datapipes.iter import (
     Filter,
     StreamReader,
     IterableWrapper,
-    ShardingFilter,
 )
+# TODO: import ShardingFilter directly from torch.utils.data.datapipes.iter as soon as it is exposed.
+#  https://github.com/pytorch/pytorch/pull/69844 was merged, but is not yet available in the nightly releases
+from torch.utils.data.datapipes.iter.grouping import ShardingFilterIterDataPipe as ShardingFilter
 
 from torchdata.datapipes.iter.load.online import (
     OnlineReaderIterDataPipe as OnlineReader,


### PR DESCRIPTION
Without this `import torchdata` fails with the latest `torch` nightly installed.