### PR TITLE
fix package exclusion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence"
     ],
     # Package Info
-    packages=find_packages(exclude=["build*", "test*", "third_party*", "examples"]),
+    packages=find_packages(exclude=["test*", "examples*"]),
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes #140. I took the liberty to also remove `"build"` and `"third_party"` since they are currently not used by `torchdata`.
