### PR TITLE
Remove duplicated DataPipe reference from bucketbatcher

### DIFF
--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -520,14 +520,12 @@ class TestDataPipe(expecttest.TestCase):
         batch_dp = source_dp.bucketbatch(
             batch_size=3, drop_last=True, batch_num=100, bucket_num=1, in_batch_shuffle=True
         )
-        self.assertEqual(3, len(batch_dp))
         self.assertEqual(9, len(list(batch_dp.unbatch())))
 
         # Functional Test: drop last is False preserves length
         batch_dp = source_dp.bucketbatch(
             batch_size=3, drop_last=False, batch_num=100, bucket_num=1, in_batch_shuffle=False
         )
-        self.assertEqual(4, len(batch_dp))
         self.assertEqual(10, len(list(batch_dp.unbatch())))
 
         def _return_self(x):
@@ -539,14 +537,12 @@ class TestDataPipe(expecttest.TestCase):
         )
         # bucket_num = 1 means there will be no shuffling if a sort key is given
         self.assertEqual([[0, 1, 2], [3, 4, 5], [6, 7, 8]], list(batch_dp))
-        self.assertEqual(3, len(batch_dp))
         self.assertEqual(9, len(list(batch_dp.unbatch())))
 
         # Functional Test: using sort_key, without in_batch_shuffle
         batch_dp = source_dp.bucketbatch(
             batch_size=3, drop_last=True, batch_num=100, bucket_num=2, in_batch_shuffle=False, sort_key=_return_self
         )
-        self.assertEqual(3, len(batch_dp))
         self.assertEqual(9, len(list(batch_dp.unbatch())))
 
         # Reset Test:
@@ -567,7 +563,8 @@ class TestDataPipe(expecttest.TestCase):
         self.assertEqual(9, len([item for batch in res_after_reset for item in batch]))
 
         # __len__ Test: returns the number of batches
-        self.assertEqual(3, len(batch_dp))
+        with self.assertRaises(TypeError):
+            len(batch_dp)
 
 
 if __name__ == "__main__":

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -51,7 +51,7 @@ class BucketBatcherIterDataPipe(IterDataPipe[DataChunk[T_co]]):
         bucket_num: int = 1,
         sort_key: Optional[Callable] = None,
         in_batch_shuffle: bool = True,
-    ) -> IterDataPipe:
+    ):
         assert batch_size > 0, "Batch size is required to be larger than 0!"
         assert batch_num > 0, "Number of batches is required to be larger than 0!"
         assert bucket_num > 0, "Number of buckets is required to be larger than 0!"


### PR DESCRIPTION
Fixes #136 

Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#177 Remove duplicated DataPipe reference from bucketbatcher**

Differential Revision: [D33719657](https://our.internmc.facebook.com/intern/diff/D33719657)