### PR TITLE
[hackathon] Adding ParquetDFIterDataPipe

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -38,3 +38,6 @@ ignore_missing_imports = True
 
 [mypy-torcharrow.*]
 ignore_missing_imports = True
+
+[mypy-pyarrow.*]
+ignore_missing_imports = True

--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -29,6 +29,7 @@ class TestDataFrame(expecttest.TestCase):
         table = df.to_arrow()
         parquet.write_table(table, os.path.join(self.temp_dir.name, fname))
 
+    @skipIfNoArrow
     def setUp(self) -> None:
         self.temp_dir = create_temp_dir()
 
@@ -42,6 +43,7 @@ class TestDataFrame(expecttest.TestCase):
             fname = f"df{i}.parquet"
             self._write_df_as_parquet(df, fname)
 
+    @skipIfNoArrow
     def tearDown(self) -> None:
         try:
             self.temp_dir.cleanup()

--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -8,6 +8,7 @@ from _utils._common_utils_for_test import reset_after_n_next_calls
 from torchdata.datapipes.iter import DataFrameMaker, IterableWrapper
 
 try:
+    import pyarrow
     import torcharrow
     import torcharrow.dtypes as dt
 
@@ -60,3 +61,7 @@ class TestDataFrame(expecttest.TestCase):
             self._compare_dataframes(exp_df, act_df)
         for exp_df, act_df in zip(expected_dfs, res_after_reset):
             self._compare_dataframes(exp_df, act_df)
+
+    @skipIfNoArrow
+    def test_parquet_dataframe_reader_iterdatapipe(self):
+        pass  # TODO: Generate a temp directory, use PyArrow to create Parquet file, then read it using the DataPipe

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -51,7 +51,10 @@ from torchdata.datapipes.iter.util.combining import (
     MapKeyZipperIterDataPipe as MapKeyZipper,
 )
 from torchdata.datapipes.iter.util.cycler import CyclerIterDataPipe as Cycler
-from torchdata.datapipes.iter.util.dataframemaker import DataFrameMakerIterDataPipe as DataFrameMaker
+from torchdata.datapipes.iter.util.dataframemaker import (
+    DataFrameMakerIterDataPipe as DataFrameMaker,
+    ParquetDFIterDataPipe as ParquetDFReader,
+)
 from torchdata.datapipes.iter.util.extractor import ExtractorIterDataPipe as Extractor
 from torchdata.datapipes.iter.util.hashchecker import HashCheckerIterDataPipe as HashChecker
 from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -122,6 +122,7 @@ __all__ = [
     "OnDiskCacheHolder",
     "OnlineReader",
     "ParagraphAggregator",
+    "ParquetDFReader",
     "RarArchiveLoader",
     "RoutedDecoder",
     "Rows2Columnar",

--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -6,11 +6,13 @@ from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
 try:
+    import pyarrow.parquet as parquet
     import torcharrow
     import torcharrow.dtypes
 except ImportError:
     torcharrow = None
     torcharrow.dtypes = None
+    parquet = None
 
 T_co = TypeVar("T_co")
 
@@ -30,7 +32,7 @@ class DataFrameMakerIterDataPipe(IterDataPipe[torcharrow.IDataFrame[T_co]]):
     """
 
     def __new__(
-        self,
+        cls,
         source_dp: IterDataPipe[T_co],
         dataframe_size: int = 1000,  # or Page Size
         dtype: Optional[torcharrow.dtypes.DType] = None,
@@ -40,4 +42,30 @@ class DataFrameMakerIterDataPipe(IterDataPipe[torcharrow.IDataFrame[T_co]]):
         # In this version, DF tracing is not available, which would allow DataPipe to run DataFrame operations
         batch_dp = source_dp.batch(dataframe_size)
         df_dp = batch_dp.map(partial(torcharrow.DataFrame, dtype=dtype, columns=columns, device=device))
+        return df_dp
+
+
+@functional_datapipe("load_parquet_as_df")
+class ParquetDFIterDataPipe(IterDataPipe):
+    r"""
+    Iterable DataPipe that takes in paths to Parquet files and return a TorchArrow DataFrame for each Parquet file.
+
+    Args:
+        source_dp: source DataPipe containing paths to the Parquet files
+        columns: List of str that specifies the column names of the DataFrame
+        use_threads: if True, Parquet reader will perform multi-threaded column reads
+        dtype: specify the TorchArrow dtype for the DataFrame
+        device: specify the device on which the DataFrame will be stored
+    """
+
+    def __new__(
+        cls,
+        source_dp: IterDataPipe[str],
+        columns: Optional[List[str]] = None,
+        use_threads: bool = False,
+        dtype: Optional[torcharrow.dtypes.DType] = None,
+        device: str = "",
+    ):
+        table_dp = source_dp.map(partial(parquet.read_table, columns=columns, use_threads=use_threads))
+        df_dp = table_dp.map(torcharrow.from_arrow)
         return df_dp


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #183
* __->__ #181
* #180

Part of DataLoader v2 hackathon, this PR implements a new DataPipe that can read Parquet files and return TorchArrow DataFrames for each row group within the Parquet files.

CI failures of TorchVision is unrelated.

This PR is dependent on a change from TorchArrow

Differential Revision: [D33803733](https://our.internmc.facebook.com/intern/diff/D33803733)