### PR TITLE
Prevent RarArchiveLoader reading nested RAR explicitly

### DIFF
--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -68,7 +68,7 @@ from torchdata.datapipes.iter.util.plain_text_reader import (
     CSVParserIterDataPipe as CSVParser,
     LineReaderIterDataPipe as LineReader,
 )
-from torchdata.datapipes.iter.util.rar_archive_loader import RarArchiveLoaderIterDataPipe as RarArchiveLoader
+from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterDataPipe as RarArchiveLoader
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
 from torchdata.datapipes.iter.util.saver import SaverIterDataPipe as Saver


### PR DESCRIPTION
Fixes #189

### Changes

- ~Rename `RarArchiveLoader` to `RarArchvieReader` and corresponding functional API~
- Raise Error when reading nested RAR
- Add tests for nested RAR and nested TAR.

cc: @pmeier There is a BC-breaking naming change.