### PR TITLE
Removing Iter/MapDataPipe examples since they have been moved into the classes' docstrings

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -14,6 +14,7 @@ This is an updated version of ``IterableDataset`` in ``torch``.
 
 .. autoclass:: IterDataPipe
 
+
 We have three types of Iterable DataPipes:
 
 1. Load - help you interact with the file systems or online databases (e.g. FileOpener, GDriveReader)
@@ -21,19 +22,6 @@ We have three types of Iterable DataPipes:
 2. Transform - transform elements within DataPipes (e.g. batching, shuffling)
 
 3. Utility - utility functions (e.g. caching, CSV parsing, filtering)
-
-These DataPipes can be invoked in two ways, using the class constructor or applying their functional form onto
-an existing `IterDataPipe` (available to most but not all DataPipes).
-
-.. code:: python
-
-    import torchdata.datapipes.iter import IterableWrapper, Mapper
-
-    dp = IterableWrapper(range(10))
-    map_dp_1 = Mapper(dp, lambda x: x + 1)  # Using class constructor
-    map_dp_2 = dp.map(lambda x: x + 1)  # Using functional form
-    list(map_dp_1)  # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    list(map_dp_2)  # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
 Load DataPipes
 -------------------------

--- a/docs/source/torchdata.datapipes.map.rst
+++ b/docs/source/torchdata.datapipes.map.rst
@@ -3,27 +3,16 @@ Map-style DataPipes
 
 .. currentmodule:: torchdata.datapipes.map
 
-A map-style dataset is one that implements the ``__getitem__()`` and ``__len__()`` protocols, and represents a map
+A Map-style DataPipe is one that implements the ``__getitem__()`` and ``__len__()`` protocols, and represents a map
 from (possibly non-integral) indices/keys to data samples.
+
+For example, when accessed with ``mapdatapipe[idx]``, could read the ``idx``-th image and its
+corresponding label from a folder on the disk.
 
 .. autoclass:: MapDataPipe
 
-For example, such a dataset, when accessed with ``mapdatapipe[idx]``, could read the ``idx``-th image and its
-corresponding label from a folder on the disk.
 
-These DataPipes can be invoked in two ways, using the class constructor or applying their functional form onto
-an existing `MapDataPipe` (available to most but not all DataPipes).
-
-.. code:: python
-
-    from torchdata.datapipes.map import SequenceWrapper, Mapper
-
-    dp = SequenceWrapper(range(10))
-    map_dp_1 = dp.map(lambda x: x + 1)
-    list(map_dp_1)  # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-    map_dp_2 = Mapper(dp, lambda x: x + 1)
-    list(map_dp_2)  # [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
+Here is the list of available Map-style DataPipes:
 
 DataPipes
 -------------------------


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #216
* #212
* __->__ #211

With https://github.com/pytorch/pytorch/pull/72618, the examples are moved into the classes' docstrings. Therefore, the examples here can be removed.

Differential Revision: [D34144165](https://our.internmc.facebook.com/intern/diff/D34144165)