### PR TITLE
Bump version for temp release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ ROOT_DIR = Path(__file__).parent.resolve()
 
 
 def _get_version():
-    version = "0.3.0a0"
+    version = "0.3.0a1"
     sha = "Unknown"
     try:
         sha = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=str(ROOT_DIR)).decode("ascii").strip()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#217 Bump version for temp release**

Have to bump version to upload this temp release to PyPI (Can not overwrite on PyPI)