### PR TITLE
Add release GHA

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -1,0 +1,55 @@
+name: Push Nightly Release
+
+on:
+  workflow_dispatch:
+  # TODO: Automatically trigger nightly release
+  # push
+  #   branches:
+  #     - main
+  # schedule
+  #   - cron: 30 23 * * *
+
+jobs:
+  # Build, Test and Upload
+  build_test_upload:
+    if: github.repository == 'pytorch/data'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # TODO: Turn the matrix on after cpp landed
+      matrix:
+        os:
+          # - macos-latest
+          - ubuntu-latest
+          # - windows-latest
+        python-version:
+          # - 3.7
+          # - 3.8
+          - 3.9
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      # TODO: Add skip if the last commit is same as previous release
+      - name: Install dependencies
+        run: |
+          pip3 install -r requirements.txt
+          pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+      - name: Build TorchData Wheel
+        run: |
+          pip3 install wheel
+          python setup.py bdist_wheel --nightly
+      - name: Install TorchData
+        run: pip3 install dist/torchdata*.whl
+      - name: Install test requirements
+        run: pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile
+      - name: Run DataPipes tests with pytest
+        run:
+          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
+          --ignore=test/test_audio_examples.py
+      # TODO: Upload
+      # - name: Push TorchData Binary to PyTorch Storage
+      # - name: Push TorchData Binary to Conda

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Push Test Release
+
+on:
+  workflow_dispatch:
+  # TODO: Automatically trigger test/official release
+  # push
+  #   branches:
+  #     - release/*
+  # schedule
+  #   - cron: 30 23 * * *
+
+jobs:
+  # Build, Test and Upload
+  build_test_upload:
+    if: github.repository == 'pytorch/data'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # TODO: Turn the matrix on after cpp landed
+      matrix:
+        os:
+          # - macos-latest
+          - ubuntu-latest
+          # - windows-latest
+        python-version:
+          # - 3.7
+          # - 3.8
+          - 3.9
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Check out source repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          pip3 install -r requirements.txt
+          # TODO: Detect test or official release
+          pip3 install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
+      - name: Build TorchData Wheel
+        run: |
+          pip3 install wheel
+          python setup.py bdist_wheel --release
+      - name: Install TorchData
+        run: pip3 install dist/torchdata*.whl
+      - name: Install test requirements
+        run: pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile
+      - name: Run DataPipes tests with pytest
+        run:
+          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
+          --ignore=test/test_audio_examples.py
+      - name: Push TorchData Binary to PyTorch Storage
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PYTORCH_BINARY_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          pip3 install --user awscli
+          set -x
+          for pkg in dist/torchdata*.whl; do
+              aws s3 cp "$pkg" "s3://pytorch/whl/test/cpu" --acl public-read
+          done
+      # TODO: Official Release to PyPI and Conda
+      # - name: Push TorchData Binary to PYPI
+      #   env:
+      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      #   run: |
+      #     echo $PYPI_TOKEN
+      #   run: |
+      #     pip3 install twine
+      #     python -m twine upload
+      #       --username __token__ \
+      #       --password "$PYPI_TOKEN" \
+      #       dist/torchdata*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,12 @@
 name: Push Test Release
 
 on:
+  # [ Note: Manually Trigger the Workflow ]
+  # 1. Go to Actions under pytorch/data repo
+  # 2. In the left sidebar, click the workflow you want to run
+  # 3. Above the list of workflow runs, select Run workflow
+  # 4. Use the Branch dropdown to select the release/* branch
+  # 5. Click Run workflow
   workflow_dispatch:
   # TODO: Automatically trigger test/official release
   # push

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 # Copyright (c) Facebook, Inc. and its affiliates.
+import argparse
 import os
 import subprocess
+import sys
+from datetime import datetime
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -9,7 +12,7 @@ from setuptools import find_packages, setup
 ROOT_DIR = Path(__file__).parent.resolve()
 
 
-def _get_version():
+def _get_version(nightly=False, release=False):
     version = "0.3.0a0"
     sha = "Unknown"
     try:
@@ -17,11 +20,16 @@ def _get_version():
     except Exception:
         pass
 
-    os_build_version = os.getenv("BUILD_VERSION")
-    if os_build_version:
-        version = os_build_version
-    elif sha != "Unknown":
-        version += "+" + sha[:7]
+    if nightly:
+        version = version[:-2] + "dev" + f"{datetime.utcnow():%Y%m%d}"
+    elif release:
+        version = version[:-2]
+    else:
+        os_build_version = os.getenv("BUILD_VERSION")
+        if os_build_version:
+            version = os_build_version
+        elif sha != "Unknown":
+            version += "+" + sha[:7]
 
     return version, sha
 
@@ -33,41 +41,61 @@ def _export_version(version, sha):
         f.write(f"git_version = {repr(sha)}\n")
 
 
-VERSION, SHA = _get_version()
-_export_version(VERSION, SHA)
+def get_parser():
+    parser = argparse.ArgumentParser(description="TorchData setup")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--nightly",
+        action="store_true",
+        help="Nightly Release",
+    )
+    group.add_argument(
+        "--release",
+        action="store_true",
+        help="Official/RC Release",
+    )
+    return parser
 
-print("-- Building version " + VERSION)
 
-pytorch_package_version = os.getenv("PYTORCH_VERSION")
+if __name__ == "__main__":
+    args, unknown = get_parser().parse_known_args()
 
-pytorch_package_dep = "torch"
-if pytorch_package_version:
-    pytorch_package_dep += "==" + pytorch_package_version
+    VERSION, SHA = _get_version(args.nightly, args.release)
+    _export_version(VERSION, SHA)
 
-setup(
-    # Metadata
-    name="torchdata",
-    version=VERSION,
-    description="Composable data loading modules for PyTorch",
-    url="https://github.com/pytorch/data",
-    author="PyTorch Team",
-    author_email="packages@pytorch.org",
-    license="BSD",
-    install_requires=["requests", pytorch_package_dep],
-    python_requires=">=3.7",
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    ],
-    # Package Info
-    packages=find_packages(exclude=["test*", "examples*"]),
-    zip_safe=False,
-)
+    print("-- Building version " + VERSION)
+
+    pytorch_package_version = os.getenv("PYTORCH_VERSION")
+
+    pytorch_package_dep = "torch"
+    if pytorch_package_version:
+        pytorch_package_dep += "==" + pytorch_package_version
+
+    sys.argv = [sys.argv[0]] + unknown
+    setup(
+        # Metadata
+        name="torchdata",
+        version=VERSION,
+        description="Composable data loading modules for PyTorch",
+        url="https://github.com/pytorch/data",
+        author="PyTorch Team",
+        author_email="packages@pytorch.org",
+        license="BSD",
+        install_requires=["requests", pytorch_package_dep],
+        python_requires=">=3.7",
+        classifiers=[
+            "Intended Audience :: Developers",
+            "Intended Audience :: Science/Research",
+            "License :: OSI Approved :: BSD License",
+            "Operating System :: MacOS :: MacOS X",
+            "Operating System :: Microsoft :: Windows",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: Implementation :: CPython",
+            "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        ],
+        # Package Info
+        packages=find_packages(exclude=["test*", "examples*"]),
+        zip_safe=False,
+    )


### PR DESCRIPTION
Copy of #220 in order to access env secrets

### Changes
- Update `setup.py` to generate right version for different types of releases (nightly, rc, official release)
- Add GHA workflow to enable to release uploading for testing and nightly
- Currently using manually dispatch to trigger this upload for now. And, manual trigger can only be carried out when this PR is landed.  Please check this test run to validate the workflow: https://github.com/pytorch/data/actions/runs/1843730857