### PR TITLE
Create daily workflow to upload RC release only if changes present

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -1,0 +1,115 @@
+name: Build, Test and Upload Wheel
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+      pip_path:
+        required: true
+        type: string
+      pre_dev_release:
+        required: true
+        type: boolean
+
+jobs:
+  build_test_upload:
+    if: github.repository == 'pytorch/data' && inputs.branch != ''
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      # TODO: Turn the matrix on after cpp landed
+      matrix:
+        os:
+          # - macos-latest
+          - ubuntu-latest
+          # - windows-latest
+        python-version:
+          # - 3.7
+          # - 3.8
+          - 3.9
+    steps:
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Pre-release/Development-release PyTorch
+        if: inputs.pre_dev_release
+        run: |
+          pip3 install numpy
+          pip3 install --pre torch -f ${{ inputs.pip_path }}
+      - name: Install Official PyTorch
+        if: ${{ ! inputs.pre_dev_release }}
+        run: |
+          pip3 install numpy
+          pip3 install torch torchdata -f ${{ inputs.pip_path }}
+      - name: Check out source repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Get Hash of the Last Commit from Release
+        if: inputs.pre_dev_release
+        run: |
+          pip3 install -r requirements.txt
+          # Using --no-deps here to make sure correct version of PyTorch Core
+          pip3 install --pre torchdata -f ${{ inputs.pip_path }} --no-deps
+          pushd ~
+          RELEASE_COMMIT=$(python -c 'import torchdata; print(torchdata.version.git_version)')
+          echo "::set-output name=hash::$RELEASE_COMMIT"
+          popd
+          pip3 uninstall -y torchdata
+        id: release_commit
+      - name: Get Hash of the Last Commit from Source
+        if: ${{ inputs.pre_dev_release }}
+        run: |
+          SOURCE_COMMIT=$(git rev-parse HEAD)
+          echo "::set-output name=hash::$SOURCE_COMMIT"
+        id: source_commit
+      # The following steps for pre-release will be skipped if the last commit
+      # from branch is the same as the last commit in release wheel
+      - name: Build and Install TorchData Wheel
+        if: |
+          ! inputs.pre_dev_release ||
+            steps.release_commit.outputs.hash != steps.source_commit.outputs.hash
+        run: |
+          pip3 install wheel
+          python setup.py bdist_wheel --release
+          pip3 install dist/torchdata*.whl
+      - name: Install test requirements
+        if: |
+          ! inputs.pre_dev_release ||
+            steps.release_commit.outputs.hash != steps.source_commit.outputs.hash
+        run: pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile
+      - name: Run DataPipes tests with pytest
+        if: |
+          ! inputs.pre_dev_release ||
+            steps.release_commit.outputs.hash != steps.source_commit.outputs.hash
+        run:
+          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
+          --ignore=test/test_audio_examples.py
+      - name: Upload Wheel to S3 Storage
+        if: |
+          inputs.pre_dev_release &&
+            (steps.release_commit.outputs.hash != steps.source_commit.outputs.hash)
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PYTORCH_BINARY_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          [[ ${{ inputs.branch }} == 'main' ]] && S3_PATH=s3://pytorch/whl/nightly/ || S3_PATH=s3://pytorch/whl/test/
+          pip3 install --user awscli
+          set -x
+          for pkg in dist/torchdata*.whl; do
+              aws s3 cp "$pkg" S3_PATH --acl public-read
+          done
+      - name: Push Official Wheel to PYPI
+        if: ${{ ! inputs.pre_dev_release }}
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          pip3 install twine
+          python -m twine upload
+            --username __token__ \
+            --password "$PYPI_TOKEN" \
+            dist/torchdata*.whl
+      # TODO: Upload Nightly/Official Wheel to Conda

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -1,55 +1,21 @@
 name: Push Nightly Release
 
 on:
+  # [ Note: Manually Trigger the Workflow ]
+  # 1. Go to Actions under pytorch/data repo
+  # 2. In the left sidebar, click the workflow you want to run
+  # 3. Above the list of workflow runs, select Run workflow
+  # 4. Use the Branch dropdown to select the release/* branch
+  # 5. Click Run workflow
   workflow_dispatch:
   # TODO: Automatically trigger nightly release
-  # push
-  #   branches:
-  #     - main
-  # schedule
+  # schedule:
   #   - cron: 30 23 * * *
 
 jobs:
-  # Build, Test and Upload
   build_test_upload:
-    if: github.repository == 'pytorch/data'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      # TODO: Turn the matrix on after cpp landed
-      matrix:
-        os:
-          # - macos-latest
-          - ubuntu-latest
-          # - windows-latest
-        python-version:
-          # - 3.7
-          # - 3.8
-          - 3.9
-    steps:
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Check out source repository
-        uses: actions/checkout@v2
-      # TODO: Add skip if the last commit is same as previous release
-      - name: Install dependencies
-        run: |
-          pip3 install -r requirements.txt
-          pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
-      - name: Build TorchData Wheel
-        run: |
-          pip3 install wheel
-          python setup.py bdist_wheel --nightly
-      - name: Install TorchData
-        run: pip3 install dist/torchdata*.whl
-      - name: Install test requirements
-        run: pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile
-      - name: Run DataPipes tests with pytest
-        run:
-          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
-          --ignore=test/test_audio_examples.py
-      # TODO: Upload
-      # - name: Push TorchData Binary to PyTorch Storage
-      # - name: Push TorchData Binary to Conda
+    uses: ./.github/workflows/_build_test_upload.yml
+    with:
+      branch: ""
+      pip_path: https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+      pre_dev_release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Push Test Release
+name: Push Official Release
 
 on:
   # [ Note: Manually Trigger the Workflow ]
@@ -8,73 +8,11 @@ on:
   # 4. Use the Branch dropdown to select the release/* branch
   # 5. Click Run workflow
   workflow_dispatch:
-  # TODO: Automatically trigger test/official release
-  # push
-  #   branches:
-  #     - release/*
-  # schedule
-  #   - cron: 30 23 * * *
 
 jobs:
-  # Build, Test and Upload
   build_test_upload:
-    if: github.repository == 'pytorch/data'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      # TODO: Turn the matrix on after cpp landed
-      matrix:
-        os:
-          # - macos-latest
-          - ubuntu-latest
-          # - windows-latest
-        python-version:
-          # - 3.7
-          # - 3.8
-          - 3.9
-    steps:
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Check out source repository
-        uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          pip3 install -r requirements.txt
-          # TODO: Detect test or official release
-          pip3 install --pre torch -f https://download.pytorch.org/whl/test/cpu/torch_test.html
-      - name: Build TorchData Wheel
-        run: |
-          pip3 install wheel
-          python setup.py bdist_wheel --release
-      - name: Install TorchData
-        run: pip3 install dist/torchdata*.whl
-      - name: Install test requirements
-        run: pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile
-      - name: Run DataPipes tests with pytest
-        run:
-          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
-          --ignore=test/test_audio_examples.py
-      - name: Push TorchData Binary to PyTorch Storage
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.PYTORCH_BINARY_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY }}
-        run: |
-          pip3 install --user awscli
-          set -x
-          for pkg in dist/torchdata*.whl; do
-              aws s3 cp "$pkg" "s3://pytorch/whl/test/cpu" --acl public-read
-          done
-      # TODO: Official Release to PyPI and Conda
-      # - name: Push TorchData Binary to PYPI
-      #   env:
-      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      #   run: |
-      #     echo $PYPI_TOKEN
-      #   run: |
-      #     pip3 install twine
-      #     python -m twine upload
-      #       --username __token__ \
-      #       --password "$PYPI_TOKEN" \
-      #       dist/torchdata*.whl
+    uses: ./.github/workflows/_build_test_upload.yml
+    with:
+      branch: ""
+      pip_path: ""
+      pre_dev_release: false

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -1,0 +1,31 @@
+name: Push Test Release
+
+on:
+  # [ Note: Manually Trigger the Workflow ]
+  # 1. Go to Actions under pytorch/data repo
+  # 2. In the left sidebar, click the workflow you want to run
+  # 3. Above the list of workflow runs, select Run workflow
+  # 4. Use the Branch dropdown to select the release/* branch
+  # 5. Click Run workflow
+  # workflow_dispatch:
+  # Automatically trigger test/official release
+  # Requred Feature of GHA: Run schedule on specific branch
+  # Otherwise, all changes for release need to be landed into main branch
+  # See: https://github.community/t/scheduled-builds-of-non-default-branch/16306
+  schedule:
+    - cron: 30 23 * * *
+
+# [ Note: Workflow/Job Level ENV ]
+# Workflow/Job level env doesn't work even though document indicates this feature
+# https://github.com/actions/runner/issues/480
+# https://github.community/t/how-to-set-and-access-a-workflow-variable/17335
+# env:
+#   RELEASE_BRANCH: ""
+
+jobs:
+  build_test_upload:
+    uses: ./.github/workflows/_build_test_upload.yml
+    with:
+      branch: "release/0.3.0"
+      pip_path: https://download.pytorch.org/whl/test/cpu/torch_test.html
+      pre_dev_release: true

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ import argparse
 import os
 import subprocess
 import sys
-from datetime import datetime
+
+from datetime import date
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -21,7 +22,8 @@ def _get_version(nightly=False, release=False):
         pass
 
     if nightly:
-        version = version[:-2] + "dev" + f"{datetime.utcnow():%Y%m%d}"
+        today = date.today()
+        version = version[:-2] + ".dev" + f"{today.year}{today.month}{today.day}"
     elif release:
         version = version[:-2]
     else:


### PR DESCRIPTION
### Changes

- Add `_build_test_upload.yml` as a utility workflow for three different releases
- Using `git_version` to determine if new changes exist in the branch. Only upload new wheel if changes present.
- Switch to `cron` to run workflow daily for RC release

Please check the result of the following workflow
- Official release (https://github.com/pytorch/data/runs/5223365922?check_suite_focus=true)
  - Install Official PyTorch
  - Checkout release branch of TorchData
  - Build Wheel and Install Wheel
  - Test
  - Upload to PyPi
  - Upload to Conda [TODO]
- Test release (https://github.com/pytorch/data/runs/5223365862?check_suite_focus=true)
  - Install RC-release PyTorch from test-channel
  - Install RC-release TorchData from test-channel
  - Checkout release branch of TorchData
  - Compare last commit of release branch and RC-release of TorchData
  - Build Wheel and Install Wheel
  - Test
  - Upload to S3
- Nightly release (https://github.com/pytorch/data/runs/5223365860?check_suite_focus=true)
  - Install nightly-release PyTorch
  - Install nightly-release TorchData
  - Checkout main branch of TorchData
  - Compare last commit of main branch and nightly-release of TorchData
  - Build Wheel and Install Wheel
  - Test
  - Upload to S3
  - Upload to Conda [TODO]