### PR TITLE
Adding version number to sidebar and updating metadata

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@ import os
 import sys
 
 import pytorch_sphinx_theme
+import torchdata
 
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -26,11 +27,14 @@ print(target_dir)
 # -- Project information -----------------------------------------------------
 
 project = "TorchData"
-copyright = "2022, Meta"
-author = "Meta"
+copyright = "2021 - Present, Torch Contributors"
+author = "Torch Contributors"
+
+# The short X.Y version
+version = "main (" + torchdata.__version__ + " )"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0"
+release = "main"
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,6 +61,15 @@ exclude_patterns = []
 # html_theme = 'alabaster'
 html_theme = "pytorch_sphinx_theme"
 html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
+
+html_theme_options = {
+    "collapse_navigation": False,
+    "display_version": True,
+    "logo_only": True,
+    "pytorch_project": "docs",
+    "navigation_with_keys": True,
+    "analytics_id": "UA-117752657-2",
+}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,8 +60,7 @@ Features described in this documentation are classified by release status:
    PyTorch on XLA Devices <http://pytorch.org/xla/>
 
 
-Indices and tables
+Indices
 ==================
 
 * :ref:`genindex`
-* :ref:`modindex`


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #236

This adds the version number to the sidebar and updates a few metadata to match other repos.

We will need to see if the number still looks correct when we are on a release branch.

Differential Revision: [D34347606](https://our.internmc.facebook.com/intern/diff/D34347606)