### PR TITLE
[Release 0.3.0] Renaming Archive readers to loaders, and extractor to decompressor

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -50,9 +50,9 @@ These DataPipes help opening and decompressing archive files of different format
 
     Extractor
     RarArchiveLoader
-    TarArchiveReader
-    XzFileReader
-    ZipArchiveReader
+    TarArchiveLoader
+    XzFileLoader
+    ZipArchiveLoader
 
 Augmenting DataPipes
 -----------------------------

--- a/examples/audio/librispeech.py
+++ b/examples/audio/librispeech.py
@@ -101,7 +101,7 @@ def LibriSpeech(root: Union[str, Path], url: str = URL, folder_in_archive: str =
     cache_decompressed_dp = cache_compressed_dp.on_disk_cache(
         filepath_fn=lambda tar_path: os.path.join(root, folder_in_archive, tar_path.split(".")[0])
     )
-    cache_decompressed_dp = FileOpener(cache_decompressed_dp, mode="b").read_from_tar()
+    cache_decompressed_dp = FileOpener(cache_decompressed_dp, mode="b").load_from_tar()
     cache_decompressed_dp = cache_decompressed_dp.end_caching(
         filepath_fn=functools.partial(decompress_filepath_fn, root_path=os.path.join(root, folder_in_archive)),
     )

--- a/examples/text/amazonreviewpolarity.py
+++ b/examples/text/amazonreviewpolarity.py
@@ -41,7 +41,7 @@ def AmazonReviewPolarity(root, split):
         filepath_fn=lambda x: os.path.join(root, _EXTRACTED_FILES[split])
     )
     cache_decompressed_dp = (
-        FileOpener(cache_decompressed_dp, mode="b").read_from_tar().filter(lambda x: _EXTRACTED_FILES[split] in x[0])
+        FileOpener(cache_decompressed_dp, mode="b").load_from_tar().filter(lambda x: _EXTRACTED_FILES[split] in x[0])
     )
     cache_decompressed_dp = cache_decompressed_dp.end_caching(mode="wb", same_filepath_fn=True)
 

--- a/examples/text/imdb.py
+++ b/examples/text/imdb.py
@@ -43,7 +43,7 @@ def IMDB(root, split):
     cache_dp = FileOpener(cache_dp, mode="b")
 
     # stack TAR extractor on top of load files data pipe
-    extracted_files = cache_dp.read_from_tar()
+    extracted_files = cache_dp.load_from_tar()
 
     # filter the files as applicable to create dataset for given split (train or test)
     filter_files = extracted_files.filter(

--- a/examples/vision/caltech101.py
+++ b/examples/vision/caltech101.py
@@ -11,7 +11,7 @@ from torchdata.datapipes.iter import (
     IterKeyZipper,
     Mapper,
     RoutedDecoder,
-    TarArchiveReader,
+    TarArchiveLoader,
 )
 
 
@@ -90,14 +90,14 @@ def collate_sample(data):
 def Caltech101(root=ROOT):
     anns_dp = IterableWrapper([os.path.join(root, "Annotations.tar")])
     anns_dp = FileOpener(anns_dp, mode="b")
-    anns_dp = TarArchiveReader(anns_dp)
+    anns_dp = TarArchiveLoader(anns_dp)
     anns_dp = Filter(anns_dp, is_ann)
     anns_dp = RoutedDecoder(anns_dp, mathandler())
     anns_dp = Mapper(anns_dp, collate_ann)
 
     images_dp = IterableWrapper([os.path.join(root, "101_ObjectCategories.tar.gz")])
     images_dp = FileOpener(images_dp, mode="b")
-    images_dp = TarArchiveReader(images_dp)
+    images_dp = TarArchiveLoader(images_dp)
     images_dp = Filter(images_dp, is_not_background_image)
     images_dp = Filter(images_dp, is_not_rogue_image)
     images_dp = RoutedDecoder(images_dp, imagehandler("pil"))

--- a/examples/vision/caltech256.py
+++ b/examples/vision/caltech256.py
@@ -3,7 +3,7 @@ import os.path
 
 from torch.utils.data.datapipes.utils.decoder import imagehandler
 
-from torchdata.datapipes.iter import FileOpener, IterableWrapper, Mapper, RoutedDecoder, TarArchiveReader
+from torchdata.datapipes.iter import FileOpener, IterableWrapper, Mapper, RoutedDecoder, TarArchiveLoader
 
 
 # Download size is ~1.2 GB so fake data is provided
@@ -24,7 +24,7 @@ def collate_sample(data):
 def Caltech256(root=ROOT):
     dp = IterableWrapper([os.path.join(root, "256_ObjectCategories.tar")])
     dp = FileOpener(dp, mode="b")
-    dp = TarArchiveReader(dp)
+    dp = TarArchiveLoader(dp)
     dp = RoutedDecoder(dp, imagehandler("pil"))
     return Mapper(dp, collate_sample)
 

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -113,7 +113,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         file_cache_dp = FileOpener(file_cache_dp, mode="rb")
 
         # Functional API
-        file_cache_dp = file_cache_dp.read_from_tar()
+        file_cache_dp = file_cache_dp.load_from_tar()
 
         def _csv_filepath_fn(csv_path):
             return os.path.join(self.temp_dir.name, "csv", os.path.basename(csv_path))
@@ -143,7 +143,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         file_cache_dp = OnDiskCacheHolder(
             tar_cache_dp, filepath_fn=lambda tar_path: os.path.join(os.path.dirname(tar_path), root_dir)
         )
-        file_cache_dp = FileOpener(file_cache_dp, mode="rb").read_from_tar()
+        file_cache_dp = FileOpener(file_cache_dp, mode="rb").load_from_tar()
         file_cache_dp = file_cache_dp.end_caching(
             mode="wb",
             filepath_fn=lambda file_path: os.path.join(self.temp_dir.name, root_dir, os.path.basename(file_path)),

--- a/torchdata/datapipes/gen_pyi.py
+++ b/torchdata/datapipes/gen_pyi.py
@@ -47,7 +47,12 @@ def main() -> None:
         "dataframe": "torcharrow.DataFrame",
         "end_caching": "IterDataPipe",
         "unzip": "List[IterDataPipe]",
+        "read_from_tar": "IterDataPipe",
+        "read_from_xz": "IterDataPipe",
+        "read_from_zip": "IterDataPipe",
+        "extract": "IterDataPipe",
     }
+    method_name_exlusion: Set[str] = {"def extract", "read_from_tar", "read_from_xz", "read_from_zip"}
 
     td_iter_method_definitions = get_method_definitions(
         iterDP_file_paths,
@@ -57,6 +62,10 @@ def main() -> None:
         iterDP_method_to_special_output_type,
         root=str(pathlib.Path(__file__).parent.resolve()),
     )
+
+    td_iter_method_definitions = [
+        s for s in td_iter_method_definitions if all(ex not in s for ex in method_name_exlusion)
+    ]
 
     iter_method_definitions = core_iter_method_definitions + td_iter_method_definitions
 

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -54,7 +54,10 @@ from torchdata.datapipes.iter.util.dataframemaker import (
     DataFrameMakerIterDataPipe as DataFrameMaker,
     ParquetDFLoaderIterDataPipe as ParquetDataFrameLoader,
 )
-from torchdata.datapipes.iter.util.extractor import ExtractorIterDataPipe as Extractor
+from torchdata.datapipes.iter.util.decompressor import (
+    DecompressorIterDataPipe as Decompressor,
+    ExtractorIterDataPipe as Extractor,
+)
 from torchdata.datapipes.iter.util.hashchecker import HashCheckerIterDataPipe as HashChecker
 from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header
 from torchdata.datapipes.iter.util.indexadder import (
@@ -72,10 +75,19 @@ from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterD
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
 from torchdata.datapipes.iter.util.saver import SaverIterDataPipe as Saver
-from torchdata.datapipes.iter.util.tararchivereader import TarArchiveReaderIterDataPipe as TarArchiveReader
+from torchdata.datapipes.iter.util.tararchiveloader import (
+    TarArchiveLoaderIterDataPipe as TarArchiveLoader,
+    TarArchiveReaderIterDataPipe as TarArchiveReader,
+)
 from torchdata.datapipes.iter.util.unzipper import UnZipperIterDataPipe as UnZipper
-from torchdata.datapipes.iter.util.xzfilereader import XzFileReaderIterDataPipe as XzFileReader
-from torchdata.datapipes.iter.util.ziparchivereader import ZipArchiveReaderIterDataPipe as ZipArchiveReader
+from torchdata.datapipes.iter.util.xzfileloader import (
+    XzFileLoaderIterDataPipe as XzFileLoader,
+    XzFileReaderIterDataPipe as XzFileReader,
+)
+from torchdata.datapipes.iter.util.ziparchiveloader import (
+    ZipArchiveLoaderIterDataPipe as ZipArchiveLoader,
+    ZipArchiveReaderIterDataPipe as ZipArchiveReader,
+)
 
 ###############################################################################
 # Reference From PyTorch Core
@@ -90,6 +102,7 @@ __all__ = [
     "Concater",
     "Cycler",
     "DataFrameMaker",
+    "Decompressor",
     "Demultiplexer",
     "EndOnDiskCacheHolder",
     "Enumerator",
@@ -133,10 +146,13 @@ __all__ = [
     "ShardingFilter",
     "Shuffler",
     "StreamReader",
+    "TarArchiveLoader",
     "TarArchiveReader",
     "UnBatcher",
     "UnZipper",
+    "XzFileLoader",
     "XzFileReader",
+    "ZipArchiveLoader",
     "ZipArchiveReader",
     "Zipper",
 ]

--- a/torchdata/datapipes/iter/__init__.pyi
+++ b/torchdata/datapipes/iter/__init__.pyi
@@ -53,7 +53,10 @@ from torchdata.datapipes.iter.util.dataframemaker import (
     DataFrameMakerIterDataPipe as DataFrameMaker,
     ParquetDFLoaderIterDataPipe as ParquetDataFrameLoader,
 )
-from torchdata.datapipes.iter.util.extractor import ExtractorIterDataPipe as Extractor
+from torchdata.datapipes.iter.util.decompressor import (
+    DecompressorIterDataPipe as Decompressor,
+    ExtractorIterDataPipe as Extractor,
+)
 from torchdata.datapipes.iter.util.hashchecker import HashCheckerIterDataPipe as HashChecker
 from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header
 from torchdata.datapipes.iter.util.indexadder import (
@@ -71,10 +74,19 @@ from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterD
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
 from torchdata.datapipes.iter.util.saver import SaverIterDataPipe as Saver
-from torchdata.datapipes.iter.util.tararchivereader import TarArchiveReaderIterDataPipe as TarArchiveReader
+from torchdata.datapipes.iter.util.tararchiveloader import (
+    TarArchiveLoaderIterDataPipe as TarArchiveLoader,
+    TarArchiveReaderIterDataPipe as TarArchiveReader,
+)
 from torchdata.datapipes.iter.util.unzipper import UnZipperIterDataPipe as UnZipper
-from torchdata.datapipes.iter.util.xzfilereader import XzFileReaderIterDataPipe as XzFileReader
-from torchdata.datapipes.iter.util.ziparchivereader import ZipArchiveReaderIterDataPipe as ZipArchiveReader
+from torchdata.datapipes.iter.util.xzfileloader import (
+    XzFileLoaderIterDataPipe as XzFileLoader,
+    XzFileReaderIterDataPipe as XzFileReader,
+)
+from torchdata.datapipes.iter.util.ziparchiveloader import (
+    ZipArchiveLoaderIterDataPipe as ZipArchiveLoader,
+    ZipArchiveReaderIterDataPipe as ZipArchiveReader,
+)
 
 ###############################################################################
 # Reference From PyTorch Core
@@ -89,6 +101,7 @@ __all__ = [
     "Concater",
     "Cycler",
     "DataFrameMaker",
+    "Decompressor",
     "Demultiplexer",
     "EndOnDiskCacheHolder",
     "Enumerator",
@@ -132,10 +145,13 @@ __all__ = [
     "ShardingFilter",
     "Shuffler",
     "StreamReader",
+    "TarArchiveLoader",
     "TarArchiveReader",
     "UnBatcher",
     "UnZipper",
+    "XzFileLoader",
     "XzFileReader",
+    "ZipArchiveLoader",
     "ZipArchiveReader",
     "Zipper",
 ]
@@ -156,7 +172,7 @@ from torchdata.datapipes.map import MapDataPipe
 # Note that, for mypy, .pyi file takes precedent over .py file, such that we must define the interface for other
 # classes/objects here, even though we are not injecting extra code into them at the moment.
 
-from .util.extractor import CompressionType
+from .util.decompressor import CompressionType
 
 try:
     import torcharrow
@@ -244,12 +260,12 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_DataPipeMeta):
     def dataframe(
         self, dataframe_size: int = 1000, dtype=None, columns: Optional[List[str]] = None, device: str = ""
     ) -> torcharrow.DataFrame: ...
+    # Functional form of 'DecompressorIterDataPipe'
+    def decompress(self, file_type: Optional[Union[str, CompressionType]] = None) -> IterDataPipe: ...
     # Functional form of 'EndOnDiskCacheHolderIterDataPipe'
     def end_caching(self, mode="wb", filepath_fn=None, *, same_filepath_fn=False, skip_read=False) -> IterDataPipe: ...
     # Functional form of 'EnumeratorIterDataPipe'
     def enumerate(self, starting_index: int = 0) -> IterDataPipe: ...
-    # Functional form of 'ExtractorIterDataPipe'
-    def extract(self, file_type: Optional[Union[str, CompressionType]] = None) -> IterDataPipe: ...
     # Functional form of 'FlatMapperIterDataPipe'
     def flatmap(self, fn: Callable) -> IterDataPipe: ...
     # Functional form of 'HeaderIterDataPipe'
@@ -260,6 +276,12 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_DataPipeMeta):
     def lines_to_paragraphs(self, joiner: Callable = ...) -> IterDataPipe: ...
     # Functional form of 'RarArchiveLoaderIterDataPipe'
     def load_from_rar(self, *, length: int = -1) -> IterDataPipe: ...
+    # Functional form of 'TarArchiveLoaderIterDataPipe'
+    def load_from_tar(self, mode: str = "r:*", length: int = -1) -> IterDataPipe: ...
+    # Functional form of 'XzFileLoaderIterDataPipe'
+    def load_from_xz(self, length: int = -1) -> IterDataPipe: ...
+    # Functional form of 'ZipArchiveLoaderIterDataPipe'
+    def load_from_zip(self, length: int = -1) -> IterDataPipe: ...
     # Functional form of 'ParquetDFLoaderIterDataPipe'
     def load_parquet_as_df(
         self, dtype=None, columns: Optional[List[str]] = None, device: str = "", use_threads: bool = False
@@ -300,12 +322,6 @@ class IterDataPipe(IterableDataset[T_co], metaclass=_DataPipeMeta):
     ) -> IterDataPipe: ...
     # Functional form of 'JsonParserIterDataPipe'
     def parse_json_files(self, **kwargs) -> IterDataPipe: ...
-    # Functional form of 'TarArchiveReaderIterDataPipe'
-    def read_from_tar(self, mode: str = "r:*", length: int = -1) -> IterDataPipe: ...
-    # Functional form of 'XzFileReaderIterDataPipe'
-    def read_from_xz(self, length: int = -1) -> IterDataPipe: ...
-    # Functional form of 'ZipArchiveReaderIterDataPipe'
-    def read_from_zip(self, length: int = -1) -> IterDataPipe: ...
     # Functional form of 'LineReaderIterDataPipe'
     def readlines(
         self,

--- a/torchdata/datapipes/iter/__init__.pyi.in
+++ b/torchdata/datapipes/iter/__init__.pyi.in
@@ -8,7 +8,7 @@ ${init_base}
 # Note that, for mypy, .pyi file takes precedent over .py file, such that we must define the interface for other
 # classes/objects here, even though we are not injecting extra code into them at the moment.
 
-from .util.extractor import CompressionType
+from .util.decompressor import CompressionType
 from torchdata.datapipes.map import MapDataPipe
 from torch.utils.data import DataChunk, IterableDataset
 from torch.utils.data._typing import _DataPipeMeta

--- a/torchdata/datapipes/iter/util/decompressor.py
+++ b/torchdata/datapipes/iter/util/decompressor.py
@@ -22,11 +22,11 @@ class CompressionType(Enum):
     ZIP = "zip"
 
 
-@functional_datapipe("extract")
-class ExtractorIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
+@functional_datapipe("decompress")
+class DecompressorIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     r"""
     Takes tuples of path and compressed stream of data, and returns tuples of
-    path and decompressed stream of data (functional name: ``extract``). The input compression format can be specified
+    path and decompressed stream of data (functional name: ``decompress``). The input compression format can be specified
     or automatically detected based on the files' file extensions.
 
     Args:
@@ -79,3 +79,15 @@ class ExtractorIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
             file_type = self._detect_compression_type(path)
             decompressor = self._DECOMPRESSORS[file_type]
             yield path, StreamWrapper(decompressor(file))
+
+
+@functional_datapipe("extract")
+class ExtractorIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
+    r"""
+    Please use ``Decompressor`` or ``.decompress`` instead.
+    """
+
+    def __new__(
+        cls, source_datapipe: IterDataPipe[Tuple[str, IOBase]], file_type: Optional[Union[str, CompressionType]] = None
+    ):
+        return DecompressorIterDataPipe(source_datapipe, file_type)

--- a/torchdata/datapipes/iter/util/tararchiveloader.py
+++ b/torchdata/datapipes/iter/util/tararchiveloader.py
@@ -12,11 +12,11 @@ from torchdata.datapipes.utils import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 
 
-@functional_datapipe("read_from_tar")
-class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+@functional_datapipe("load_from_tar")
+class TarArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
     r"""
     Opens/decompresses tar binary streams from an Iterable DataPipe which contains tuples of path name and
-    tar binary stream, and yields a tuple of path name and extracted binary stream (functional name: ``read_from_tar``).
+    tar binary stream, and yields a tuple of path name and extracted binary stream (functional name: ``load_from_tar``).
 
     Args:
         datapipe: Iterable DataPipe that provides tuples of path name and tar binary stream
@@ -60,3 +60,13 @@ class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         if self.length == -1:
             raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
         return self.length
+
+
+@functional_datapipe("read_from_tar")
+class TarArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+    r"""
+    Please use ``TarArchiveLoader`` or ``.load_from_tar`` instead.
+    """
+
+    def __new__(cls, datapipe: Iterable[Tuple[str, BufferedIOBase]], mode: str = "r:*", length: int = -1):
+        return TarArchiveLoaderIterDataPipe(datapipe, mode, length)

--- a/torchdata/datapipes/iter/util/xzfileloader.py
+++ b/torchdata/datapipes/iter/util/xzfileloader.py
@@ -11,12 +11,12 @@ from torchdata.datapipes.utils import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 
 
-@functional_datapipe("read_from_xz")
-class XzFileReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+@functional_datapipe("load_from_xz")
+class XzFileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
     r"""
     Decompresses xz (lzma) binary streams from an Iterable DataPipe which contains tuples of
     path name and xy binary streams, and yields a tuple of path name and extracted binary
-    stream (functional name: ``read_from_xz``).
+    stream (functional name: ``load_from_xz``).
 
     Args:
         datapipe: Iterable DataPipe that provides tuples of path name and xy binary stream
@@ -49,3 +49,13 @@ class XzFileReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         if self.length == -1:
             raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
         return self.length
+
+
+@functional_datapipe("read_from_xz")
+class XzFileReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+    r"""
+    Please use ``XzFileLoader`` or ``.load_from_xz`` instead.
+    """
+
+    def __new__(cls, datapipe: Iterable[Tuple[str, BufferedIOBase]], length: int = -1):
+        return XzFileLoaderIterDataPipe(datapipe, length)

--- a/torchdata/datapipes/iter/util/ziparchiveloader.py
+++ b/torchdata/datapipes/iter/util/ziparchiveloader.py
@@ -13,11 +13,11 @@ from torchdata.datapipes.utils import StreamWrapper
 from torchdata.datapipes.utils.common import validate_pathname_binary_tuple
 
 
-@functional_datapipe("read_from_zip")
-class ZipArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+@functional_datapipe("load_from_zip")
+class ZipArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
     r"""
     Opens/decompresses zip binary streams from an Iterable DataPipe which contains a tuple of path name and
-    zip binary stream, and yields a tuple of path name and extracted binary stream (functional name: ``read_from_zip``).
+    zip binary stream, and yields a tuple of path name and extracted binary stream (functional name: ``load_from_zip``).
 
     Args:
         datapipe: Iterable DataPipe that provides tuples of path name and zip binary stream
@@ -61,3 +61,13 @@ class ZipArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         if self.length == -1:
             raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
         return self.length
+
+
+@functional_datapipe("read_from_zip")
+class ZipArchiveReaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
+    r"""
+    Please use ``ZipArchiveLoader`` or ``.load_from_zip`` instead.
+    """
+
+    def __new__(cls, datapipe: Iterable[Tuple[str, BufferedIOBase]], length: int = -1):
+        return ZipArchiveLoaderIterDataPipe(datapipe, length)


### PR DESCRIPTION
Merging a PR that has landed to main to release 0.3.0.
--
* https://github.com/pytorch/data/pull/243

Renaming Archive readers to loaders, and extractor to decompressor.

Note that the old ones are still functional, but excluded from the documentation and .pyi file. There is no deprecation warnings for them (we can add them after the first release).
