### PR TITLE
[Release 0.3.0] Adding usage examples to all IterDataPipes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -95,6 +95,8 @@ signature_replacements = {
     "torch.utils.data.datapipes.map.grouping.T": "T",
     "torch.utils.data.datapipes.map.combining.T_co": "T_co",
     "torch.utils.data.datapipes.map.combinatorics.T_co": "T_co",
+    "torchdata.datapipes.iter.util.cycler.T_co": "T_co",
+    "torchdata.datapipes.iter.util.paragraphaggregator.T_co": "T_co",
     "typing.": "",
 }
 

--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -48,7 +48,7 @@ These DataPipes help opening and decompressing archive files of different format
     :toctree: generated/
     :template: datapipe.rst
 
-    Extractor
+    Decompressor
     RarArchiveLoader
     TarArchiveLoader
     XzFileLoader

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -36,6 +36,10 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
     Args:
         root: The root `fsspec` path directory to list files from
         masks: Unix style filter string or string list for filtering file name(s)
+
+    Example:
+        >>> from torchdata.datapipes.iter import FSSpecFileLister
+        >>> datapipe = FSSpecFileLister(root=dir_path)
     """
 
     def __init__(
@@ -82,6 +86,11 @@ class FSSpecFileOpenerIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: Iterable DataPipe that provides the pathnames or URLs
         mode: An optional string that specifies the mode in which the file is opened (``"r"`` by default)
+
+    Example:
+        >>> from torchdata.datapipes.iter import FSSpecFileLister
+        >>> datapipe = FSSpecFileLister(root=dir_path)
+        >>> file_dp = datapipe.open_file_by_fsspec()
     """
 
     def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r") -> None:
@@ -111,6 +120,15 @@ class FSSpecSaverIterDataPipe(IterDataPipe[str]):
         source_datapipe: Iterable DataPipe with tuples of metadata and data
         mode: Mode in which the file will be opened for write the data (``"w"`` by default)
         filepath_fn: Function that takes in metadata and returns the target path of the new file
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> def filepath_fn(name: str) -> str:
+        >>>     return dir_path + name
+        >>> name_to_data = {"1.txt": b"DATA1", "2.txt": b"DATA2", "3.txt": b"DATA3"}
+        >>> source_dp = IterableWrapper(sorted(name_to_data.items()))
+        >>> fsspec_saver_dp = source_dp.save_by_fsspec(filepath_fn=filepath_fn, mode="wb")
+        >>> res_file_paths = list(fsspec_saver_dp)
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -47,6 +47,10 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     Note:
         Default ``PathManager`` currently supports local file path, normal HTTP URL and OneDrive URL.
         S3 URL is supported only with ``iopath``>=0.1.9.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IoPathFileLister
+        >>> datapipe = IoPathFileLister(root=S3URL)
     """
 
     def __init__(
@@ -93,6 +97,11 @@ class IoPathFileOpenerIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Note:
         Default ``PathManager`` currently supports local file path, normal HTTP URL and OneDrive URL.
         S3 URL is supported only with `iopath`>=0.1.9.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IoPathFileLister
+        >>> datapipe = IoPathFileLister(root=S3URL)
+        >>> file_dp = datapipe.open_file_by_iopath()
     """
 
     def __init__(self, source_datapipe: IterDataPipe[str], mode: str = "r", pathmgr=None) -> None:
@@ -135,6 +144,15 @@ class IoPathSaverIterDataPipe(IterDataPipe[str]):
     Note:
         Default ``PathManager`` currently supports local file path, normal HTTP URL and OneDrive URL.
         S3 URL is supported only with `iopath`>=0.1.9.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> def filepath_fn(name: str) -> str:
+        >>>     return S3URL + name
+        >>> name_to_data = {"1.txt": b"DATA1", "2.txt": b"DATA2", "3.txt": b"DATA3"}
+        >>> source_dp = IterableWrapper(sorted(name_to_data.items()))
+        >>> iopath_saver_dp = source_dp.save_by_iopath(filepath_fn=filepath_fn, mode="wb")
+        >>> res_file_paths = list(iopath_saver_dp)
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -33,6 +33,18 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: a DataPipe that contains URLs
         timeout: timeout in seconds for HTTP request
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
+        >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
+        >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
+        >>> reader_dp = http_reader_dp.readlines()
+        >>> it = iter(reader_dp)
+        >>> path, line = next(it)
+        >>> path
+        https://raw.githubusercontent.com/pytorch/data/main/LICENSE
+        >>> line
+        b'BSD 3-Clause License'
     """
 
     def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None) -> None:
@@ -85,6 +97,18 @@ class GDriveReaderDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: a DataPipe that contains URLs to GDrive files
         timeout: timeout in seconds for HTTP request
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, GDriveReader
+        >>> gdrive_file_url = "https://drive.google.com/uc?export=download&id=SomeIDToAGDriveFile"
+        >>> gdrive_reader_dp = GDriveReader(IterableWrapper([gdrive_file_url]))
+        >>> reader_dp = gdrive_reader_dp.readlines()
+        >>> it = iter(reader_dp)
+        >>> path, line = next(it)
+        >>> path
+        https://drive.google.com/uc?export=download&id=SomeIDToAGDriveFile
+        >>> line
+        <First line from the GDrive File>
     """
     source_datapipe: IterDataPipe[str]
 
@@ -108,6 +132,18 @@ class OnlineReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: a DataPipe that contains URLs
         timeout: timeout in seconds for HTTP request
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, OnlineReader
+        >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
+        >>> online_reader_dp = OnlineReader(IterableWrapper([file_url]))
+        >>> reader_dp = online_reader_dp.readlines()
+        >>> it = iter(reader_dp)
+        >>> path, line = next(it)
+        >>> path
+        https://raw.githubusercontent.com/pytorch/data/main/LICENSE
+        >>> line
+        b'BSD 3-Clause License'
     """
     source_datapipe: IterDataPipe[str]
 

--- a/torchdata/datapipes/iter/transform/flatmap.py
+++ b/torchdata/datapipes/iter/transform/flatmap.py
@@ -24,6 +24,15 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
     Args:
         datapipe: Source IterDataPipe
         fn: the function to be applied to each element in the DataPipe, the output must be a Sequence
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> def fn(e):
+        >>>     return [e, e * 10]
+        >>> source_dp = IterableWrapper(list(range(5)))
+        >>> flatmapped_dp = source_dp.flatmap(fn)
+        >>> list(flatmapped_dp)
+        [0, 0, 1, 10, 2, 20, 3, 30, 4, 40]
     """
 
     def __init__(self, datapipe: IterDataPipe, fn: Callable):

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -32,6 +32,13 @@ class InMemoryCacheHolderIterDataPipe(IterDataPipe[T_co]):
     Args:
         source_dp: source DataPipe from which elements are read and stored in memory
         size: The maximum size (in megabytes) that this DataPipe can hold in memory. This defaults to unlimited.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> source_dp = IterableWrapper(range(10))
+        >>> cache_dp = source_dp.in_memory_cache(size=5)
+        >>> list(cache_dp)
+        [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     """
     size: Optional[int] = None
     idx: int
@@ -125,13 +132,14 @@ class OnDiskCacheHolderIterDataPipe(IterDataPipe):
             the given file path from ``filepath_fn``.
 
     Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> url = IterableWrapper(["https://path/to/filename", ])
         >>> def _filepath_fn(url):
         >>>     temp_dir = tempfile.gettempdir()
         >>>     return os.path.join(temp_dir, os.path.basename(url))
         >>> hash_dict = {"expected_filepath": expected_MD5_hash}
         >>> cache_dp = url.on_disk_cache(filepath_fn=_filepath_fn, hash_dict=_hash_dict, hash_type="md5")
-        You must call ``.end_caching`` at a later point to stop tracing and save the results to local files.
+        >>> # You must call ``.end_caching`` at a later point to stop tracing and save the results to local files.
         >>> cache_dp = HttpReader(cache_dp).end_caching(mode="wb". filepath_fn=_filepath_fn)
     """
 
@@ -235,6 +243,18 @@ class EndOnDiskCacheHolderIterDataPipe(IterDataPipe):
         same_filepath_fn: Set to ``True`` to use same ``filepath_fn`` from the ``OnDiskCacheHolder``.
         skip_read: Boolean value to skip reading the file handle from ``datapipe``.
             By default, reading is enabled and reading function is created based on the ``mode``.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
+        >>> url = IterableWrapper(["https://path/to/filename", ])
+        >>> def _filepath_fn(url):
+        >>>     temp_dir = tempfile.gettempdir()
+        >>>     return os.path.join(temp_dir, os.path.basename(url))
+        >>> hash_dict = {"expected_filepath": expected_MD5_hash}
+        >>> # You must call ``.on_disk_cache`` at some point before ``.end_caching``
+        >>> cache_dp = url.on_disk_cache(filepath_fn=_filepath_fn, hash_dict=_hash_dict, hash_type="md5")
+        >>> # You must call ``.end_caching`` at a later point to stop tracing and save the results to local files.
+        >>> cache_dp = HttpReader(cache_dp).end_caching(mode="wb". filepath_fn=_filepath_fn)
     """
 
     def __new__(cls, datapipe, mode="wb", filepath_fn=None, *, same_filepath_fn=False, skip_read=False):

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -30,6 +30,18 @@ class IterKeyZipperIterDataPipe(IterDataPipe[T_co]):
             If it's specified as ``None``, the buffer size is set as infinite.
         merge_fn: Function that combines the item from ``source_datapipe`` and the item from ``ref_datapipe``,
             by default a tuple is created
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> from operator import itemgetter
+        >>> def merge_fn(t1, t2):
+        >>>     return t1[1] + t2[1]
+        >>> dp1 = IterableWrapper([('a', 100), ('b', 200), ('c', 300)])
+        >>> dp2 = IterableWrapper([('a', 1), ('b', 2), ('c', 3), ('d', 4)])
+        >>> res_dp = dp1.zip_with_iter(dp2, key_fn=itemgetter(0),
+        >>>                            ref_key_fn=itemgetter(0), keep_key=True, merge_fn=merge_fn)
+        >>> list(res_dp)
+        [('a', 101), ('b', 202), ('c', 303)]
     """
 
     def __init__(
@@ -105,6 +117,18 @@ class MapKeyZipperIterDataPipe(IterDataPipe[T_co]):
         key_fn: Function that maps each item from ``source_iterdatapipe`` to a key that exists in ``map_datapipe``
         merge_fn: Function that combines the item from ``source_iterdatapipe`` and the matching item
             from ``map_datapipe``, by default a tuple is created
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> from torchdata.datapipes.map import SequenceWrapper
+        >>> from operator import itemgetter
+        >>> def merge_fn(tuple_from_iter, value_from_map):
+        >>>     return tuple_from_iter[0], tuple_from_iter[1] + value_from_map
+        >>> dp1 = IterableWrapper([('a', 1), ('b', 2), ('c', 3)])
+        >>> mapdp = SequenceWrapper({'a': 100, 'b': 200, 'c': 300, 'd': 400})
+        >>> res_dp = dp1.zip_with_map(map_datapipe=mapdp, key_fn=itemgetter(0), merge_fn=merge_fn)
+        >>> list(res_dp)
+        [('a', 101), ('b', 202), ('c', 303)]
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/cycler.py
+++ b/torchdata/datapipes/iter/util/cycler.py
@@ -16,6 +16,13 @@ class CyclerIterDataPipe(IterDataPipe[T_co]):
     Args:
         source_datapipe: source DataPipe that will be cycled through
         count: the number of times to read through ``source_datapipe` (if ``None``, it will cycle in perpetuity)
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(range(3))
+        >>> dp = dp.cycle(2)
+        >>> list(dp)
+        [0, 1, 2, 0, 1, 2]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[T_co], count: Optional[int] = None) -> None:

--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -31,6 +31,21 @@ class DataFrameMakerIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IData
         dtype: specify the `TorchArrow` dtype for the DataFrame, use ``torcharrow.dtypes.DType``
         columns: List of str that specifies the column names of the DataFrame
         device: specify the device on which the DataFrame will be stored
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> import torcharrow.dtypes as dt
+        >>> source_data = [(i,) for i in range(3)]
+        >>> source_dp = IterableWrapper(source_data)
+        >>> DTYPE = dt.Struct([dt.Field("Values", dt.int32)])
+        >>> df_dp = source_dp.dataframe(dtype=DTYPE)
+        >>> list(df_dp)[0]
+          index    Values
+        -------  --------
+              0         0
+              1         1
+              2         2
+        dtype: Struct([Field('Values', int32)]), count: 3, null_count: 0
     """
 
     def __new__(
@@ -64,6 +79,20 @@ class ParquetDFLoaderIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IDat
         use_threads: if ``True``, Parquet reader will perform multi-threaded column reads
         dtype: specify the `TorchArrow` dtype for the DataFrame, use ``torcharrow.dtypes.DType``
         device: specify the device on which the DataFrame will be stored
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister
+        >>> import torcharrow.dtypes as dt
+        >>> DTYPE = dt.Struct([dt.Field("Values", dt.int32)])
+        >>> source_dp = FileLister(".", masks="df*.parquet")
+        >>> parquet_df_dp = source_dp.load_parquet_as_df(dtype=DTYPE)
+        >>> list(parquet_df_dp)[0]
+          index    Values
+        -------  --------
+              0         0
+              1         1
+              2         2
+        dtype: Struct([Field('Values', int32)]), count: 3, null_count: 0
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/decompressor.py
+++ b/torchdata/datapipes/iter/util/decompressor.py
@@ -32,6 +32,15 @@ class DecompressorIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Args:
         source_datapipe: IterDataPipe containing tuples of path and compressed stream of data
         file_type: Optional `string` or ``CompressionType`` that represents what compression format of the inputs
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> tar_file_dp = FileLister(self.temp_dir.name, "*.tar")
+        >>> tar_load_dp = FileOpener(tar_file_dp, mode="b")
+        >>> tar_decompress_dp = Decompressor(tar_load_dp, file_type="tar")
+        >>> for _, stream in tar_decompress_dp:
+        >>>     print(stream.read())
+        b'0123456789abcdef'
     """
 
     types = CompressionType

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -28,7 +28,19 @@ class HashCheckerIterDataPipe(IterDataPipe[Tuple[str, U]]):
             does not work with non-seekable stream, e.g. HTTP)
 
     Example:
-        >>> dp = dp.check_hash({'train.py':'0d8b94d9fa9fb1ad89b9e3da9e1521495dca558fc5213b0fd7fd7b71c23f9921'})
+        >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
+        >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
+        >>> expected_MD5_hash = "bb9675028dd39d2dd2bf71002b93e66c"
+        >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
+        >>> # An exception is only raised when the hash doesn't match, otherwise (path, stream) is returned
+        >>> check_hash_dp = http_reader_dp.check_hash({file_url: expected_MD5_hash}, "md5", rewind=False)
+        >>> reader_dp = check_hash_dp.readlines()
+        >>> it = iter(reader_dp)
+        >>> path, line = next(it)
+        >>> path
+        https://raw.githubusercontent.com/pytorch/data/main/LICENSE
+        >>> line
+        b'BSD 3-Clause License'
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -16,6 +16,13 @@ class HeaderIterDataPipe(IterDataPipe[T_co]):
     Args:
         source_datapipe: the DataPipe from which elements will be yielded
         limit: the number of elements to yield before stopping
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(range(10))
+        >>> header_dp = dp.header(3)
+        >>> list(header_dp)
+        [0, 1, 2]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[T_co], limit: int = 10) -> None:

--- a/torchdata/datapipes/iter/util/indexadder.py
+++ b/torchdata/datapipes/iter/util/indexadder.py
@@ -16,6 +16,13 @@ class EnumeratorIterDataPipe(IterDataPipe[Tuple[int, K]]):
     Args:
         source_datapipe: Iterable DataPipe being indexed
         starting_index: Index from which enumeration will start
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(['a', 'b', 'c'])
+        >>> enum_dp = dp.enumerate()
+        >>> list(enum_dp)
+        [(0, 'a'), (1, 'b'), (2, 'c')]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[K], starting_index: int = 0) -> None:
@@ -37,8 +44,15 @@ class IndexAdderIterDataPipe(IterDataPipe[Dict]):
     of the data is set to the provided ``index_name``.
 
     Args:
-        source_datapipe: Iterable DataPipe being indexed
+        source_datapipe: Iterable DataPipe being indexed, its row/batch must be of type `Dict`
         index_name: Name of the key to store data index
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper([{'a': 1, 'b': 2}, {'c': 3, 'a': 1}])
+        >>> index_dp = dp.add_index("order")
+        >>> list(index_dp)
+        [{'a': 1, 'b': 2, 'order': 0}, {'c': 3, 'a': 1, 'order': 1}]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[Dict], index_name: str = "index") -> None:

--- a/torchdata/datapipes/iter/util/jsonparser.py
+++ b/torchdata/datapipes/iter/util/jsonparser.py
@@ -14,6 +14,18 @@ class JsonParserIterDataPipe(IterDataPipe[Tuple[str, Dict]]):
     Args:
         source_datapipe: a DataPipe with tuples of file name and JSON data stream
         kwargs: keyword arguments that will be passed through to ``json.loads``
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, FileOpener
+        >>> import os
+        >>> def get_name(path_and_stream):
+        >>>     return os.path.basename(path_and_stream[0]), path_and_stream[1]
+        >>> datapipe1 = IterableWrapper(["empty.json", "1.json", "2.json"])
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> datapipe3 = datapipe2.map(get_name)
+        >>> json_dp = datapipe3.parse_json_files()
+        >>> list(json_dp)
+        [('1.json', ['foo', {'bar': ['baz', None, 1.0, 2]}]), ('2.json', {'__complex__': True, 'real': 1, 'imag': 2})]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[Tuple[str, IO]], **kwargs) -> None:

--- a/torchdata/datapipes/iter/util/paragraphaggregator.py
+++ b/torchdata/datapipes/iter/util/paragraphaggregator.py
@@ -24,6 +24,15 @@ class ParagraphAggregatorIterDataPipe(IterDataPipe[Tuple[str, str]]):
     Args:
         source_datapipe: a DataPipe with tuples of a file name and a line
         joiner: a function that joins a list of lines together
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> source_dp = IterableWrapper(
+        >>>                 [("file1", "Line1"), ("file1", "Line2"), ("file2", "Line2,1"), ("file2", "Line2,2"), ("file2", "Line2,3")]
+        >>>             )
+        >>> para_agg_dp = source_dp.lines_to_paragraphs(joiner=lambda ls: " ".join(ls))
+        >>> list(para_agg_dp)
+        [('file1', 'Line1 Line2'), ('file2', 'Line2,1 Line2,2 Line2,3')]
     """
 
     def __init__(self, source_datapipe: IterDataPipe[Tuple[str, T_co]], joiner: Callable = _default_line_join) -> None:

--- a/torchdata/datapipes/iter/util/plain_text_reader.py
+++ b/torchdata/datapipes/iter/util/plain_text_reader.py
@@ -79,6 +79,16 @@ class LineReaderIterDataPipe(IterDataPipe[Union[Str_Or_Bytes, Tuple[str, Str_Or_
         errors: the error handling scheme used while decoding
         return_path: if ``True``, each line will return a tuple of path and contents, rather
             than just the contents
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> import io
+        >>> text1 = "Line1\nLine2"
+        >>> text2 = "Line2,1\r\nLine2,2\r\nLine2,3"
+        >>> source_dp = IterableWrapper([("file1", io.StringIO(text1)), ("file2", io.StringIO(text2))])
+        >>> line_reader_dp = source_dp.readlines()
+        >>> list(line_reader_dp)
+        [('file1', 'Line1'), ('file1', 'Line2'), ('file2', 'Line2,1'), ('file2', 'Line2,2'), ('file2', 'Line2,3')]
     """
 
     def __init__(
@@ -158,6 +168,18 @@ class CSVParserIterDataPipe(_CSVBaseParserIterDataPipe):
         errors: the error handling scheme used while decoding
         return_path: if ``True``, each line will return a tuple of path and contents, rather
             than just the contents
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, FileOpener
+        >>> import os
+        >>> def get_name(path_and_stream):
+        >>>     return os.path.basename(path_and_stream[0]), path_and_stream[1]
+        >>> datapipe1 = IterableWrapper(["1.csv", "empty.csv", "empty2.csv"])
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> datapipe3 = datapipe2.map(get_name)
+        >>> csv_parser_dp = datapipe3.parse_csv()
+        >>> list(csv_parser_dp)
+        [['key', 'item'], ['a', '1'], ['b', '2'], []]
     """
 
     def __init__(
@@ -202,6 +224,18 @@ class CSVDictParserIterDataPipe(_CSVBaseParserIterDataPipe):
         errors: the error handling scheme used while decoding
         return_path: if ``True``, each line will return a tuple of path and contents, rather
             than just the contents
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> import os
+        >>> def get_name(path_and_stream):
+        >>>     return os.path.basename(path_and_stream[0]), path_and_stream[1]
+        >>> datapipe1 = FileLister(".", "*.csv")
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> datapipe3 = datapipe2.map(get_name)
+        >>> csv_dict_parser_dp = datapipe3.parse_csv_as_dict()
+        >>> list(csv_dict_parser_dp)
+        [{'key': 'a', 'item': '1'}, {'key': 'b', 'item': '2'}]
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/rararchiveloader.py
+++ b/torchdata/datapipes/iter/util/rararchiveloader.py
@@ -49,6 +49,15 @@ class RarArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, io.BufferedIOBase]]):
     Args:
         datapipe: Iterable DataPipe that provides tuples of path name and rar binary stream
         length: Nominal length of the DataPipe
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> datapipe1 = FileLister(".", "*.rar")
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> rar_loader_dp = datapipe2.load_from_rar()
+        >>> for _, stream in rar_loader_dp:
+        >>>     print(stream.read())
+        b'0123456789abcdef'
     """
 
     def __init__(self, datapipe: IterDataPipe[Tuple[str, io.BufferedIOBase]], *, length: int = -1):

--- a/torchdata/datapipes/iter/util/rows2columnar.py
+++ b/torchdata/datapipes/iter/util/rows2columnar.py
@@ -21,7 +21,27 @@ class Rows2ColumnarIterDataPipe(IterDataPipe[Dict]):
     Args:
         source_datapipe: a DataPipe where each item is a batch. Within each batch,
             there are rows and each row is a `List` or `Dict`
-        column_names: a function that joins a list of lines together
+        column_names: if each element in a batch contains `Dict`, ``column_names`` act as a filter for matching keys;
+            otherwise, these are used as keys to for the generated `Dict` of each batch
+
+    Example:
+        >>> # Each element in a batch is a `Dict`
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper([[{'a': 1}, {'b': 2, 'a': 1}], [{'a': 1, 'b': 200}, {'b': 2, 'c': 3, 'a': 100}]])
+        >>> row2col_dp = dp.rows2columnar()
+        >>> list(row2col_dp)
+        [defaultdict(<class 'list'>, {'a': [1, 1], 'b': [2]}),
+         defaultdict(<class 'list'>, {'a': [1, 100], 'b': [200, 2], 'c': [3]})]
+        >>> row2col_dp = dp.rows2columnar(column_names=['a'])
+        >>> list(row2col_dp)
+        [defaultdict(<class 'list'>, {'a': [1, 1]}),
+         defaultdict(<class 'list'>, {'a': [1, 100]})]
+        >>> # Each element in a batch is a `List`
+        >>> dp = IterableWrapper([[[0, 1, 2, 3], [4, 5, 6, 7]]])
+        >>> row2col_dp = dp.rows2columnar(column_names=["1st_in_batch", "2nd_in_batch", "3rd_in_batch", "4th_in_batch"])
+        >>> list(row2col_dp)
+        [defaultdict(<class 'list'>, {'1st_in_batch': [0, 4], '2nd_in_batch': [1, 5],
+                                      '3rd_in_batch': [2, 6], '4th_in_batch': [3, 7]})]
     """
     column_names: List[str]
 

--- a/torchdata/datapipes/iter/util/samplemultiplexer.py
+++ b/torchdata/datapipes/iter/util/samplemultiplexer.py
@@ -23,6 +23,15 @@ class SampleMultiplexerDataPipe(IterDataPipe[T_co]):
         pipes_to_weights_dict: a `Dict` of IterDataPipes and Weights. The total weight of
             unexhausted DataPipes will be normalized to 1 for the purpose of sampling.
         seed: random seed to initialize the random number generator
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, SampleMultiplexer
+        >>> source_dp1 = IterableWrapper([0] * 10)
+        >>> source_dp2 = IterableWrapper([1] * 10)
+        >>> d = {source_dp1: 99999999, source_dp2: 0.0000001}
+        >>> sample_mul_dp = SampleMultiplexer(pipes_to_weights_dict=d, seed=0)
+        >>> list(sample_mul_dp)
+        [0, 0, 0, 0, 0, 1, 1, 1, 1, 1]
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/saver.py
+++ b/torchdata/datapipes/iter/util/saver.py
@@ -20,6 +20,18 @@ class SaverIterDataPipe(IterDataPipe[str]):
         source_datapipe: Iterable DataPipe with tuples of metadata and data
         mode: Node in which the file will be opened for write the data (``"w"`` by default)
         filepath_fn: Function that takes in metadata and returns the target path of the new file
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> import os
+        >>> def filepath_fn(name: str) -> str:
+        >>>     return os.path.join(".", os.path.basename(name))
+        >>> name_to_data = {"1.txt": b"DATA1", "2.txt": b"DATA2", "3.txt": b"DATA3"}
+        >>> source_dp = IterableWrapper(sorted(name_to_data.items()))
+        >>> saver_dp = source_dp.save_to_disk(filepath_fn=filepath_fn, mode="wb")
+        >>> res_file_paths = list(saver_dp)
+        >>> res_file_paths
+        ['./1.txt', './2.txt', './3.txt']
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/util/tararchiveloader.py
+++ b/torchdata/datapipes/iter/util/tararchiveloader.py
@@ -28,6 +28,15 @@ class TarArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         The opened file handles will be closed automatically if the default ``DecoderDataPipe``
         is attached. Otherwise, user should be responsible to close file handles explicitly
         or let Python's GC close them periodically.
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> datapipe1 = FileLister(".", "*.tar")
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> tar_loader_dp = datapipe2.load_from_tar()
+        >>> for _, stream in tar_loader_dp:
+        >>>     print(stream.read())
+        b'0123456789abcdef'
     """
 
     def __init__(self, datapipe: Iterable[Tuple[str, BufferedIOBase]], mode: str = "r:*", length: int = -1) -> None:

--- a/torchdata/datapipes/iter/util/unzipper.py
+++ b/torchdata/datapipes/iter/util/unzipper.py
@@ -27,6 +27,17 @@ class UnZipperIterDataPipe(IterDataPipe[T]):
             to the slowest child DataPipe. Use -1 for the unlimited buffer.
         columns_to_skip: optional indices of columns that the DataPipe should skip (each index should be
             an integer from 0 to sequence_length - 1)
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> source_dp = IterableWrapper([(i, i + 10, i + 20) for i in range(3)])
+        >>> dp1, dp2, dp3 = source_dp.unzip(sequence_length=3)
+        >>> list(dp1)
+        [0, 1, 2]
+        >>> list(dp2)
+        [10, 11, 12]
+        >>> list(dp3)
+        [20, 21, 22]
     """
 
     def __new__(

--- a/torchdata/datapipes/iter/util/xzfileloader.py
+++ b/torchdata/datapipes/iter/util/xzfileloader.py
@@ -26,6 +26,15 @@ class XzFileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         The opened file handles will be closed automatically if the default ``DecoderDataPipe``
         is attached. Otherwise, user should be responsible to close file handles explicitly
         or let Python's GC close them periodically.
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> datapipe1 = FileLister(".", "*.xz")
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> xz_loader_dp = datapipe2.load_from_xz()
+        >>> for _, stream in xz_loader_dp:
+        >>>     print(stream.read())
+        b'0123456789abcdef'
     """
 
     def __init__(self, datapipe: Iterable[Tuple[str, BufferedIOBase]], length: int = -1) -> None:

--- a/torchdata/datapipes/iter/util/ziparchiveloader.py
+++ b/torchdata/datapipes/iter/util/ziparchiveloader.py
@@ -28,6 +28,15 @@ class ZipArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
         is attached. Otherwise, user should be responsible to close file handles explicitly
         or let Python's GC close them periodically. Due to how `zipfiles` implements its ``open()`` method,
         the data_stream variable below cannot be closed within the scope of this function.
+
+    Example:
+        >>> from torchdata.datapipes.iter import FileLister, FileOpener
+        >>> datapipe1 = FileLister(".", "*.zip")
+        >>> datapipe2 = FileOpener(datapipe1, mode="b")
+        >>> zip_loader_dp = datapipe2.load_from_zip()
+        >>> for _, stream in zip_loader_dp:
+        >>>     print(stream.read())
+        b'0123456789abcdef'
     """
 
     def __init__(self, datapipe: Iterable[Tuple[str, BufferedIOBase]], length: int = -1) -> None:


### PR DESCRIPTION
Merging a PR that has landed to main to release 0.3.0.
--
* https://github.com/pytorch/data/pull/249

Adding usage examples to all IterDataPipes