### PR TITLE
Ensuring DataFrame DataPipes are serializable

### DIFF
--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -163,3 +163,7 @@ class TestDataFrame(expecttest.TestCase):
             self._compare_dataframes(exp_df, act_df)
         for exp_df, act_df in zip(expected_dfs, res_after_reset):
             self._compare_dataframes(exp_df, act_df)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -158,7 +158,7 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
             (iterdp.OnDiskCacheHolder, (), {}),
             (iterdp.OnlineReader, (), {}),
             (iterdp.ParagraphAggregator, (), {}),
-            # (iterdp.ParquetDataFrameLoader, (), {"dtype": DTYPE}),
+            (iterdp.ParquetDataFrameLoader, (), {"dtype": DTYPE}),
             (iterdp.RarArchiveLoader, (), {}),
             (iterdp.Rows2Columnar, (), {}),
             (iterdp.SampleMultiplexer, (), {}),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #276
* #275

`torcharrow.dtypes.Struct` requires `dill` to serialize

Differential Revision: [D34625706](https://our.internmc.facebook.com/intern/diff/D34625706)