### PR TITLE
[Release 0.3.0] Fix aws upload

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -201,7 +201,7 @@ jobs:
           else
             S3_PATH=s3://pytorch/whl/test/
           fi
-          pip3 install --user awscli
+          pip3 install awscli
           set -x
           for pkg in dist/torchdata*.whl; do
             aws s3 cp "$pkg" "$S3_PATH" --acl public-read


### PR DESCRIPTION
Forward fix for #274

Docker image requires to install `aws` using root permission rather than `user`. Otherwise, we can not invoke `aws`

Before this PR: https://github.com/pytorch/data/runs/5424789165?check_suite_focus=true
After this PR: https://github.com/pytorch/data/runs/5424716846?check_suite_focus=true

The same fix will be patched in #270 for main branch