### PR TITLE
[DataPipe] Implement BucketBatcher with max token

### DIFF
--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -131,10 +131,10 @@ jobs:
       - name: Install test requirements
         run: pip install dill expecttest numpy pytest
 
-      - name: Run torchtext example datasets tests
+      - name: Run torchaudio example datasets tests
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
         run: pytest --no-header -v test/test_audio_examples.py
-      - name: Run torchtext example datasets (including slow tests)
+      - name: Run torchaudio example datasets (including slow tests)
         if: ${{ contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
         run: pytest --no-header -v test/test_audio_examples.py
         env:

--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -76,6 +76,7 @@ These DataPipes help to perform combinatorial operations.
     :toctree: generated/
     :template: datapipe.rst
 
+    InBatchShuffler
     Sampler
     Shuffler
 
@@ -111,6 +112,7 @@ These DataPipes have you group samples within a DataPipe.
     BucketBatcher
     Collator
     Grouper
+    MaxTokenBucketizer
     UnBatcher
 
 IO DataPipes

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -172,6 +172,8 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
             (iterdp.HashChecker, None, ({},), {}),
             (iterdp.Header, None, (3,), {}),
             (iterdp.HttpReader, None, (), {}),
+            # TODO (ejguan): Deterministic serialization is required
+            #  (iterdp.InBatchShuffler, IterableWrapper(range(10)).batch(3), (), {}),
             (iterdp.InMemoryCacheHolder, None, (), {}),
             (iterdp.IndexAdder, IterableWrapper([{"a": 1, "b": 2}, {"c": 3, "a": 1}]), ("label",), {}),
             (iterdp.IoPathFileLister, ".", (), {}),
@@ -205,6 +207,12 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
                     [("file1", StringIO("Line1\nLine2")), ("file2", StringIO("Line2,1\r\nLine2,2\r\nLine2,3"))]
                 ),
                 (),
+                {},
+            ),
+            (
+                iterdp.MaxTokenBucketizer,
+                IterableWrapper(["1", "22", "1", "4444", "333", "1", "22", "22", "333"]),
+                (4,),
                 {},
             ),
             (

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -38,7 +38,11 @@ from torchdata.datapipes.iter.load.online import (
     HTTPReaderIterDataPipe as HttpReader,
     OnlineReaderIterDataPipe as OnlineReader,
 )
-from torchdata.datapipes.iter.transform.bucketbatcher import BucketBatcherIterDataPipe as BucketBatcher
+from torchdata.datapipes.iter.transform.bucketbatcher import (
+    BucketBatcherIterDataPipe as BucketBatcher,
+    InBatchShufflerIterDataPipe as InBatchShuffler,
+    MaxTokenBucketizerIterDataPipe as MaxTokenBucketizer,
+)
 from torchdata.datapipes.iter.transform.flatmap import FlatMapperIterDataPipe as FlatMapper
 from torchdata.datapipes.iter.util.cacheholder import (
     EndOnDiskCacheHolderIterDataPipe as EndOnDiskCacheHolder,
@@ -120,6 +124,7 @@ __all__ = [
     "HashChecker",
     "Header",
     "HttpReader",
+    "InBatchShuffler",
     "InMemoryCacheHolder",
     "IndexAdder",
     "IoPathFileLister",
@@ -132,6 +137,7 @@ __all__ = [
     "LineReader",
     "MapKeyZipper",
     "Mapper",
+    "MaxTokenBucketizer",
     "Multiplexer",
     "OnDiskCacheHolder",
     "OnlineReader",

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -1,6 +1,9 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
+import heapq
 import random
-from typing import Callable, Optional, TypeVar
+
+from functools import partial
+from typing import Callable, Iterator, List, Optional, TypeVar
 
 from torch.utils.data import DataChunk
 
@@ -10,10 +13,35 @@ from torchdata.datapipes.iter import IterDataPipe
 T_co = TypeVar("T_co", covariant=True)
 
 
-def _in_batch_shuffle_fn(data: DataChunk):
-    d = list(data)
-    random.shuffle(d)
-    return DataChunk(d)
+@functional_datapipe("in_batch_shuffle")
+class InBatchShufflerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
+    r"""
+    Shuffles each mini-batch from the prior DataPipe (functional name: ``in_batch_shuffle``).
+
+    Args:
+        datapipe: Iterable DataPipe with batched data
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> source_dp = IterableWrapper(range(10))
+        >>> batch_dp = source_dp.batch(batch_size=3, drop_last=True)
+        >>> list(batch_dp)
+        [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+        >>> in_batch_shuffle_dp = batch_dp.in_batch_shuffle()
+        >>> list(in_batch_shuffle_dp)
+        [[2, 0, 1], [3, 5, 4], [7, 8, 6]]
+    """
+
+    def __init__(self, datapipe: IterDataPipe[DataChunk[T_co]]):
+        self.datapipe = datapipe
+
+    def __iter__(self) -> Iterator[DataChunk[T_co]]:
+        for batch in self.datapipe:
+            random.shuffle(batch)
+            yield batch
+
+    def __len__(self) -> int:
+        return len(self.datapipe)
 
 
 @functional_datapipe("bucketbatch")
@@ -58,7 +86,6 @@ class BucketBatcherIterDataPipe(IterDataPipe[DataChunk[T_co]]):
     bucket_num: int
     sort_key: Optional[Callable]
     in_batch_shuffle: bool
-    length: Optional[int]
 
     def __new__(
         cls,
@@ -80,7 +107,7 @@ class BucketBatcherIterDataPipe(IterDataPipe[DataChunk[T_co]]):
         # Shuffle by pool_size
         if bucket_num > 1 or sort_key is None:
             if in_batch_shuffle:
-                datapipe = datapipe.batch(batch_size=pool_size, drop_last=False).map(fn=_in_batch_shuffle_fn).unbatch()
+                datapipe = datapipe.batch(batch_size=pool_size, drop_last=False).in_batch_shuffle().unbatch()
             else:
                 datapipe = datapipe.shuffle(buffer_size=pool_size)
         # Sort by bucket_size if sort_key is given
@@ -92,7 +119,110 @@ class BucketBatcherIterDataPipe(IterDataPipe[DataChunk[T_co]]):
         if sort_key is not None:
             # In-batch shuffle each bucket seems not that useful, it seems misleading since .batch is called prior.
             if in_batch_shuffle:
-                datapipe = datapipe.batch(batch_size=bucket_num, drop_last=False).map(fn=_in_batch_shuffle_fn).unbatch()
+                datapipe = datapipe.batch(batch_size=bucket_num, drop_last=False).in_batch_shuffle().unbatch()
             else:
                 datapipe = datapipe.shuffle(buffer_size=bucket_size)
         return datapipe
+
+
+def _default_len_fn(token):
+    return len(token)
+
+
+def _token_len_fn(token, len_fn):
+    return len_fn(token), token
+
+
+def _token_filter_fn(data, *, min_len, max_len):
+    length, token = data
+    return length >= min_len and length <= max_len
+
+
+@functional_datapipe("max_token_bucketize")
+class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
+    r"""
+    Creates mini-batches of data from a min-heap with limited size, and the total length of samples
+    returned by ``len_fn`` within each batch will be limited by ``max_token_count``.
+    (functional name: ``max_token_bucketize``). If ``min_len`` or ``max_len`` is set, the samples with
+    length that is out of ``[min_len, max_len]`` will be filtered out.
+
+    The purpose of this DataPipe is to batch samples with similar length according to ``len_fn``.
+    Min-heap is used here to make sure the samples are sorted incrementally based on the length. And,
+    the total length of samples in each batch is guaranteed to be smaller than ``max_token_count``.
+    For an example in the audio domain, it may be batching samples with similar length. Then, given the
+    ``max_token_count``, each batch may be concatenated to a Tensor with the same size and minimum padding.
+
+    Args:
+        datapipe: Iterable DataPipe being batched
+        max_token_count: Maximum length of total length of data in each batch
+        len_fn: Function to be applied to each element to get lengths. ``len(data)`` is used by default.
+        min_len: Optional minimum length to be included into each batch
+        max_len: Optional maximum length to be included into each batch.
+        buffer_size: This restricts how many tokens are taken from prior DataPipe to bucketize
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> source_dp = IterableWrapper(['1', '11', '1', '1111', '111', '1', '11', '11', '111'])
+        >>> # Using default len_fn to sort samples based on length (string length in this case)
+        >>> batch_dp = source_dp.max_token_bucketize(max_token_count=5)
+        >>> list(batch_dp)
+        [['1', '1', '1', '11'], ['11', '11'], ['111'], ['111'], ['1111']]
+        >>> batch_dp = source_dp.max_token_bucketize(max_token_count=4, buffer_size=4)
+        >>> list(batch_dp)
+        [['1', '1', '1'], ['11', '11'], ['11'], ['111'], ['111'], ['1111']]
+    """
+    datapipe: IterDataPipe[T_co]
+    max_token_count: int
+    len_fn: Callable
+    min_len: int
+    max_len: Optional[int]
+    buffer_size: int
+
+    def __init__(
+        self,
+        datapipe: IterDataPipe[T_co],
+        max_token_count: int,
+        len_fn: Callable = _default_len_fn,
+        min_len: int = 0,
+        max_len: Optional[int] = None,
+        buffer_size: int = 1000,
+    ) -> None:
+        if max_len is None:
+            max_len = max_token_count
+
+        if min_len < 0 or min_len > max_len:
+            raise ValueError("``min_len`` should be larger than 0 and equal to or smaller than ``max_len``.")
+        if max_len > max_token_count:
+            raise ValueError("``max_token_count`` must be equal to or greater than ``max_len``.")
+        datapipe = datapipe.map(partial(_token_len_fn, len_fn=len_fn))
+        datapipe = datapipe.filter(partial(_token_filter_fn, min_len=min_len, max_len=max_len))
+        if buffer_size <= 0:
+            raise ValueError("'buffer_size' is required to be a positive integer.")
+        self.datapipe = datapipe
+        self.max_token_count = max_token_count
+        self.buffer_size = buffer_size
+
+    def __iter__(self) -> Iterator[DataChunk[T_co]]:
+        buffer: List = []
+        batch: List = []
+        batch_size: int = 0
+        for d in self.datapipe:
+            heapq.heappush(buffer, d)
+            if len(buffer) == self.buffer_size:
+                length, token = heapq.heappop(buffer)
+                if batch_size + length > self.max_token_count:
+                    yield batch
+                    batch = []
+                    batch_size = 0
+                batch.append(token)
+                batch_size += length
+        while buffer:
+            length, token = heapq.heappop(buffer)
+            if batch_size + length > self.max_token_count:
+                yield batch
+                batch = []
+                batch_size = 0
+            batch.append(token)
+            batch_size += length
+        if batch:
+            yield batch


### PR DESCRIPTION
Add `max_token_bucketizer`

There are two options to do streaming bucketizer:
- Using `buffer` as a priority queue to keep yielding the shortest token dynamically. Whenever a token is fetched from buffer, a new token is pushed into the buffer.
- Sort `buffer` and yield batches from `buffer` without adding new tokens from DataPipe until the batches are yielded from `buffer`.

The time complexity of these two methods should be the same as `O(N log(buffer_size)`. I prefer the first approach as we would reduce the potential skewness of data within local buffer.


Added `in_batch_shuffle` as the syntax sugar and for future deterministic data preprocessing.