### PR TITLE
Adding LimiterIterDataPipe

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -180,6 +180,7 @@ These DataPipes helps you select specific samples within a DataPipe.
 
     Filter
     Header
+    Limiter
 
 Text DataPipes
 -----------------------------

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -329,6 +329,24 @@ class TestDataPipe(expecttest.TestCase):
             pass
         self.assertEqual(20, len(header_dp))
 
+    def test_limiter_iterdatapipe(self) -> None:
+        # Functional Test: ensure the limit is enforced
+        source_dp = IterableWrapper(range(20))
+        limiter_dp = source_dp.limit(5)
+        self.assertEqual(list(range(5)), list(limiter_dp))
+
+        # Functional Test: still works when the limit is greater than the length of the source
+        limiter_dp = source_dp.limit(30)
+        self.assertEqual(list(range(20)), list(limiter_dp))
+
+        # __len__ Test: returns the limit when it is less than the length of source
+        limiter_dp = source_dp.limit(5)
+        self.assertEqual(5, len(limiter_dp))
+
+        # __len__ Test: returns the length of source when it is less than the limit
+        limiter_dp = source_dp.limit(30)
+        self.assertEqual(20, len(limiter_dp))
+
     def test_enumerator_iterdatapipe(self) -> None:
         letters = "abcde"
         source_dp = IterableWrapper(letters)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -199,6 +199,7 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
                 (),
                 {},
             ),
+            (iterdp.Limiter, None, (5,), {}),
             (
                 iterdp.LineReader,
                 IterableWrapper(

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -59,7 +59,7 @@ from torchdata.datapipes.iter.util.decompressor import (
     ExtractorIterDataPipe as Extractor,
 )
 from torchdata.datapipes.iter.util.hashchecker import HashCheckerIterDataPipe as HashChecker
-from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header
+from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header, LimiterIterDataPipe as Limiter
 from torchdata.datapipes.iter.util.indexadder import (
     EnumeratorIterDataPipe as Enumerator,
     IndexAdderIterDataPipe as IndexAdder,
@@ -129,6 +129,7 @@ __all__ = [
     "IterKeyZipper",
     "IterableWrapper",
     "JsonParser",
+    "Limiter",
     "LineReader",
     "MapKeyZipper",
     "Mapper",

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -2,6 +2,9 @@
 from typing import Iterator, TypeVar
 from warnings import warn
 
+import torch.distributed as dist
+
+from torch.utils.data import get_worker_info
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 
@@ -53,3 +56,65 @@ class HeaderIterDataPipe(IterDataPipe[T_co]):
                 "The actual value may be smaller if the actual length of source_datapipe is smaller than the limit."
             )
             return self.limit
+
+
+@functional_datapipe("limit")
+class LimiterIterDataPipe(IterDataPipe[T_co]):
+    """
+    Limits the number of samples that the source DataPipe can yield based the input as well as the number of
+    processes and workers if distribute- or multi-processing is enabled (functional name: ``limit``).
+
+    The number of samples that will be yielded equals ``num_take // (num_processes * worker_info.num_workers)``.
+
+    Args:
+        source_datapipe: IterDataPipe with samples of data that will be yielded
+        num_take: the number of samples that you wish to yield across all processes and workers, should be less than
+            or equal to the ``len(source_datapipe)``
+
+    Example:
+        >>> source_dp = IterableWrapper(range(20))
+        >>> limiter_dp = source_dp.limit(5)
+        >>> list(limiter_dp)
+        [0, 1, 2, 3, 4]
+    """
+
+    def __init__(self, source_datapipe: IterDataPipe[T_co], num_take: int) -> None:
+        super().__init__()
+        self.source_datapipe: IterDataPipe[T_co] = source_datapipe
+        self.num_take: int = num_take
+        self.num_processes: int = 1
+        if dist.is_available() and dist.is_initialized():
+            self.num_processes = dist.get_world_size()
+
+    def _get_num_workers(self):
+        num_workers = self.num_processes
+        worker_info = get_worker_info()
+        if worker_info is not None:
+            # Note that we are assuming each distributed process has the same number of workers
+            num_workers *= worker_info.num_workers
+        return num_workers
+
+    def __iter__(self) -> Iterator:
+        # TODO: pmeier - this is weird as it drops more elements than it should
+        worker_num_take = self.num_take // self._get_num_workers()
+
+        for i, data in enumerate(self.source_datapipe):
+            # TODO: If each instance of the source_datapipe (of different worker/process) is not independently
+            #  shuffled, then all Limiter will return the same set of samples
+            #  Should we return samples based on process_id and worker_id?
+            #  Alternatively, should we optionally allow people to shuffle inside `__init__`?
+            if i < worker_num_take:
+                yield data
+            else:
+                break
+
+    # TODO: What is the length that user wants here
+    #       1) The total dataset length, or 2) the length that the specific worker/process will yield
+    def __len__(self) -> int:
+        max_num_take = self.num_take
+        try:
+            if len(self.source_datapipe) < self.num_take:
+                max_num_take = len(self.source_datapipe)
+        except TypeError:
+            pass
+        return max_num_take // self._get_num_workers()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #285

This DataPipe is the upstreamed version of `TakerDataPipe` in `torchvision`. I read through that implementation and made a best guess about what the desirable behavior should be.

https://github.com/pytorch/vision/blob/d32bc4ba9ac32ca413825a1a062455f1c747ce5f/torchvision/prototype/datasets/utils/_internal.py#L202-L232

This implementation is not final at the moment as I still have some questions about what this DataPipe should do.
