### PR TITLE
[Release 0.3.0] Enable official release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
   build_test_upload:
     uses: ./.github/workflows/_build_test_upload.yml
     with:
-      branch: ""
+      branch: "release/0.3.0"
       pre_dev_release: false
-      pytorch_version: ""
+      pytorch_version: "1.11.0"
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
Example workflow without uploading: https://github.com/pytorch/data/runs/5498280111?check_suite_focus=true

Conda is still missing because of the missing token.