### PR TITLE
Fix build_docs_job due to the change of security protocal for GitHub

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
 # torch
 # PyTorch Theme
--e git+git://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
+-e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Fixes the error for build_docs_job workflow:
https://github.com/pytorch/data/runs/5555336090?check_suite_focus=true