### PR TITLE
Deprecate transforms.RandomSizedCrop in torchvision example

### DIFF
--- a/examples/vision/imagefolder.py
+++ b/examples/vision/imagefolder.py
@@ -21,7 +21,7 @@ BATCH_SIZE = None
 
 data_transform = transforms.Compose(
     [
-        transforms.RandomSizedCrop(224),
+        transforms.RandomResizedCrop(224),
         transforms.RandomHorizontalFlip(),
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),


### PR DESCRIPTION
Fixes #{issue number}

### Changes

-
-
