### PR TITLE
Fix conda linux release and trigger uploading with partial wheel/conda build

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -53,7 +53,6 @@ jobs:
         id: get_release_type
 
   wheel_build_test:
-    if: ${{ needs.get_release_type.outputs.type }}
     needs: get_release_type
     runs-on: ${{ matrix.os }}
     strategy:
@@ -107,7 +106,7 @@ jobs:
           path: dist/torchdata*.whl
 
   wheel_upload:
-    if: always() && ${{ needs.get_release_type.outputs.type }}
+    if: always()
     needs: [get_release_type, wheel_build_test]
     runs-on: ubuntu-latest
     outputs:
@@ -160,7 +159,6 @@ jobs:
             dist/torchdata*.whl
 
   conda_build_test:
-    if: ${{ needs.get_release_type.outputs.type }}
     needs: get_release_type
     runs-on: ${{ matrix.os }}
     strategy:
@@ -201,7 +199,7 @@ jobs:
           path: conda-bld/*/torchdata-*.tar.bz2
 
   conda_upload:
-    if: always() && ${{ needs.get_release_type.outputs.type }}
+    if: always()
     needs: [get_release_type, conda_build_test]
     runs-on: ubuntu-latest
     container: continuumio/miniconda3

--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -31,6 +31,7 @@ test:
   source_files:
     - test
   requires:
+    - cpuonly
     - pytest
     - expecttest
     - fsspec


### PR DESCRIPTION
Changes:
- For conda package, we need to enforce testing using cpuonly version of PyTorch, since we don't have cuda on CI machines.
- Remove all `if` condition to make sure that wheel/conda uploading happens even when a few wheels/conda packages are not built successfully.

See the failing workflow last night: https://github.com/pytorch/data/actions/runs/2034148892