### PR TITLE
Forward conda nightly token to workflow

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -228,6 +228,7 @@ jobs:
         shell: bash
         env:
           CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}
+          CONDA_NIGHTLY_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_NIGHTLY_PYTORCHBOT_TOKEN }}
         run: |
           conda install -yq anaconda-client
           if [[ ${{ needs.get_release_type.outputs.type }} == 'official' ]]; then

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -1,6 +1,7 @@
 name: Push Nightly Release
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: 00 12 * * *
 


### PR DESCRIPTION
- Fix another bug in the workflow (I completely missed this point as I couldn't test it)
- Add a manual trigger for nightly-release as a fail-over method