### PR TITLE
Force removing previous nightly and change nightly to UTC-11

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -253,7 +253,7 @@ jobs:
                   for new_package in ./$subdir/torchdata-*-$build.tar.bz2; do
                     if [[ -f "$new_package" ]]; then
                       echo "Removing $CONDA_CHANNEL/torchdata/$version/$subdir/torchdata-$version-$build.tar.bz2"
-                      anaconda -t "${CONDA_NIGHTLY_PYTORCHBOT_TOKEN}" remove "$CONDA_CHANNEL/torchdata/$version/$subdir/torchdata-$version-$build.tar.bz2"
+                      anaconda -t "${CONDA_NIGHTLY_PYTORCHBOT_TOKEN}" remove -f "$CONDA_CHANNEL/torchdata/$version/$subdir/torchdata-$version-$build.tar.bz2"
                       break
                     fi
                   done

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -3,7 +3,7 @@ name: Push Nightly Release
 on:
   workflow_dispatch:
   schedule:
-    - cron: 00 15 * * *
+    - cron: 00 11 * * *
 
 jobs:
   build_test_upload:


### PR DESCRIPTION
Adding `-f` to remove terminal prompt when removing old nightly release
Change nightly release to UTC-11 to ublock TorchVision CI