### PR TITLE
Update license header for pytorch/data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 # Most of the configurations are taken from PyTorch

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,3 +1,9 @@
+@REM Copyright (c) Meta Platforms, Inc. and affiliates.
+@REM All rights reserved.
+@REM
+@REM This source code is licensed under the BSD-style license found in the
+@REM LICENSE file in the root directory of this source tree.
+
 @ECHO OFF
 
 pushd %~dp0

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 h1 {
   font-size: 2rem;
   letter-spacing: 1.78px;

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/audio/librispeech.py
+++ b/examples/audio/librispeech.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import functools
 import os
 

--- a/examples/text/ag_news.py
+++ b/examples/text/ag_news.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torchdata.datapipes.iter import HttpReader
 
 from .utils import _add_docstring_header, _create_dataset_directory, _wrap_split_argument

--- a/examples/text/amazonreviewpolarity.py
+++ b/examples/text/amazonreviewpolarity.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from torchdata.datapipes.iter import FileOpener, GDriveReader, IterableWrapper

--- a/examples/text/imdb.py
+++ b/examples/text/imdb.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 from pathlib import Path
 

--- a/examples/text/squad1.py
+++ b/examples/text/squad1.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from torchdata.datapipes.iter import FileOpener, HttpReader, IterableWrapper, IterDataPipe

--- a/examples/text/squad2.py
+++ b/examples/text/squad2.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from torchdata.datapipes.iter import FileOpener, HttpReader, IterableWrapper, IterDataPipe

--- a/examples/text/utils.py
+++ b/examples/text/utils.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 # The following utility functions are copied from torchtext
 # https://github.com/pytorch/text/blob/main/torchtext/data/datasets_utils.py

--- a/examples/vision/__init__.py
+++ b/examples/vision/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/vision/caltech101.py
+++ b/examples/vision/caltech101.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os.path
 import re
 

--- a/examples/vision/caltech256.py
+++ b/examples/vision/caltech256.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os.path
 
 from torch.utils.data.datapipes.utils.decoder import imagehandler

--- a/examples/vision/imagefolder.py
+++ b/examples/vision/imagefolder.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import http.server
 import os
 import re

--- a/packaging/build_conda.sh
+++ b/packaging/build_conda.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 set -ex
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/packaging/build_wheel.sh
+++ b/packaging/build_wheel.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 set -ex
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/packaging/pkg_helpers.bash
+++ b/packaging/pkg_helpers.bash
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 # A set of useful bash functions for common functionality we need to do in
 # many build scripts

--- a/packaging/torchdata/bld.bat
+++ b/packaging/torchdata/bld.bat
@@ -1,3 +1,9 @@
+@REM Copyright (c) Meta Platforms, Inc. and affiliates.
+@REM All rights reserved.
+@REM
+@REM This source code is licensed under the BSD-style license found in the
+@REM LICENSE file in the root directory of this source tree.
+
 @echo off
 
 git submodule update --init --recursive

--- a/packaging/torchdata/build.sh
+++ b/packaging/torchdata/build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 set -ex
 
 git submodule update --init --recursive

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import distutils.command.clean
 import os
 import shutil

--- a/test/_fakedata/_create_fake_data.py
+++ b/test/_fakedata/_create_fake_data.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import tarfile
 

--- a/test/_utils/__init__.py
+++ b/test/_utils/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/_utils/_common_utils_for_test.py
+++ b/test/_utils/_common_utils_for_test.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import hashlib
 import os
 import tempfile

--- a/test/test_audio_examples.py
+++ b/test/test_audio_examples.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import sys
 import tempfile

--- a/test/test_dataframe.py
+++ b/test/test_dataframe.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import unittest
 import warnings

--- a/test/test_datapipe.py
+++ b/test/test_datapipe.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import io
 import itertools
 import unittest

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import unittest
 import warnings

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import bz2
 import hashlib
 import itertools

--- a/test/test_period.py
+++ b/test/test_period.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import io
 import os
 import unittest

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import io
 import os
 import unittest

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import pickle
 import unittest

--- a/test/test_text_examples.py
+++ b/test/test_text_examples.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 import torch.multiprocessing as mp

--- a/tools/gen_pyi.py
+++ b/tools/gen_pyi.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 from pathlib import Path
 from typing import Dict, List, Optional, Set

--- a/tools/setup_helpers/__init__.py
+++ b/tools/setup_helpers/__init__.py
@@ -1,1 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .extension import *  # noqa

--- a/tools/setup_helpers/extension.py
+++ b/tools/setup_helpers/extension.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import distutils.sysconfig
 import os
 import platform

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torchdata import _extension  # noqa: F401
 
 from . import datapipes

--- a/torchdata/_extension.py
+++ b/torchdata/_extension.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import importlib
 import os
 from pathlib import Path

--- a/torchdata/_torchdata/__init__.pyi
+++ b/torchdata/_torchdata/__init__.pyi
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import List
 

--- a/torchdata/csrc/CMakeLists.txt
+++ b/torchdata/csrc/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 if(BUILD_S3)
 
   message(STATUS "Building S3 IO functionality")

--- a/torchdata/csrc/pybind/S3Handler/S3Handler.cpp
+++ b/torchdata/csrc/pybind/S3Handler/S3Handler.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "S3Handler.h"
 
 namespace torchdata {

--- a/torchdata/csrc/pybind/S3Handler/S3Handler.h
+++ b/torchdata/csrc/pybind/S3Handler/S3Handler.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include "precompile.h"
 
 namespace torchdata {

--- a/torchdata/csrc/pybind/S3Handler/precompile.h
+++ b/torchdata/csrc/pybind/S3Handler/precompile.h
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #ifndef TORCHDATA_S3_IO_H
 #define TORCHDATA_S3_IO_H
 

--- a/torchdata/csrc/pybind/pybind.cpp
+++ b/torchdata/csrc/pybind/pybind.cpp
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 

--- a/torchdata/datapipes/__init__.py
+++ b/torchdata/datapipes/__init__.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.utils.data import DataChunk, functional_datapipe
 
 from . import iter, map, utils

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.utils.data import IterDataPipe
 
 from torch.utils.data.datapipes.iter import (

--- a/torchdata/datapipes/iter/load/__init__.py
+++ b/torchdata/datapipes/iter/load/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import posixpath
 

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from typing import Any, Callable, Iterator, List, Optional, Tuple, Union

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import re
 from typing import Iterator, Optional, Tuple
 from urllib.parse import urlparse

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from io import BytesIO
 from typing import Iterator, Tuple
 

--- a/torchdata/datapipes/iter/transform/__init__.py
+++ b/torchdata/datapipes/iter/transform/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import heapq
 import random
 

--- a/torchdata/datapipes/iter/transform/flatmap.py
+++ b/torchdata/datapipes/iter/transform/flatmap.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Callable, TypeVar
 
 from torch.utils.data import functional_datapipe, IterDataPipe

--- a/torchdata/datapipes/iter/util/__init__.py
+++ b/torchdata/datapipes/iter/util/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/iter/util/bz2fileloader.py
+++ b/torchdata/datapipes/iter/util/bz2fileloader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import bz2
 import warnings
 from io import BufferedIOBase

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import hashlib
 import inspect
 import os.path

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import warnings
 from collections import OrderedDict
 from typing import Callable, Iterator, Optional, TypeVar

--- a/torchdata/datapipes/iter/util/cycler.py
+++ b/torchdata/datapipes/iter/util/cycler.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Iterator, Optional, TypeVar
 
 from torchdata.datapipes import functional_datapipe

--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from functools import partial
 from typing import List, Optional, TypeVar
 

--- a/torchdata/datapipes/iter/util/decompressor.py
+++ b/torchdata/datapipes/iter/util/decompressor.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import bz2
 import gzip
 import lzma

--- a/torchdata/datapipes/iter/util/hashchecker.py
+++ b/torchdata/datapipes/iter/util/hashchecker.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import hashlib
 
 from io import IOBase

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Iterator, TypeVar
 from warnings import warn
 

--- a/torchdata/datapipes/iter/util/indexadder.py
+++ b/torchdata/datapipes/iter/util/indexadder.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, Iterator, Tuple, TypeVar
 
 from torchdata.datapipes import functional_datapipe

--- a/torchdata/datapipes/iter/util/jsonparser.py
+++ b/torchdata/datapipes/iter/util/jsonparser.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import json
 from typing import Dict, IO, Iterator, Tuple
 

--- a/torchdata/datapipes/iter/util/paragraphaggregator.py
+++ b/torchdata/datapipes/iter/util/paragraphaggregator.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Callable, Iterator, List, Tuple, TypeVar
 
 from torch.utils.data.datapipes.utils.common import check_lambda_fn

--- a/torchdata/datapipes/iter/util/plain_text_reader.py
+++ b/torchdata/datapipes/iter/util/plain_text_reader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import contextlib
 import csv
 from typing import IO, Iterator, Tuple, TypeVar, Union

--- a/torchdata/datapipes/iter/util/rararchiveloader.py
+++ b/torchdata/datapipes/iter/util/rararchiveloader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import io
 import os.path
 from typing import Iterator, Tuple

--- a/torchdata/datapipes/iter/util/rows2columnar.py
+++ b/torchdata/datapipes/iter/util/rows2columnar.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from collections import defaultdict
 from typing import Dict, Iterator, List, Union
 

--- a/torchdata/datapipes/iter/util/samplemultiplexer.py
+++ b/torchdata/datapipes/iter/util/samplemultiplexer.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import random
 from typing import Dict, Iterator, Optional, Sized, TypeVar
 

--- a/torchdata/datapipes/iter/util/saver.py
+++ b/torchdata/datapipes/iter/util/saver.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 
 from typing import Any, Callable, Iterator, Optional, Tuple, Union

--- a/torchdata/datapipes/iter/util/tararchiveloader.py
+++ b/torchdata/datapipes/iter/util/tararchiveloader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import tarfile
 import warnings

--- a/torchdata/datapipes/iter/util/unzipper.py
+++ b/torchdata/datapipes/iter/util/unzipper.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Optional, Sequence, TypeVar
 
 from torch.utils.data.datapipes.iter.combining import _ChildDataPipe, _ForkerIterDataPipe

--- a/torchdata/datapipes/iter/util/xzfileloader.py
+++ b/torchdata/datapipes/iter/util/xzfileloader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import lzma
 import warnings
 from io import BufferedIOBase

--- a/torchdata/datapipes/iter/util/ziparchiveloader.py
+++ b/torchdata/datapipes/iter/util/ziparchiveloader.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import sys
 import warnings

--- a/torchdata/datapipes/map/__init__.py
+++ b/torchdata/datapipes/map/__init__.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.utils.data import MapDataPipe
 
 from torch.utils.data.datapipes.map import Batcher, Concater, Mapper, SequenceWrapper, Shuffler, Zipper

--- a/torchdata/datapipes/map/load/__init__.py
+++ b/torchdata/datapipes/map/load/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/map/load/transform.py
+++ b/torchdata/datapipes/map/load/transform.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/map/transform/__init__.py
+++ b/torchdata/datapipes/map/transform/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/map/util/__init__.py
+++ b/torchdata/datapipes/map/util/__init__.py
@@ -1,1 +1,5 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/datapipes/map/util/utils.py
+++ b/torchdata/datapipes/map/util/utils.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import warnings
 
 from typing import Callable, Dict, Optional

--- a/torchdata/datapipes/utils/__init__.py
+++ b/torchdata/datapipes/utils/__init__.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.utils.data.datapipes.utils.common import StreamWrapper
 
 __all__ = ["StreamWrapper"]

--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -1,4 +1,9 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from io import IOBase
 from typing import Tuple
 


### PR DESCRIPTION
Summary:
This diff is automatically generated via
```
arc lint --apply-patches --take LICENSELINT --paths-cmd "hg files -X 'glob:pytorch/data/docs/**' pytorch/data"
```

All files are updated or attached with new license

Differential Revision: D35444604

