### PR TITLE
Fix conda build for awssdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/*
 dist/*
 *.egg-info/*
+conda-bld/*
 
 torchdata/version.py
 torchdata/datapipes/iter/__init__.pyi

--- a/torchdata/_extension.py
+++ b/torchdata/_extension.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib
+import importlib.machinery
 import os
 from pathlib import Path
 


### PR DESCRIPTION
Fixes #350

This is caused by `machinery` not initialized when we import `importlib`. See the recent nightly workflow: https://github.com/pytorch/data/actions/runs/2114765935