### PR TITLE
Prevent any release workflow running on fork

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -26,10 +26,7 @@ on:
 
 jobs:
   get_release_type:
-    if: |
-      github.repository == 'pytorch/data' &&
-      ( github.ref_name == 'main' || startsWith(github.ref_name, 'release/') || github.ref_type == 'tag' ) &&
-      inputs.branch != ''
+    if: inputs.branch != ''
     runs-on: ubuntu-latest
     outputs:
       type: ${{ steps.get_release_type.outputs.type }}
@@ -106,7 +103,7 @@ jobs:
           path: dist/torchdata*.whl
 
   wheel_upload:
-    if: always()
+    if: always() && inputs.branch != ''
     needs: [get_release_type, wheel_build_test]
     runs-on: ubuntu-latest
     outputs:
@@ -199,7 +196,7 @@ jobs:
           path: conda-bld/*/torchdata-*.tar.bz2
 
   conda_upload:
-    if: always()
+    if: always() && inputs.branch != ''
     needs: [get_release_type, conda_build_test]
     runs-on: ubuntu-latest
     container: continuumio/miniconda3
@@ -269,7 +266,9 @@ jobs:
           fi
 
   build_docs:
-    if: always() && ( needs.wheel_upload.outputs.upload == 'true' || needs.conda_upload.outputs.upload == 'true' )
+    if: |
+      always() && inputs.branch != '' &&
+      ( needs.wheel_upload.outputs.upload == 'true' || needs.conda_upload.outputs.upload == 'true' )
     needs: [get_release_type, wheel_upload, conda_upload]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build_test_upload:
+    if: |
+      github.repository == 'pytorch/data' && github.ref_name == 'main'
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: "main"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   build_test_upload:
+    if: github.repository == 'pytorch/data' && github.ref_type == 'tag'
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: ""

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   build_test_upload:
+    if: github.repository == 'pytorch/data' && startsWith(github.ref_name, 'release/')
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: ""


### PR DESCRIPTION
This PR would prevent the nightly workflow being run on forked repo
See the action on my fork: https://github.com/ejguan/data/actions/runs/2160757127