### PR TITLE
Override wrong python https proxy on Windows

### DIFF
--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -60,27 +60,6 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         # __len__ Test: returns the length of source DataPipe
         self.assertEqual(1, len(http_reader_dp))
 
-        if os.name == "nt":
-            try:
-                import winreg
-            except ImportError:
-                return
-            internetSettings = winreg.OpenKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
-                0,
-                winreg.KEY_SET_VALUE,
-            )
-
-            def _set_winreg_key(name, value):
-                _, reg_type = winreg.QueryValueEx(internetSettings, name)
-                winreg.SetValueEx(internetSettings, name, 0, reg_type, value)
-
-            _set_winreg_key("ProxyEnable", 1)
-            _set_winreg_key("ProxyServer", "127.0.0.1:8080")
-
-            _ = list(http_reader_dp)
-
     def test_on_disk_cache_holder_iterdatapipe(self):
         tar_file_url = "https://raw.githubusercontent.com/pytorch/data/main/test/_fakedata/csv.tar.gz"
         expected_file_name = os.path.join(self.temp_dir.name, "csv.tar.gz")

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import os
 import re
 import urllib
 
@@ -21,14 +20,15 @@ from torchdata.datapipes.utils import StreamWrapper
 
 # TODO: Remove this helper function when https://bugs.python.org/issue42627 is resolved
 def _get_proxies() -> Optional[Dict[str, str]]:
-    if os.name == "nt":
-        proxies = urllib.request.getproxies()
-        address = proxies.get("https")
-        # The default proxy type of Windows is HTTP
-        if address and address.startswith("https"):
-            address = "http" + address[5:]
-            proxies["https"] = address
-            return proxies
+    #  import os
+    #  if os.name == "nt":
+    #      proxies = urllib.request.getproxies()
+    #      address = proxies.get("https")
+    #      # The default proxy type of Windows is HTTP
+    #      if address and address.startswith("https"):
+    #          address = "http" + address[5:]
+    #          proxies["https"] = address
+    #          return proxies
     return None
 
 

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -20,15 +20,16 @@ from torchdata.datapipes.utils import StreamWrapper
 
 # TODO: Remove this helper function when https://bugs.python.org/issue42627 is resolved
 def _get_proxies() -> Optional[Dict[str, str]]:
-    #  import os
-    #  if os.name == "nt":
-    #      proxies = urllib.request.getproxies()
-    #      address = proxies.get("https")
-    #      # The default proxy type of Windows is HTTP
-    #      if address and address.startswith("https"):
-    #          address = "http" + address[5:]
-    #          proxies["https"] = address
-    #          return proxies
+    import os
+
+    if os.name == "nt":
+        proxies = urllib.request.getproxies()
+        address = proxies.get("https")
+        # The default proxy type of Windows is HTTP
+        if address and address.startswith("https"):
+            address = "http" + address[5:]
+            proxies["https"] = address
+            return proxies
     return None
 
 

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -4,11 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import re
-from typing import Iterator, Optional, Tuple
-from urllib.parse import urlparse
+import urllib
+
+from typing import Dict, Iterator, Optional, Tuple
 
 import requests
+
 from requests.exceptions import HTTPError, RequestException
 
 from torchdata.datapipes import functional_datapipe
@@ -16,13 +19,27 @@ from torchdata.datapipes.iter import IterDataPipe
 from torchdata.datapipes.utils import StreamWrapper
 
 
+# TODO: Remove this helper function when https://bugs.python.org/issue42627 is resolved
+def _get_proxies() -> Optional[Dict[str, str]]:
+    if os.name == "nt":
+        proxies = urllib.request.getproxies()
+        address = proxies.get("https")
+        # The default proxy type of Windows is HTTP
+        if address and address.startswith("https"):
+            address = "http" + address[5:]
+            proxies["https"] = address
+            return proxies
+    return None
+
+
 def _get_response_from_http(url: str, *, timeout: Optional[float]) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
+            proxies = _get_proxies()
             if timeout is None:
-                r = session.get(url, stream=True)
+                r = session.get(url, stream=True, proxies=proxies)
             else:
-                r = session.get(url, timeout=timeout, stream=True)
+                r = session.get(url, timeout=timeout, stream=True, proxies=proxies)
         return url, StreamWrapper(r.raw)
     except HTTPError as e:
         raise Exception(f"Could not get the file. [HTTP Error] {e.response}.")
@@ -166,7 +183,7 @@ class OnlineReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
     def __iter__(self) -> Iterator[Tuple[str, StreamWrapper]]:
         for url in self.source_datapipe:
-            parts = urlparse(url)
+            parts = urllib.parse.urlparse(url)
 
             if re.match(r"(drive|docs)[.]google[.]com", parts.netloc):
                 yield _get_response_from_google_drive(url, timeout=self.timeout)


### PR DESCRIPTION
Fixes #355

This is patch to fix a bug embedded in Python `urllib` in TorchData. See: https://bugs.python.org/issue42627

Simply speaking, python uses `https` proxy for urls with `https` but windows platform expects `http` proxy for these urls.

I have no idea how to create such test for windows, I am open for suggestions