### PR TITLE
Adding `zip_longest` DataPipe

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -101,6 +101,7 @@ These tend to involve multiple DataPipes, combining them or splitting one to man
     SampleMultiplexer
     UnZipper
     Zipper
+    ZipperLongest
 
 Grouping DataPipes
 -----------------------------

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -902,5 +902,40 @@ class TestIterDataPipe(expecttest.TestCase):
         with self.assertRaises(TypeError):
             len(output_dp)
 
+    def test_zip_longest_iterdatapipe(self):
+
+        # Functional Test: raises TypeError when an input is not of type `IterDataPipe`
+        with self.assertRaises(TypeError):
+            input_dp1 = IterableWrapper(range(10))
+            input_no_dp = list(range(10))
+            output_dp = input_dp1.zip_longest(input_no_dp)  # type: ignore[arg-type]
+
+        # Functional Test: raises TypeError when an input does not have valid length
+        input_dp1 = IterableWrapper(range(10))
+        input_dp_no_len = IDP_NoLen(range(5))
+        output_dp = input_dp1.zip_longest(input_dp_no_len)
+        with self.assertRaisesRegex(TypeError, r"instance doesn't have valid length$"):
+            len(output_dp)
+
+        # Functional Test: zips the results properly even when lengths are different
+        # (zips to the longest, filling missing values with default value None.)
+        input_dp1 = IterableWrapper(range(10))
+        input_dp2 = IterableWrapper(range(5))
+        output_dp = input_dp1.zip_longest(input_dp2)
+        exp = [(i, i) for i in range(5)] + [(i, None) for i in range(5, 10)]
+        self.assertEqual(list(output_dp), exp)
+
+        # Functional Test: zips the results properly even when lengths are different
+        # (zips to the longest, filling missing values with user input)
+        input_dp1 = IterableWrapper(range(10))
+        input_dp2 = IterableWrapper(range(5))
+        output_dp = input_dp1.zip_longest(input_dp2, fill_value=-1)
+        exp = [(i, i) for i in range(5)] + [(i, -1) for i in range(5, 10)]
+        self.assertEqual(list(output_dp), exp)
+
+        # __len__ Test: length matches the length of the shortest input
+        self.assertEqual(len(output_dp), 10)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -269,6 +269,7 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
             (iterdp.WebDataset, IterableWrapper([("foo.txt", b"1"), ("bar.txt", b"2")]), (), {}),
             (iterdp.XzFileLoader, None, (), {}),
             (iterdp.ZipArchiveLoader, None, (), {}),
+            (iterdp.ZipperLongest, IterableWrapper(range(10)), (), {}),
         ]
 
         picklable_datapipes = _filter_by_module_availability(picklable_datapipes)

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -95,6 +95,7 @@ from torchdata.datapipes.iter.util.plain_text_reader import (
     LineReaderIterDataPipe as LineReader,
 )
 from torchdata.datapipes.iter.util.mux_longest import MultiplexerLongestIterDataPipe as MultiplexerLongest
+from torchdata.datapipes.iter.util.zip_longest import ZipperLongestIterDataPipe as ZipperLongest
 from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterDataPipe as RarArchiveLoader
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
@@ -192,6 +193,7 @@ __all__ = [
     "ZipArchiveLoader",
     "ZipArchiveReader",
     "Zipper",
+    "ZipperLongest",
 ]
 
 # Please keep this list sorted

--- a/torchdata/datapipes/iter/util/zip_longest.py
+++ b/torchdata/datapipes/iter/util/zip_longest.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch.utils.data.datapipes._decorator import functional_datapipe
+from torch.utils.data.datapipes.datapipe import IterDataPipe
+from typing import List, Any, Iterator, Tuple, Sized, Set, Optional
+
+
+@functional_datapipe('zip_longest')
+class ZipperLongestIterDataPipe(IterDataPipe):
+    r"""
+    Aggregates elements into a tuple from each of the input DataPipes (functional name: ``zip_longest``).
+    The output is stopped until all input DataPipes are exhausted. If any input DataPipe is exhausted,
+    missing values are filled-in with `fill_value` (default value is None).
+
+    Args:
+        *datapipes: Iterable DataPipes being aggregated
+        *fill_value: Value that user input to fill in the missing values from DataPipe. Default value is None.
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp1, dp2, dp3 = IterableWrapper(range(3)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
+        >>> list(dp1.zip_longest(dp2, dp3))
+        [(0, 10, 20), (1, 11, 21), (2, 12, 22), (None, 13, 23), (None, 14, 24)]
+        >>> list(dp1.zip_longest(dp2, dp3, -1))
+        [(0, 10, 20), (1, 11, 21), (2, 12, 22), (-1, 13, 23), (-1, 14, 24)]
+    """
+    datapipes: Tuple[IterDataPipe]
+    length: Optional[int]
+    fill_value: Any
+
+    def __init__(self, *datapipes: IterDataPipe, fill_value: Any = None,):
+        if not all(isinstance(dp, IterDataPipe) for dp in datapipes):
+            raise TypeError("All inputs are required to be `IterDataPipe` "
+                            "for `ZipperLongestIterDataPipe`.")
+        super().__init__()
+        self.datapipes = datapipes  # type: ignore[assignment]
+        self.length = None
+        self.fill_value = fill_value
+
+    def __iter__(self) -> Iterator[Tuple]:
+        iterators = [iter(x) for x in self.datapipes]
+        finished: Set[int] = set()
+        while len(finished) < len(iterators):
+            values: List[Any] = []
+            for i in range(len(iterators)):
+                value = self.fill_value
+                if i not in finished:
+                    try:
+                        value = next(iterators[i])
+                    except StopIteration:
+                        finished.add(i)
+                        if len(finished) == len(iterators):
+                            return
+                values.append(value)
+            yield tuple(values)
+
+    def __len__(self) -> int:
+        if self.length is not None:
+            if self.length == -1:
+                raise TypeError("{} instance doesn't have valid length".format(type(self).__name__))
+            return self.length
+        if all(isinstance(dp, Sized) for dp in self.datapipes):
+            self.length = max(len(dp) for dp in self.datapipes)
+        else:
+            self.length = -1
+        return len(self)


### PR DESCRIPTION
Summary:
OSS issue discussion: https://github.com/pytorch/data/issues/346
This diff updates `zip` and `zip_longest` data pipe.
`zip`: Aggregates elements into a tuple from each of the input DataPipes (functional name: ``zip``).
    The output is stopped as soon as the shortest input DataPipe is exhausted.

`zip` example:

```
>>> from torchdata.datapipes.iter import IterableWrapper
>>> dp1, dp2, dp3 = IterableWrapper(range(5)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
>>> list(dp1.zip(dp2, dp3))
[(0, 10, 20), (1, 11, 21), (2, 12, 22), (3, 13, 23), (4, 14, 24)]

```

`zip_longest`: Aggregates elements into a tuple from each of the input DataPipes (functional name: `zip_longest`). The output is stopped until all input DataPipes are exhausted, and skips over the finished datapipes.

`zip_longest` example:

```
 >>> from torchdata.datapipes.iter import IterableWrapper
>>> dp1, dp2, dp3 = IterableWrapper(range(3)), IterableWrapper(range(10, 15)), IterableWrapper(range(20, 25))
>>> list(dp1.zip_longest(dp2, dp3))
[(0, 10, 20), (1, 11, 21), (2, 12, 22), (13, 23), (14, 24)]
```

Reviewed By: ejguan

Differential Revision: D35760498

