### PR TITLE
Solve issue #282: Update FSSpecFileLister, IoPathFileLister

### DIFF
--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -69,20 +69,18 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         datapipe = FSSpecFileLister(root=["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
 
         # check all file paths within sub_folder are listed
-        for path in datapipe:
-            self.assertIn(
-                path.split("://")[1],
-                {
-                    fsspec.implementations.local.make_path_posix(file)
-                    for file in (self.temp_sub_files + self.temp_sub_files_2)
-                },
+        file_lister = list(map(lambda path: path.split("://")[1], datapipe))
+        file_lister.sort()
+        temp_files = list(
+            map(
+                lambda file: fsspec.implementations.local.make_path_posix(file),
+                self.temp_sub_files + self.temp_sub_files_2,
             )
+        )
+        temp_files.sort()
 
-        for file in self.temp_sub_files + self.temp_sub_files_2:
-            self.assertIn(
-                fsspec.implementations.local.make_path_posix(file),
-                {path.split("://")[1] for path in datapipe},
-            )
+        # check all file paths within sub_folder are listed
+        self.assertEqual(file_lister, temp_files)
 
     @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -71,10 +71,17 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self.temp_sub_dir = create_temp_dir(self.temp_dir.name)
         self.temp_sub_files = create_temp_files(self.temp_sub_dir, 4, False)
 
+        self.temp_dir_2 = create_temp_dir()
+        self.temp_files_2 = create_temp_files(self.temp_dir_2)
+        self.temp_sub_dir_2 = create_temp_dir(self.temp_dir_2.name)
+        self.temp_sub_files_2 = create_temp_files(self.temp_sub_dir_2, 4, False)
+
     def tearDown(self):
         try:
             self.temp_sub_dir.cleanup()
             self.temp_dir.cleanup()
+            self.temp_sub_dir_2.cleanup()
+            self.temp_dir_2.cleanup()
         except Exception as e:
             warnings.warn(f"TestDataPipeLocalIO was not able to cleanup temp dir due to {e}")
 
@@ -600,6 +607,17 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         # check all file paths within sub_folder are listed
         for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
+
+    @skipIfNoIoPath
+    def test_io_path_file_lister_iterdatapipe_with_list(self):
+        datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
+
+        # check all file paths within sub_folder are listed
+        for path in datapipe:
+            self.assertTrue(path in (self.temp_sub_files + self.temp_sub_files_2))
+
+        for file in self.temp_sub_files + self.temp_sub_files_2:
+            self.assertTrue(file in datapipe)
 
     @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -612,12 +612,13 @@ class TestDataPipeLocalIO(expecttest.TestCase):
     def test_io_path_file_lister_iterdatapipe_with_list(self):
         datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
 
-        # check all file paths within sub_folder are listed
-        for path in datapipe:
-            self.assertTrue(path in (self.temp_sub_files + self.temp_sub_files_2))
+        file_lister = list(datapipe)
+        file_lister.sort()
+        all_temp_files = list(self.temp_sub_files + self.temp_sub_files_2)
+        all_temp_files.sort()
 
-        for file in self.temp_sub_files + self.temp_sub_files_2:
-            self.assertTrue(file in datapipe)
+        # check all file paths within sub_folder are listed
+        self.assertEqual(file_lister, all_temp_files)
 
     @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -59,8 +59,9 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
                 root,
             ]
         if not isinstance(root, IterDataPipe):
-            root = IterableWrapper(root)
-        self.datapipe: IterDataPipe = root
+            self.datapipe: Union[IterDataPipe, IterableWrapper] = IterableWrapper(root)
+        else:
+            self.datapipe = root
         self.masks = masks
 
     def __iter__(self) -> Iterator[str]:

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -73,7 +73,7 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
             else:
                 protocol_list = fs.protocol
 
-            is_local = fs.protocol == "file" or not any(root.startswith(protocol) for protocol in fs.protocol)
+            is_local = fs.protocol == "file" or not any(root.startswith(protocol) for protocol in protocol_list)
             if fs.isfile(path):
                 yield root
             else:
@@ -95,6 +95,7 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
                             if root.startswith(protocol):
                                 starts_with = True
                                 yield protocol + "://" + abs_path
+                                break
 
                         if not starts_with:
                             yield abs_path

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -7,12 +7,12 @@
 import os
 import posixpath
 
-from typing import Any, Callable, Iterator, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterator, List, Optional, Sequence, Tuple, Union
 
 from torch.utils.data.datapipes.utils.common import match_masks
 
 from torchdata.datapipes import functional_datapipe
-from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 from torchdata.datapipes.utils import StreamWrapper
 
 try:
@@ -39,7 +39,7 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
     and yields the full pathname or URL for each file within the directory.
 
     Args:
-        root: The root `fsspec` path directory to list files from
+        root: The root `fsspec` path directory or list of path directories to list files from
         masks: Unix style filter string or string list for filtering file name(s)
 
     Example:
@@ -49,37 +49,44 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
 
     def __init__(
         self,
-        root: str,
+        root: Union[str, Sequence[str], IterDataPipe],
         masks: Union[str, List[str]] = "",
     ) -> None:
         _assert_fsspec()
 
-        self.root: str = root
+        if isinstance(root, str):
+            root = [
+                root,
+            ]
+        if not isinstance(root, IterDataPipe):
+            root = IterableWrapper(root)
+        self.datapipe: IterDataPipe = root
         self.masks = masks
 
     def __iter__(self) -> Iterator[str]:
-        fs, path = fsspec.core.url_to_fs(self.root)
-        is_local = fs.protocol == "file" or not self.root.startswith(fs.protocol)
-        if fs.isfile(path):
-            yield self.root
-        else:
-            for file_name in fs.ls(path):
-                if not match_masks(file_name, self.masks):
-                    continue
+        for root in self.datapipe:
+            fs, path = fsspec.core.url_to_fs(root)
+            is_local = fs.protocol == "file" or not root.startswith(fs.protocol)
+            if fs.isfile(path):
+                yield root
+            else:
+                for file_name in fs.ls(path):
+                    if not match_masks(file_name, self.masks):
+                        continue
 
-                # ensure the file name has the full fsspec protocol path
-                if file_name.startswith(fs.protocol):
-                    yield file_name
-                else:
-                    if is_local:
-                        abs_path = os.path.join(path, file_name)
+                    # ensure the file name has the full fsspec protocol path
+                    if file_name.startswith(fs.protocol):
+                        yield file_name
                     else:
-                        abs_path = posixpath.join(path, file_name)
+                        if is_local:
+                            abs_path = os.path.join(path, file_name)
+                        else:
+                            abs_path = posixpath.join(path, file_name)
 
-                    if self.root.startswith(fs.protocol):
-                        yield fs.protocol + "://" + abs_path
-                    else:
-                        yield abs_path
+                        if root.startswith(fs.protocol):
+                            yield fs.protocol + "://" + abs_path
+                        else:
+                            yield abs_path
 
 
 @functional_datapipe("open_file_by_fsspec")

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -77,8 +77,9 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
                 root,
             ]
         if not isinstance(root, IterDataPipe):
-            root = IterableWrapper(root)
-        self.datapipe: IterDataPipe = root
+            self.datapipe: Union[IterDataPipe, IterableWrapper] = IterableWrapper(root)
+        else:
+            self.datapipe = root
         self.pathmgr = _create_default_pathmanager() if pathmgr is None else pathmgr
         self.masks = masks
 


### PR DESCRIPTION
Fixes #282 

### Summary

Updated FSSpecFileLister and IoPathFileLister to optionally take a list of strings as root paths. As per the contributors guideline, added tests to the testsuite to cover changes and ran the pre-commit format checker.

### Changes
- Updated FSSpecFileLister to take either a str or sequence of strings as root path argument (in \_init_ arguments)

- Updated \_init_ of FSSpecFileLister to check if root argument is string or list and make into IterDataPipe

- Updated \_iter_ of FSSPecFileLister to look through all root paths when yielding files

- Added unit test in test_fsspec.py to test for multiple root path input to FSSpecFileLister

- Updated IoPathFileLister to take either a str or sequence of strings as root path argument (in \_init_ arguments)

- Updated \_init_ of IoPathFileLister to check if root argument is string or list and make into IterDataPipe

- Updated \_iter_ of IoPathFileLister to look through all root paths when yielding files

- Added unit test in test\_local_io.py to test for multiple root path input to IoPathFileLister
