### PR TITLE
add support for `**kwargs` in `HttpReader`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ conda install pytorch -c pytorch-nightly
 git clone https://github.com/pytorch/data.git
 cd data
 python setup.py develop
-pip install flake8 typing mypy pytest
+pip install flake8 typing mypy pytest expecttest
 ```
 
 ## Pull Requests

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -41,7 +41,8 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
         expected_file_name = "LICENSE"
         expected_MD5_hash = "bb9675028dd39d2dd2bf71002b93e66c"
-        http_reader_dp = HttpReader(IterableWrapper([file_url]))
+        query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
+        http_reader_dp = HttpReader(IterableWrapper([file_url, query_params]))
 
         # Functional Test: test if the Http Reader can download and read properly
         reader_dp = http_reader_dp.readlines()
@@ -58,7 +59,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         self.assertTrue(io.BufferedReader, type(stream))
 
         # __len__ Test: returns the length of source DataPipe
-        self.assertEqual(1, len(http_reader_dp))
+        self.assertEqual(2, len(http_reader_dp))
 
     def test_on_disk_cache_holder_iterdatapipe(self):
         tar_file_url = "https://raw.githubusercontent.com/pytorch/data/main/test/_fakedata/csv.tar.gz"

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -41,9 +41,9 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
         expected_file_name = "LICENSE"
         expected_MD5_hash = "bb9675028dd39d2dd2bf71002b93e66c"
-        query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
+        query_params = {"auth": ("fake_username", "fake_password"), "allow_redirects": True}
         timeout = 120
-        http_reader_dp = HttpReader(IterableWrapper([file_url, timeout, query_params]))
+        http_reader_dp = HttpReader(IterableWrapper([file_url]), timeout=timeout, **query_params)
 
         # Functional Test: test if the Http Reader can download and read properly
         reader_dp = http_reader_dp.readlines()

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -60,7 +60,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         self.assertTrue(io.BufferedReader, type(stream))
 
         # __len__ Test: returns the length of source DataPipe
-        self.assertEqual(3, len(http_reader_dp))
+        self.assertEqual(1, len(http_reader_dp))
 
     def test_on_disk_cache_holder_iterdatapipe(self):
         tar_file_url = "https://raw.githubusercontent.com/pytorch/data/main/test/_fakedata/csv.tar.gz"

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -42,7 +42,8 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         expected_file_name = "LICENSE"
         expected_MD5_hash = "bb9675028dd39d2dd2bf71002b93e66c"
         query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
-        http_reader_dp = HttpReader(IterableWrapper([file_url, query_params]))
+        timeout = 120
+        http_reader_dp = HttpReader(IterableWrapper([file_url, timeout, query_params]))
 
         # Functional Test: test if the Http Reader can download and read properly
         reader_dp = http_reader_dp.readlines()
@@ -59,7 +60,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         self.assertTrue(io.BufferedReader, type(stream))
 
         # __len__ Test: returns the length of source DataPipe
-        self.assertEqual(2, len(http_reader_dp))
+        self.assertEqual(3, len(http_reader_dp))
 
     def test_on_disk_cache_holder_iterdatapipe(self):
         tar_file_url = "https://raw.githubusercontent.com/pytorch/data/main/test/_fakedata/csv.tar.gz"

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -60,13 +60,13 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
     Args:
         source_datapipe: a DataPipe that contains URLs
+        timeout: timeout in seconds for HTTP request
         **kwargs: a Dictionary to pass optional arguments that requests takes. For the full list check out https://docs.python-requests.org/en/master/api/
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
         >>> query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
-
         >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -34,13 +34,13 @@ def _get_proxies() -> Optional[Dict[str, str]]:
 
 
 def _get_response_from_http(
-    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, Any]]
+    url: str, *, timeout: Optional[float], headers : Optional[Dict[str,str]], query_params: Optional[Dict[str, Any]]
 ) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
             proxies = _get_proxies()
             if timeout is None:
-                r = session.get(url, stream=True, proxies=proxies, **query_params)
+                r = session.get(url, stream=True, headers=headers, proxies=proxies, **query_params)
             else:
                 r = session.get(url, timeout=timeout, stream=True, proxies=proxies, **query_params)
         return url, StreamWrapper(r.raw)
@@ -65,6 +65,7 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
+        >>> # Optionally pass in query_param dict as HttpReader(IterableWrapper([(file_url, query_param)]))
         >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -68,7 +68,7 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
         >>> query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
         >>> timeout = 120
-        >>> http_reader_dp = HttpReader(IterableWrapper([file_url, timeout, query_params]))
+        >>> http_reader_dp = HttpReader(IterableWrapper([file_url]), timeout=timeout, query_params)
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)
         >>> path, line = next(it)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -33,7 +33,7 @@ def _get_proxies() -> Optional[Dict[str, str]]:
     return None
 
 
-def _get_response_from_http(url: str, *, timeout: Optional[float], query_params : Dict[str, str]) -> Tuple[str, StreamWrapper]:
+def _get_response_from_http(url: str, *, timeout: Optional[float], query_params : Optional[Dict[str, str]]) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
             proxies = _get_proxies()

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -34,7 +34,7 @@ def _get_proxies() -> Optional[Dict[str, str]]:
 
 
 def _get_response_from_http(
-    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, Any]]
+    url: str, *, timeout: Optional[float], **query_params: Optional[Dict[str, Any]]
 ) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
@@ -75,14 +75,19 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         b'BSD 3-Clause License'
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs : Optional[Dict[str, Any]]) -> None:
+    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None,
+     **kwargs : Optional[Dict[str, Any]]) -> None:
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.timeout = timeout
         self.query_params = kwargs
 
     def __iter__(self) -> Iterator[Tuple[str, StreamWrapper]]:
         for url in self.source_datapipe:
-            yield _get_response_from_http(url, timeout=self.timeout, query_params=self.query_params)
+            if self.query_params:
+                yield _get_response_from_http(url, timeout=self.timeout, **self.query_params)
+            else:
+                yield _get_response_from_http(url, timeout=self.timeout)
+
 
     def __len__(self) -> int:
         return len(self.source_datapipe)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -65,7 +65,6 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
-        >>> # Optionally pass in query_param dict as HttpReader(IterableWrapper([(file_url, query_param)]))
         >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)
@@ -76,7 +75,7 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         b'BSD 3-Clause License'
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs) -> None:
+    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs : Optional[Dict[str, Any]]) -> None:
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.timeout = timeout
         self.query_params = kwargs

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -7,7 +7,7 @@
 import re
 import urllib
 
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Any, Dict, Iterator, Optional, Tuple
 
 import requests
 
@@ -34,7 +34,7 @@ def _get_proxies() -> Optional[Dict[str, str]]:
 
 
 def _get_response_from_http(
-    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, str]]
+    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, Any]]
 ) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -65,7 +65,8 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
-        >>> http_reader_dp = HttpReader(IterableWrapper([file_url, query_params]))
+        >>> # optional query_params
+        >>> http_reader_dp = HttpReader(IterableWrapper([(file_url, query_params)]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)
         >>> path, line = next(it)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -7,7 +7,7 @@
 import re
 import urllib
 
-from typing import Dict, Iterator, Optional, Tuple, Dict
+from typing import Dict, Iterator, Optional, Tuple
 
 import requests
 
@@ -33,7 +33,9 @@ def _get_proxies() -> Optional[Dict[str, str]]:
     return None
 
 
-def _get_response_from_http(url: str, *, timeout: Optional[float], query_params : Optional[Dict[str, str]]) -> Tuple[str, StreamWrapper]:
+def _get_response_from_http(
+    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, str]] = {}
+) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
             proxies = _get_proxies()
@@ -73,7 +75,12 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         b'BSD 3-Clause License'
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], query_params : Optional[Dict[str,str]] = {}, timeout: Optional[float] = None) -> None:
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe[str],
+        query_params: Optional[Dict[str, str]] = {},
+        timeout: Optional[float] = None,
+    ) -> None:
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.timeout = timeout
         self.query_params = query_params

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -67,7 +67,8 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
         >>> query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
-        >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
+        >>> timeout = 120
+        >>> http_reader_dp = HttpReader(IterableWrapper([file_url, timeout, query_params]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)
         >>> path, line = next(it)
@@ -77,8 +78,7 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         b'BSD 3-Clause License'
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None,
-     **kwargs : Optional[Dict[str, Any]]) -> None:
+    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs : Optional[Dict[str, Any]]) -> None:
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.timeout = timeout
         self.query_params = kwargs

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -78,7 +78,9 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         b'BSD 3-Clause License'
     """
 
-    def __init__(self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs : Optional[Dict[str, Any]]) -> None:
+    def __init__(
+        self, source_datapipe: IterDataPipe[str], timeout: Optional[float] = None, **kwargs: Optional[Dict[str, Any]]
+    ) -> None:
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.timeout = timeout
         self.query_params = kwargs
@@ -89,7 +91,6 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
                 yield _get_response_from_http(url, timeout=self.timeout, **self.query_params)
             else:
                 yield _get_response_from_http(url, timeout=self.timeout)
-
 
     def __len__(self) -> int:
         return len(self.source_datapipe)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -34,13 +34,13 @@ def _get_proxies() -> Optional[Dict[str, str]]:
 
 
 def _get_response_from_http(
-    url: str, *, timeout: Optional[float], headers : Optional[Dict[str,str]], query_params: Optional[Dict[str, Any]]
+    url: str, *, timeout: Optional[float], query_params: Optional[Dict[str, Any]]
 ) -> Tuple[str, StreamWrapper]:
     try:
         with requests.Session() as session:
             proxies = _get_proxies()
             if timeout is None:
-                r = session.get(url, stream=True, headers=headers, proxies=proxies, **query_params)
+                r = session.get(url, stream=True, proxies=proxies, **query_params)
             else:
                 r = session.get(url, timeout=timeout, stream=True, proxies=proxies, **query_params)
         return url, StreamWrapper(r.raw)

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -60,11 +60,13 @@ class HTTPReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
     Args:
         source_datapipe: a DataPipe that contains URLs
-        timeout: timeout in seconds for HTTP request
+        **kwargs: a Dictionary to pass optional arguments that requests takes. For the full list check out https://docs.python-requests.org/en/master/api/
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, HttpReader
         >>> file_url = "https://raw.githubusercontent.com/pytorch/data/main/LICENSE"
+        >>> query_params = {"auth" : ("fake_username", "fake_password"), "allow_redirects" : True}
+
         >>> http_reader_dp = HttpReader(IterableWrapper([file_url]))
         >>> reader_dp = http_reader_dp.readlines()
         >>> it = iter(reader_dp)


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #391 

### Changes

- Added support for `**kwarg` for `request` parameters in `HttpReader`

Although it doesn't look like the HTTP dataset pipe is tested anywhere so I'll take a closer look and add one