### PR TITLE
filters important for reading WebDataset files (and also more generally useful)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,7 @@ Features described in this documentation are classified by release status:
 
    tutorial.rst
    examples.rst
+   webdataset.rst
 
 
 .. toctree::

--- a/docs/source/webdataset.rst
+++ b/docs/source/webdataset.rst
@@ -1,0 +1,131 @@
+WebDataset
+================
+
+Format
+---------------------------------------------
+
+WebDataset stores deep learning as tar files, with the simple convention
+that files that belong together and make up a training sample share
+the same basename. WebDataset can read files from local disk or from
+any pipe, which allows it to access files using common cloud object
+stores. WebDataset can also read concatenated MsgPack and CBORs sources.
+
+The WebDataset representation allows writing purely sequential I/O
+pipelines for large scale deep learning. This is important for achieving
+high I/O rates from local storage (3x-10x for local drives compared to
+random access) and for using object stores and cloud storage for training.
+
+The WebDataset format represents images, movies, audio, etc. in their
+native file formats, making the creation of WebDataset format data as
+easy as just creating a tar archive. Because of the way data is aligned,
+WebDataset works well with block deduplication as well and aligns data
+on predictable boundaries.
+
+Standard tools can be.. code:: bash
+
+.. code:: bash
+   curl -s http://storage.googleapis.com/nvdata-openimages/openimages-train-000000.tar | tar tf - | sed 10q
+
+::
+
+   e39871fd9fd74f55.jpg
+   e39871fd9fd74f55.json
+   f18b91585c4d3f3e.jpg
+   f18b91585c4d3f3e.json
+   ede6e66b2fb59aab.jpg
+   ede6e66b2fb59aab.json
+   ed600d57fcee4f94.jpg
+   ed600d57fcee4f94.json
+   ff47e649b23f446d.jpg
+   ff47e649b23f446d.json
+
+Related Projects
+------------------
+
+-  the new ``torchdata`` library in PyTorch will add native (built-in)
+   support for WebDataset
+-  the AIStore server provides high-speed storage, caching, and data
+   transformation for WebDataset data
+-  WebDataset training can be carried out directly against S3, GCS, and
+   other cloud storage buckets
+-  NVIDIA’s DALI library supports reading WebDataset format data
+   directly
+-  there is a companion project to read WebDataset data in Julia
+-  the ``tarp`` command line program can be used for quick and easy
+   dataset transformations of WebDataset data used for accessing and processing WebDataset-format files.
+
+Using WebDataset in ``torchdata``
+--------------------------------
+
+.. code:: python
+    import numpy as np
+    import torchdata.datapipes as dp
+    from itertools import islice
+    from imageio import imread
+    import io
+
+
+    src = "https://storage.googleapis.com/nvdata-ocropus/ia1-{000000..000033}.tar"
+
+    ds = (
+        dp.iter.IterableWrapper([src])
+        .shardexpand()
+        .shuffle()
+        .popen()
+        .filecache(cachedir="mycache", verbose=True)
+        .load_from_tar(mode="r|")
+        .decode(
+            jpg=lambda s: imread(io.BytesIO(s.read())),
+            png=lambda s: imread(io.BytesIO(s.read())),
+        )
+        .webdataset()
+        .extract_keys("__key__", ["*.jpg", "*.png"])
+        .incshuffle(initial=5, buffer_size=10000)
+    )
+
+    print(list(islice(ds, 0, 10)))
+
+
+.. code:: python
+    ds = (
+        # iterates through all source shard specs (only one in this case)
+        dp.iter.IterableWrapper([src])
+
+        # expand the {0000000..000033} notation in the shard specification
+        .shardexpand()
+
+        # shuffle the .tar files
+        .shuffle()
+
+        # open each of the .tar files in turn (this can open local or remote files)
+        .popen()
+
+        # cache the tar files locally so they don't have to be re-downloaded every time
+        .filecache(cachedir="mycache", verbose=True)
+
+        # extract the individual files from the tar files
+        .load_from_tar(mode="r|")
+
+        # decode files ending in .jpg and .png as images
+        # (we need the extra io.BytesIO because imread requires a seekable source)
+        .decode(
+            jpg=lambda s: imread(io.BytesIO(s.read())),
+            png=lambda s: imread(io.BytesIO(s.read())),
+        )
+
+        # group together files in the tar file based on WebDataset conventions
+        # this returns a stream of dictionaries
+        .webdataset()
+
+        # turn the dictionaries into tuples by extracting the sample key and
+        # anything that matches one of the image formats
+        .extract_keys("__key__", ["*.jpg", "*.png"])
+
+        # incrementally shuffle the resulting training samples
+        .incshuffle(initial=5, buffer_size=10000)
+    )
+
+    print(list(islice(ds, 0, 10)))
+
+
+

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -35,6 +35,7 @@ from torchdata.datapipes.iter import (
     ParagraphAggregator,
     PipeOpener,
     RenameKeys,
+    ExtractKeys,
     Rows2Columnar,
     SampleMultiplexer,
     ShardExpander,
@@ -913,24 +914,22 @@ class TestIterDataPipe(expecttest.TestCase):
         output = list(iter(stage2))
         assert len(output) == 10
 
-
     def test_decoder(self):
         def decode_junk(_):
             return "junk"
 
         stage1 = IterableWrapper([
-                ("test000.bin", io.BytesIO(b"000")),
-                ("test000.txt", io.BytesIO(b"000")),
-                ("test000.jnk", io.BytesIO(b"")),
-                ("test001.bin", io.BytesIO(b"001")),
-                ("test001.txt", io.BytesIO(b"001")),
+            ("test000.bin", io.BytesIO(b"000")),
+            ("test000.txt", io.BytesIO(b"000")),
+            ("test000.jnk", io.BytesIO(b"")),
+            ("test001.bin", io.BytesIO(b"001")),
+            ("test001.txt", io.BytesIO(b"001")),
         ])
         stage2 = FileDecoder(stage1, ("*.jnk", decode_junk))
         output = list(iter(stage2))
         assert len(output) == 5
         assert output[1][1] == "000"
         assert output[2][1] == "junk"
-
 
     def test_renamer(self):
         stage1 = IterableWrapper([
@@ -941,6 +940,18 @@ class TestIterDataPipe(expecttest.TestCase):
         output = list(iter(stage2))
         assert len(output) == 2
         assert set(output[0].keys()) == set(["t", "b"])
+
+    def test_extractor(self):
+        stage1 = IterableWrapper([
+            {"1.txt": "1", "1.bin": "1b"},
+            {"2.txt": "2", "2.bin": "2b"},
+        ])
+        stage2 = ExtractKeys(stage1, "*.txt", "*.bin")
+        output = list(iter(stage2))
+        assert len(output) == 2
+        assert output[0][0] == "1"
+        assert output[0][1] == "1b"
+
 
 
 

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -26,6 +26,7 @@ from torchdata.datapipes.iter import (
     InBatchShuffler,
     IndexAdder,
     InMemoryCacheHolder,
+    IncrementalShuffler,
     IterableWrapper,
     IterDataPipe,
     IterKeyZipper,
@@ -952,7 +953,14 @@ class TestIterDataPipe(expecttest.TestCase):
         assert output[0][0] == "1"
         assert output[0][1] == "1b"
 
-
+    def test_incshuffle(self):
+        for initial in [3, 10, 17, 167, 1000, 1500]:
+            for buffer in [3, 6, 10, 19, 223, 1000, 1001, 1500]:
+                for n in [10, 100, 1000]:
+                    stage1 = IterableWrapper(range(n))
+                    stage2 = IncrementalShuffler(stage1, initial=initial, buffer_size=buffer)
+                    output = list(iter(stage2))
+                    assert set(output) == set(range(n))
 
 
 if __name__ == "__main__":

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -34,6 +34,7 @@ from torchdata.datapipes.iter import (
     IoPathSaver,
     IterableWrapper,
     JsonParser,
+    PipeOpener,
     RarArchiveLoader,
     Saver,
     TarArchiveLoader,
@@ -777,6 +778,35 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         assert len(items) == nsamples
         assert items[0][".txt"] == "text0"
         assert items[9][".bin"] == "bin9"
+
+
+    def test_popener_local_file_cat(self) -> None:
+        nfiles = 100
+        testdata = b"hello, world"
+        dest = os.path.join(self.temp_dir.name, "testdata")
+        with open(dest, "wb") as stream:
+            stream.write(testdata)
+        stage1 = IterableWrapper([dest] * nfiles)
+        stage2 = PipeOpener(stage1)
+        count = 0
+        for path, stream in stage2:
+            data = stream.read()
+            count += 1
+            assert data == testdata
+        assert count == nfiles
+
+
+    def test_popener_pipe_url(self) -> None:
+        nfiles = 100
+        url = "pipe:echo hello world"
+        stage1 = IterableWrapper([url] * nfiles)
+        stage2 = PipeOpener(stage1)
+        count = 0
+        for path, stream in stage2:
+            data = stream.read()
+            count += 1
+            assert data == b"hello world\n"
+        assert count == nfiles
 
 
 if __name__ == "__main__":

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -116,6 +116,8 @@ from torchdata.datapipes.iter.util.webdataset import (
     FileDecoderIterDataPipe as FileDecoder,
     RenameKeysIterDataPipe as RenameKeys,
     ShardExpanderIterDataPipe as ShardExpander,
+    IncrementalShufflerIterDataPipe as IncrementalShuffler,
+    FileCacheIterDataPipe as FileCache,
 )
 from torchdata.datapipes.iter.util.xzfileloader import (
     XzFileLoaderIterDataPipe as XzFileLoader,
@@ -147,6 +149,7 @@ __all__ = [
     "FSSpecFileLister",
     "FSSpecFileOpener",
     "FSSpecSaver",
+    "FileCache",
     "FileDecoder",
     "FileLister",
     "FileOpener",
@@ -160,6 +163,7 @@ __all__ = [
     "HttpReader",
     "InBatchShuffler",
     "InMemoryCacheHolder",
+    "IncrementalShuffler",
     "IndexAdder",
     "IoPathFileLister",
     "IoPathFileOpener",

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -112,6 +112,7 @@ from torchdata.datapipes.iter.util.unzipper import UnZipperIterDataPipe as UnZip
 from torchdata.datapipes.iter.util.webdataset import (
     WebDatasetIterDataPipe as WebDataset,
     PipeOpenerIterDataPipe as PipeOpener,
+    ExtractKeysIterDataPipe as ExtractKeys,
     FileDecoderIterDataPipe as FileDecoder,
     RenameKeysIterDataPipe as RenameKeys,
     ShardExpanderIterDataPipe as ShardExpander,
@@ -141,6 +142,7 @@ __all__ = [
     "Demultiplexer",
     "EndOnDiskCacheHolder",
     "Enumerator",
+    "ExtractKeys",
     "Extractor",
     "FSSpecFileLister",
     "FSSpecFileOpener",

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -109,7 +109,13 @@ from torchdata.datapipes.iter.util.tfrecordloader import (
     TFRecordLoaderIterDataPipe as TFRecordLoader,
 )
 from torchdata.datapipes.iter.util.unzipper import UnZipperIterDataPipe as UnZipper
-from torchdata.datapipes.iter.util.webdataset import WebDatasetIterDataPipe as WebDataset
+from torchdata.datapipes.iter.util.webdataset import (
+    WebDatasetIterDataPipe as WebDataset,
+    PipeOpenerIterDataPipe as PipeOpener,
+    FileDecoderIterDataPipe as FileDecoder,
+    RenameKeysIterDataPipe as RenameKeys,
+    ShardExpanderIterDataPipe as ShardExpander,
+)
 from torchdata.datapipes.iter.util.xzfileloader import (
     XzFileLoaderIterDataPipe as XzFileLoader,
     XzFileReaderIterDataPipe as XzFileReader,
@@ -139,6 +145,7 @@ __all__ = [
     "FSSpecFileLister",
     "FSSpecFileOpener",
     "FSSpecSaver",
+    "FileDecoder",
     "FileLister",
     "FileOpener",
     "Filter",
@@ -170,7 +177,9 @@ __all__ = [
     "OnlineReader",
     "ParagraphAggregator",
     "ParquetDataFrameLoader",
+    "PipeOpener",
     "RarArchiveLoader",
+    "RenameKeys",
     "RoutedDecoder",
     "Rows2Columnar",
     "S3FileLister",
@@ -178,6 +187,7 @@ __all__ = [
     "SampleMultiplexer",
     "Sampler",
     "Saver",
+    "ShardExpander",
     "ShardingFilter",
     "Shuffler",
     "StreamReader",

--- a/torchdata/datapipes/iter/util/webdataset.py
+++ b/torchdata/datapipes/iter/util/webdataset.py
@@ -326,7 +326,8 @@ class ExtractKeysIterDataPipe(IterDataPipe[Dict]):
         for sample in self.source_datapipe:
             result = []
             for pattern in self.patterns:
-                matches = [x for x in sample.keys() if fnmatch(x, pattern)]
+                pattern = [pattern] if not isinstance(pattern, (list, tuple)) else pattern
+                matches = [x for x in sample.keys() if any(fnmatch(x, p) for p in pattern)]
                 if len(matches) == 0:
                     if self.ignore_missing:
                         continue


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

### Changes

This PR adds a number of additional filters that are important for reading WebDataset-style sharded datasets.

Most of these filters are also useful independently of WebDataset, e.g. for decoding files in tar files, for faster shuffling, etc.

- WebDataset / .webdataset -- group files in stream into samples based on basename
- ShardExpander / .shardexpand -- expand brace notations for file shards
- FileDecoder / .decode -- apply file decoders based on matching glob patterns / extensions
- PipeOpener / .popen -- reads local and remote datasets using command line programs
- RenameKeys / .rename_keys -- rename samples in a dictionary by matching keys against glob patterns
- ExtractKeys / .extract_keys -- extract sample fields and return tuple based on glob patterns
- IncrementalShuffler / .incshuffle -- inline shuffling of shards and samples with low startup latency
- FileCache / .filecache -- cache files / shards in a local data directory