### PR TITLE
Fix lint and test Error introduced by DataLoader2

### DIFF
--- a/test/_utils/_common_utils_for_test.py
+++ b/test/_utils/_common_utils_for_test.py
@@ -6,6 +6,7 @@
 
 import hashlib
 import os
+import sys
 import tempfile
 from typing import List, Tuple, TypeVar
 
@@ -13,6 +14,11 @@ from torchdata.datapipes.iter import IterDataPipe
 
 
 T_co = TypeVar("T_co", covariant=True)
+
+
+IS_LINUX = sys.platform == "linux"
+IS_WINDOWS = sys.platform == "win32"
+IS_MACOS = sys.platform == "darwin"
 
 
 class IDP_NoLen(IterDataPipe):

--- a/test/test_dataloader2_checkpoint_utils.py
+++ b/test/test_dataloader2_checkpoint_utils.py
@@ -8,20 +8,13 @@ import pickle
 from typing import Any, Dict, Optional, Tuple
 from unittest import TestCase
 
-from torchdata.dataloader2.dataloader2 import (
-    READING_SERVICE_STATE_KEY_NAME,
-    SERIALIZED_DATAPIPE_KEY_NAME,
-)
-from torchdata.dataloader2.dataloader2_checkpoint_utils import (
-    try_deserialize_as_dlv2_checkpoint,
-)
+from torchdata.dataloader2.dataloader2 import READING_SERVICE_STATE_KEY_NAME, SERIALIZED_DATAPIPE_KEY_NAME
+from torchdata.dataloader2.dataloader2_checkpoint_utils import try_deserialize_as_dlv2_checkpoint
 
 
 class DataLoader2CheckpointUtilTest(TestCase):
     def _test_try_deserialize_as_dlv2_checkpoint(
-        self,
-        checkpoint_bytes: Optional[bytes],
-        expected: Tuple[bool, Optional[Dict[str, Any]]],
+        self, checkpoint_bytes: Optional[bytes], expected: Tuple[bool, Optional[Dict[str, Any]]]
     ) -> None:
         ans = try_deserialize_as_dlv2_checkpoint(checkpoint_bytes)
         self.assertEqual(ans, expected)
@@ -35,15 +28,11 @@ class DataLoader2CheckpointUtilTest(TestCase):
             SERIALIZED_DATAPIPE_KEY_NAME: "",
             READING_SERVICE_STATE_KEY_NAME: "",
         }
-        self._test_try_deserialize_as_dlv2_checkpoint(
-            pickle.dumps(dlv2_state_dict1), (True, dlv2_state_dict1)
-        )
+        self._test_try_deserialize_as_dlv2_checkpoint(pickle.dumps(dlv2_state_dict1), (True, dlv2_state_dict1))
 
         dlv2_state_dict2 = {
             SERIALIZED_DATAPIPE_KEY_NAME: b"123",
             READING_SERVICE_STATE_KEY_NAME: b"456",
         }
 
-        self._test_try_deserialize_as_dlv2_checkpoint(
-            pickle.dumps(dlv2_state_dict2), (True, dlv2_state_dict2)
-        )
+        self._test_try_deserialize_as_dlv2_checkpoint(pickle.dumps(dlv2_state_dict2), (True, dlv2_state_dict2))

--- a/torchdata/dataloader2/_graph_utils.py
+++ b/torchdata/dataloader2/_graph_utils.py
@@ -56,7 +56,7 @@ def list_connected_datapipes(scan_obj: IterDataPipe, only_datapipe: bool) -> Lis
 
 def traverse(datapipe: IterDataPipe, only_datapipe: bool = False) -> DataPipeGraph:
     if not isinstance(datapipe, IterDataPipe):
-        raise RuntimeError("Expected `IterDataPipe`, but {} is found".format(type(datapipe)))
+        raise RuntimeError(f"Expected `IterDataPipe`, but {type(datapipe)} is found")
 
     items: List[IterDataPipe] = list_connected_datapipes(datapipe, only_datapipe)
     d = {datapipe: {}}

--- a/torchdata/dataloader2/_graph_utils.py
+++ b/torchdata/dataloader2/_graph_utils.py
@@ -11,7 +11,7 @@ from typing import Dict, List
 
 from torch.utils.data import IterDataPipe
 
-DataPipeGraph = Dict[IterDataPipe, "DataPipeGraph"]
+DataPipeGraph = Dict[IterDataPipe, "DataPipeGraph"]  # type: ignore[misc]
 
 
 # Modified based on torch.utils.data.graph
@@ -31,9 +31,9 @@ def list_connected_datapipes(scan_obj: IterDataPipe, only_datapipe: bool) -> Lis
         for k, v in obj.__dict__.items():
             if isinstance(v, (IterDataPipe, dict, list, set, tuple)):  # including all potential containers
                 state[k] = v
-        return state
+        return state  # type: ignore[return-value]
 
-    def reduce_hook(obj: IterDataPipe):  # pyre-ignore
+    def reduce_hook(obj: IterDataPipe):
         if obj == scan_obj:
             raise NotImplementedError
         else:
@@ -59,7 +59,7 @@ def traverse(datapipe: IterDataPipe, only_datapipe: bool = False) -> DataPipeGra
         raise RuntimeError(f"Expected `IterDataPipe`, but {type(datapipe)} is found")
 
     items: List[IterDataPipe] = list_connected_datapipes(datapipe, only_datapipe)
-    d = {datapipe: {}}
+    d: DataPipeGraph = {datapipe: {}}
     for item in items:
         d[datapipe].update(traverse(item, only_datapipe))
     return d

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -12,10 +12,7 @@ from typing import Any, Callable, Dict, Generic, Iterator, Optional, TypeVar
 from torch.utils.data import IterDataPipe
 
 from .error import PauseIteration
-from .reading_service import (
-    CheckpointableReadingServiceInterface,
-    ReadingServiceInterface,
-)
+from .reading_service import CheckpointableReadingServiceInterface, ReadingServiceInterface
 
 T_co = TypeVar("T_co", covariant=True)
 SERIALIZED_DATAPIPE_KEY_NAME = "serialized_datapipe"
@@ -26,18 +23,14 @@ def serialize_datapipe(datapipe: IterDataPipe) -> bytes:
     try:
         return pickle.dumps(datapipe)
     except pickle.PickleError as e:
-        raise NotImplementedError(
-            f"Prototype only support pickle-able datapipes for checkpoint: {e}"
-        )
+        raise NotImplementedError(f"Prototype only support pickle-able datapipes for checkpoint: {e}")
 
 
 def deserialize_datapipe(serialized_state: bytes) -> IterDataPipe:
     try:
         return pickle.loads(serialized_state)
     except pickle.PickleError as e:
-        raise NotImplementedError(
-            f"Prototype only support pickle-able datapipes for checkpoint: {e}"
-        )
+        raise NotImplementedError(f"Prototype only support pickle-able datapipes for checkpoint: {e}")
 
 
 @dataclass
@@ -73,24 +66,16 @@ class DataLoader2(Generic[T_co]):
 
     def __iter__(self) -> Iterator[T_co]:
         if self._terminated:
-            raise Exception(
-                "Cannot iterate over the DataLoader as it has already been shut down"
-            )
+            raise Exception("Cannot iterate over the DataLoader as it has already been shut down")
 
         if self._reset_iter:
             if not self._adapted and self.reading_service is not None:
                 if self.reading_service_state is None:
                     self.datapipe = self.reading_service.initialize(self.datapipe)
                 else:
-                    if not isinstance(
-                        self.reading_service, CheckpointableReadingServiceInterface
-                    ):
-                        raise TypeError(
-                            "Cannot restore from non-checkpointable reading service"
-                        )
-                    self.datapipe = self.reading_service.restore(
-                        self.datapipe, self.reading_service_state
-                    )
+                    if not isinstance(self.reading_service, CheckpointableReadingServiceInterface):
+                        raise TypeError("Cannot restore from non-checkpointable reading service")
+                    self.datapipe = self.reading_service.restore(self.datapipe, self.reading_service_state)
                 self._adapted = True
 
             if self.reading_service is not None:
@@ -149,15 +134,11 @@ class DataLoader2(Generic[T_co]):
         Reading Service State: Reading Service checkpoint information.
         """
         reading_service_state = None
-        if self.reading_service is not None and isinstance(
-            self.reading_service, CheckpointableReadingServiceInterface
-        ):
+        if self.reading_service is not None and isinstance(self.reading_service, CheckpointableReadingServiceInterface):
             reading_service_state = self.reading_service.checkpoint()
 
         # Serialize datapipe after applying adapters and before reading service adaption
-        serialized_datapipe = serialize_datapipe(
-            self._datapipe_before_reading_service_adapt
-        )
+        serialized_datapipe = serialize_datapipe(self._datapipe_before_reading_service_adapt)
 
         return {
             SERIALIZED_DATAPIPE_KEY_NAME: serialized_datapipe,

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -60,7 +60,6 @@ class DataLoader2(Generic[T_co]):
         self._terminated: bool = False
 
         if self.datapipe_adapter_fn is not None:
-            # pyre-fixme[4]: Attribute annotation cannot contain `Any`.
             self.datapipe = self.datapipe_adapter_fn(self.datapipe)
         self._datapipe_before_reading_service_adapt: IterDataPipe = self.datapipe
 
@@ -91,7 +90,7 @@ class DataLoader2(Generic[T_co]):
         if self._reset_iter:
             raise StopIteration
         try:
-            return next(self._datapipe_iter)  # pyre-ignore[6]
+            return next(self._datapipe_iter)  # type: ignore[arg-type]
         except PauseIteration:
             raise StopIteration
         except StopIteration:
@@ -100,8 +99,6 @@ class DataLoader2(Generic[T_co]):
             self._reset_iter = True
             raise
 
-    # Have to add this delegation methods for `limit`, `resume`, etc.
-    # pyre-fixme[3]: Return annotation cannot be `Any`.
     def __getattr__(self, name: str) -> Any:
         if self._datapipe_iter is None:
             raise AttributeError
@@ -122,7 +119,7 @@ class DataLoader2(Generic[T_co]):
     def __enter__(self) -> "DataLoader2[T_co]":
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback) -> None:  # pyre-ignore
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
         self.shutdown()
 
     def state_dict(self) -> Dict[str, Any]:
@@ -158,7 +155,7 @@ class DataLoader2(Generic[T_co]):
         serialized_datapipe = state[SERIALIZED_DATAPIPE_KEY_NAME]
         reading_service_state = state[READING_SERVICE_STATE_KEY_NAME]
 
-        data_loader = DataLoader2(
+        data_loader: "DataLoader2[T_co]" = DataLoader2(
             datapipe=deserialize_datapipe(serialized_datapipe),
             datapipe_adapter_fn=None,
             reading_service=reading_service,

--- a/torchdata/dataloader2/dataloader2_checkpoint_utils.py
+++ b/torchdata/dataloader2/dataloader2_checkpoint_utils.py
@@ -8,17 +8,12 @@ import logging
 import pickle
 from typing import Any, Dict, Optional, Tuple
 
-from torchdata.dataloader2.dataloader2 import (
-    READING_SERVICE_STATE_KEY_NAME,
-    SERIALIZED_DATAPIPE_KEY_NAME,
-)
+from torchdata.dataloader2.dataloader2 import READING_SERVICE_STATE_KEY_NAME, SERIALIZED_DATAPIPE_KEY_NAME
 
 logger: logging.Logger = logging.getLogger()
 
 
-def try_deserialize_as_dlv2_checkpoint(
-    checkpoint_bytes: Optional[bytes],
-) -> Tuple[bool, Optional[Dict[str, Any]]]:
+def try_deserialize_as_dlv2_checkpoint(checkpoint_bytes: Optional[bytes]) -> Tuple[bool, Optional[Dict[str, Any]]]:
     """
     Handling the checkpoint conversion from bytes to DataLoader V2 format.
     Model store checkpoint agent only store ByteIO/Tensor/ShardedTensor.
@@ -44,14 +39,9 @@ def try_deserialize_as_dlv2_checkpoint(
                 logger.info("Checkpoint deserialized as dataloader v2 checkpoing.")
                 return True, deserialized_state_dict
     except pickle.UnpicklingError:
-        logger.info(
-            "Reader checkpoint UnpicklingError. Proceed as dataloader v1 checkpoint."
-        )
+        logger.info("Reader checkpoint UnpicklingError. Proceed as dataloader v1 checkpoint.")
     except Exception:
-        logger.warn(
-            "Exception when deserializing reader checkpoint as dataloader v2 "
-            "checkpoint."
-        )
+        logger.warn("Exception when deserializing reader checkpoint as dataloader v2 checkpoint")
         raise
     return False, None
 

--- a/torchdata/dataloader2/error.py
+++ b/torchdata/dataloader2/error.py
@@ -5,6 +5,5 @@
 # LICENSE file in the root directory of this source tree.
 
 
-
 class PauseIteration(StopIteration):
     pass

--- a/torchdata/dataloader2/graph.py
+++ b/torchdata/dataloader2/graph.py
@@ -9,7 +9,7 @@ from typing import List, Type
 
 from torch.utils.data import IterDataPipe
 
-from ._graph_utils import traverse, DataPipeGraph
+from ._graph_utils import DataPipeGraph, traverse
 
 
 # In case that there will be multiple datapipe needs to be adapted
@@ -79,9 +79,7 @@ def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> No
 
 # For each `recv_dp`, find if the source_datapipe needs to be replaced by the new one.
 # If found, find where the `old_dp` is located in `recv_dp` and switch it to the `new_dp`
-def _replace_dp(
-    recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe  # pyre-ignore
-) -> None:
+def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe) -> None:  # pyre-ignore
     for send_dp in send_graph:
         if send_dp is old_dp:
             _assign_attr(recv_dp, old_dp, new_dp, inner_dp=True)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -6,7 +6,7 @@
 
 
 from abc import ABC, abstractmethod
-from typing import Callable, Optional, Iterator
+from typing import Callable, Optional
 
 from torch.utils.data import DataLoader, IterDataPipe
 from torch.utils.data.datapipes.iter import IterableWrapper
@@ -154,10 +154,6 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         return IterableWrapper(self.dl_)
 
     def finalize(self) -> None:
-        if (
-            self.persistent_workers
-            and self.dl_ is not None
-            and self.dl_._iterator is not None
-        ):
+        if self.persistent_workers and self.dl_ is not None and self.dl_._iterator is not None:
             self.dl_._iterator._shutdown_workers()  # pyre-ignore
             self.dl_._iterator = None  # pyre-ignore

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -126,7 +126,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         pin_memory: bool = False,
         timeout: float = 0,
         worker_init_fn: Optional[Callable[[int], None]] = None,
-        multiprocessing_context=None,  # pyre-ignore
+        multiprocessing_context=None,
         prefetch_factor: int = 2,
         persistent_workers: bool = False,
     ) -> None:
@@ -134,7 +134,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         self.pin_memory = pin_memory
         self.timeout = timeout
         self.worker_init_fn = worker_init_fn
-        self.multiprocessing_context = multiprocessing_context  # pyre-ignore
+        self.multiprocessing_context = multiprocessing_context
         self.prefetch_factor = prefetch_factor
         self.persistent_workers = persistent_workers
         self.dl_: Optional[DataLoader] = None
@@ -155,5 +155,5 @@ class MultiProcessingReadingService(ReadingServiceInterface):
 
     def finalize(self) -> None:
         if self.persistent_workers and self.dl_ is not None and self.dl_._iterator is not None:
-            self.dl_._iterator._shutdown_workers()  # pyre-ignore
-            self.dl_._iterator = None  # pyre-ignore
+            self.dl_._iterator._shutdown_workers()  # type: ignore[attr-defined]
+            self.dl_._iterator = None


### PR DESCRIPTION
Per title
- For lint, auto generated by `pre-commit run --all-files`
- For test Error, add `fork` as the start method for multiprocessing. And, skip this test for windows because there is no `fork` on windows system.