### PR TITLE
dataloader v2 checkpoint utils rename

### DIFF
--- a/test/test_dataloader2_checkpoint_utils.py
+++ b/test/test_dataloader2_checkpoint_utils.py
@@ -5,43 +5,38 @@
 # LICENSE file in the root directory of this source tree.
 
 import pickle
-from torchdata.dataloader2.dataloader2_utils import (
+from typing import Any, Dict, Optional, Tuple
+from unittest import TestCase
+
+from torchdata.dataloader2.dataloader2 import (
+    READING_SERVICE_STATE_KEY_NAME,
+    SERIALIZED_DATAPIPE_KEY_NAME,
+)
+from torchdata.dataloader2.dataloader2_checkpoint_utils import (
     try_deserialize_as_dlv2_checkpoint,
 )
-from unittest import TestCase
-from typing import Any, Dict, Tuple, Optional
-from torchdata.dataloader2.dataloader2 import (
-    SERIALIZED_DATAPIPE_KEY_NAME,
-    READING_SERVICE_STATE_KEY_NAME,
-)
 
-class DataLoader2UtilTest(TestCase):
+
+class DataLoader2CheckpointUtilTest(TestCase):
     def _test_try_deserialize_as_dlv2_checkpoint(
         self,
         checkpoint_bytes: Optional[bytes],
-        expected: Tuple[bool, Optional[Dict[str, Any]]]
+        expected: Tuple[bool, Optional[Dict[str, Any]]],
     ) -> None:
         ans = try_deserialize_as_dlv2_checkpoint(checkpoint_bytes)
         self.assertEqual(ans, expected)
 
     def test_try_deserialize_as_dlv2_checkpoint(self) -> None:
-        self._test_try_deserialize_as_dlv2_checkpoint(
-            None,
-            (False, None)
-        )
+        self._test_try_deserialize_as_dlv2_checkpoint(None, (False, None))
 
-        self._test_try_deserialize_as_dlv2_checkpoint(
-            b"123",
-            (False, None)
-        )
+        self._test_try_deserialize_as_dlv2_checkpoint(b"123", (False, None))
 
         dlv2_state_dict1 = {
             SERIALIZED_DATAPIPE_KEY_NAME: "",
             READING_SERVICE_STATE_KEY_NAME: "",
         }
         self._test_try_deserialize_as_dlv2_checkpoint(
-            pickle.dumps(dlv2_state_dict1),
-            (True, dlv2_state_dict1)
+            pickle.dumps(dlv2_state_dict1), (True, dlv2_state_dict1)
         )
 
         dlv2_state_dict2 = {
@@ -50,6 +45,5 @@ class DataLoader2UtilTest(TestCase):
         }
 
         self._test_try_deserialize_as_dlv2_checkpoint(
-            pickle.dumps(dlv2_state_dict2),
-            (True, dlv2_state_dict2)
+            pickle.dumps(dlv2_state_dict2), (True, dlv2_state_dict2)
         )

--- a/torchdata/dataloader2/dataloader2_checkpoint_utils.py
+++ b/torchdata/dataloader2/dataloader2_checkpoint_utils.py
@@ -6,30 +6,33 @@
 
 import logging
 import pickle
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from torchdata.dataloader2.dataloader2 import (
-    SERIALIZED_DATAPIPE_KEY_NAME,
     READING_SERVICE_STATE_KEY_NAME,
+    SERIALIZED_DATAPIPE_KEY_NAME,
 )
 
 logger: logging.Logger = logging.getLogger()
 
 
 def try_deserialize_as_dlv2_checkpoint(
-    checkpoint_bytes: Optional[bytes]
+    checkpoint_bytes: Optional[bytes],
 ) -> Tuple[bool, Optional[Dict[str, Any]]]:
     """
     Handling the checkpoint conversion from bytes to DataLoader V2 format.
     Model store checkpoint agent only store ByteIO/Tensor/ShardedTensor.
+
     Args:
-        checkpoint_bytes: checkpoint in bytes format
+        checkpoint_bytes: checkpoint in bytes format.
+
     Returns:
-        Tuple[succeeded, dataloader2_checkpoint]: if we succeeded in converting to dataloader v2 checkpoint,
-        and the checkpoint as in dataloader2 checkpoint format
+        Tuple[succeeded, dataloader2_checkpoint]: if we succeeded in converting
+        to dataloader v2 checkpoint, and the checkpoint as in dataloader2
+        checkpoint format.
     """
     if checkpoint_bytes is None:
-        logger.info("Empty reader checkpoint")
+        logger.info("Empty reader checkpoint.")
         return False, None
     try:
         deserialized_state_dict = pickle.loads(checkpoint_bytes)
@@ -38,7 +41,7 @@ def try_deserialize_as_dlv2_checkpoint(
                 SERIALIZED_DATAPIPE_KEY_NAME in deserialized_state_dict.keys()
                 and READING_SERVICE_STATE_KEY_NAME in deserialized_state_dict.keys()
             ):
-                logger.info("Checkpoint deserialized as dataloader v2 checkpoing")
+                logger.info("Checkpoint deserialized as dataloader v2 checkpoing.")
                 return True, deserialized_state_dict
     except pickle.UnpicklingError:
         logger.info(
@@ -46,15 +49,14 @@ def try_deserialize_as_dlv2_checkpoint(
         )
     except Exception:
         logger.warn(
-            "Exception when deserializing reader checkpoint as dataloader v2 checkpoint"
+            "Exception when deserializing reader checkpoint as dataloader v2 "
+            "checkpoint."
         )
         raise
     return False, None
 
 
-def serialize_dlv2_checkpoint(
-    dlv2_checkpoint: Dict[str, Any]
-) -> bytes:
+def serialize_dlv2_checkpoint(dlv2_checkpoint: Dict[str, Any]) -> bytes:
     """
     Handling the checkpoint conversion from DataLoader V2 format to bytes format.
     """


### PR DESCRIPTION
Summary:
* Rename the dataloader v2 checkpoint utils to be specific and to avoid overwhelming the file dataloader2_utils.py.
* Modify the tests accordingly.
* Minor format fix for dataloader v2 checkpoint utils.

Differential Revision: D36296496

