### PR TITLE
fix lint error for `load_state_dict` API 

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -163,6 +163,7 @@ class DataLoader2(Generic[T_co]):
         data_loader.reading_service_state = reading_service_state
         return data_loader
 
+
     def load_state_dict(self, state: Dict[str, Any]) -> None:
         # edge case checking
         # iterator has already been created: 1) iterator is just created 2) iterator is created and iter is exhausted

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -163,12 +163,13 @@ class DataLoader2(Generic[T_co]):
         data_loader.reading_service_state = reading_service_state
         return data_loader
 
-
     def load_state_dict(self, state: Dict[str, Any]) -> None:
         # edge case checking
         # iterator has already been created: 1) iterator is just created 2) iterator is created and iter is exhausted
         if self._datapipe_iter is not None:
-            raise RuntimeError("DataLoaderV2 iterator has already been created, `load_state_dict()` can’t be called. Please create a new dataloader in order to use load state dict.")
+            raise RuntimeError(
+                "DataLoaderV2 iterator has already been created, `load_state_dict()` can’t be called. Please create a new dataloader in order to use load state dict."
+            )
 
         serialized_datapipe = state[SERIALIZED_DATAPIPE_KEY_NAME]
         reading_service_state = state[READING_SERVICE_STATE_KEY_NAME]


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes  lint errors in previous `load_state_dict` API  [commit](https://github.com/pytorch/data/commit/02157d825af9a31b0f782a9b2a9d504c59a28280) 

### Changes

- update based on ```pre-commit run --files torchdata/dataloader2/dataloader2.py```
