### PR TITLE
Temporarily revert awssdk on linux

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -52,7 +52,7 @@ jobs:
   wheel_build_test:
     needs: get_release_type
     runs-on: ${{ matrix.os }}
-    container: ${{ startsWith( matrix.os, 'ubuntu' ) && 'quay.io/pypa/manylinux2014_x86_64' || null }}
+    # container: ${{ startsWith( matrix.os, 'ubuntu' ) && 'quay.io/pypa/manylinux2014_x86_64' || null }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
           - "3.10"
     steps:
       - name: Setup Python ${{ matrix.python-version }}
-        if: ${{ ! startsWith( matrix.os, 'ubuntu' ) }}
+        # if: ${{ ! startsWith( matrix.os, 'ubuntu' ) }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
@@ -87,25 +87,25 @@ jobs:
       - name: Install Build Dependency
         shell: bash
         run: |
-          if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
-            yum -y install ninja-build
-            yum -y install openssl-devel openssl-static curl-devel zlib-devel
-          else
-            pip install cmake ninja
-            echo "/home/runner/.local/bin" >> $GITHUB_PATH
-          fi
+          # if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
+          #   yum -y install ninja-build
+          #   yum -y install openssl-devel openssl-static curl-devel zlib-devel
+          # else
+          pip install cmake ninja
+          echo "/home/runner/.local/bin" >> $GITHUB_PATH
+          # fi
       - name: Install PyTorch and Build TorchData Wheel
         shell: bash
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           PYTORCH_VERSION: ${{ inputs.pytorch_version }}
-          BUILD_S3: 1
+          BUILD_S3: ${{ startsWith( matrix.os, 'ubuntu' ) && 'OFF' || 'ON' }}
         run: |
-          if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
-            # See: https://github.com/actions/checkout/issues/760
-            git config --global --add safe.directory /__w/data/data
-            source packaging/manylinux_wheel_helper.sh
-          fi
+          # if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
+          #   # See: https://github.com/actions/checkout/issues/760
+          #   git config --global --add safe.directory /__w/data/data
+          #   source packaging/manylinux_wheel_helper.sh
+          # fi
           packaging/build_wheel.sh
       - name: Validate TorchData Wheel
         shell: bash
@@ -113,7 +113,7 @@ jobs:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
           if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
-            source packaging/manylinux_wheel_helper.sh
+            # source packaging/manylinux_wheel_helper.sh
             pip3 install auditwheel
           fi
           pip3 install pkginfo
@@ -129,18 +129,18 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
-            source packaging/manylinux_wheel_helper.sh
-          fi
+          # if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
+          #   source packaging/manylinux_wheel_helper.sh
+          # fi
           pip3 install dist/torchdata*.whl
       - name: Run DataPipes Tests with pytest
         shell: bash
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
-            source packaging/manylinux_wheel_helper.sh
-          fi
+          # if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
+          #   source packaging/manylinux_wheel_helper.sh
+          # fi
           pip3 install expecttest fsspec iopath==0.1.9 numpy pytest rarfile protobuf
           pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
       - name: Upload Wheels to Github


### PR DESCRIPTION
Due to AWSSDK requires libcrypto, which is not included manylinux standard, the linux binary breaks TorchVision's CI.

I am reverting awssdk built for linux before I figure out make `libcrypto` and `libssl` all statically linked to aws and packaged into TorchData.

See: https://github.com/pytorch/data/issues/418