### PR TITLE
Updating DataPipe naming guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,22 +86,24 @@ the checks automatically before every `git commit`, you can install them with `p
 
 When adding a new DataPipe, there are few things that need to be done to ensure it is working and documented properly.
 
-1. Testing - please add unit tests to ensure that the DataPipe is functioning properly. Here are the
+1. Naming - please following the naming convention as
+   [described here](https://github.com/pytorch/data/blob/main/docs/source/tutorial.rst#naming).
+2. Testing - please add unit tests to ensure that the DataPipe is functioning properly. Here are the
    [test requirements](https://github.com/pytorch/data/issues/106) that we have.
    - One test that is commonly missed is the serialization test. Please add the new DataPipe to
      [`test_serialization.py`](https://github.com/pytorch/data/blob/main/test/test_serialization.py).
    - If your test requires interacting with files in the file system (e.g. opening a `csv` or `tar` file, we prefer
      those files to be generated during the test (see `test_local_io.py`). If the file is on a remote server, see
      `test_remote_io.py`.
-2. Documentation - ensure that the DataPipe has docstring, usage example, and that it is added to the right category of
+3. Documentation - ensure that the DataPipe has docstring, usage example, and that it is added to the right category of
    the right RST file to be rendered.
    - If your DataPipe has a functional form (i.e. `@functional_datapipe(...)`), include at the
      [end of the first sentence](https://github.com/pytorch/data/blob/main/torchdata/datapipes/iter/util/combining.py#L119)
      of your docstring. This will make sure it correctly shows up in the
      [summary table](https://pytorch.org/data/main/torchdata.datapipes.iter.html#archive-datapipes) of our
      documentation.
-3. Import - import the DataPipe in the correct `__init__.py` file.
-4. Interface - if the DataPipe has a functional form, make sure that is generated properly by `gen_pyi.py` into the
+4. Import - import the DataPipe in the correct `__init__.py` file.
+5. Interface - if the DataPipe has a functional form, make sure that is generated properly by `gen_pyi.py` into the
    relevant interface file.
    - You can re-generate the pyi files by re-running `python setup.py develop`, then you can examine the new outputs.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -140,6 +140,9 @@ DataPipe is essentially a container to apply an operation to data yielded from a
 we alias to just "Operation-er" in **init** files. For our ``IterDataPipe`` example, we'll name the module
 ``MapperIterDataPipe`` and alias it as ``iter.Mapper`` under ``torchdata.datapipes``.
 
+For the functional method name, the naming convention is ``datapipe.<operation>``. For instance,
+the functional method name of ``Mapper`` is ``map``, such that it can be invoked by ``datapipe.map(...)``.
+
 
 Constructor
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #428

Quick fix to ensure contributors know about our naming conventions