### PR TITLE
Add linter to check if shuffle before sharding

### DIFF
--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -7,8 +7,9 @@
 
 import unittest
 
-from torchdata.datapipes.iter import IterableWrapper, ShardingFilter, Shuffler
 from torchdata.dataloader2.linter import _check_shuffle_before_sharding
+
+from torchdata.datapipes.iter import IterableWrapper, ShardingFilter, Shuffler
 
 
 def dummy_fn(x):

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -32,6 +32,9 @@ class LinterTest(unittest.TestCase):
         dp = source_dp.map(dummy_fn).sharding_filter()
         self.assertFalse(_check_shuffle_before_sharding(dp))
 
+        dp = source_dp.map(dummy_fn).sharding_filter().shuffle()
+        self.assertFalse(_check_shuffle_before_sharding(dp))
+
         # Multi pathes
         def _multi_path_dp_1(shuffle):
             s_dp = source_dp.shuffle() if shuffle else source_dp

--- a/test/test_linter.py
+++ b/test/test_linter.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from torchdata.datapipes.iter import IterableWrapper, ShardingFilter, Shuffler
+from torchdata.dataloader2.linter import _check_shuffle_before_sharding
+
+
+def dummy_fn(x):
+    return x
+
+
+class LinterTest(unittest.TestCase):
+    def test_sharding_shuffle(self):
+        source_dp = IterableWrapper(list(range(20)))
+
+        # Single path
+        dp = source_dp.map(dummy_fn).shuffle()
+        self.assertTrue(_check_shuffle_before_sharding(dp))
+        dp = source_dp.map(dummy_fn)
+        self.assertTrue(_check_shuffle_before_sharding(dp))
+
+        dp = source_dp.map(dummy_fn).shuffle().sharding_filter()
+        self.assertTrue(_check_shuffle_before_sharding(dp))
+
+        dp = source_dp.map(dummy_fn).sharding_filter()
+        self.assertFalse(_check_shuffle_before_sharding(dp))
+
+        # Multi pathes
+        def _multi_path_dp_1(shuffle):
+            s_dp = source_dp.shuffle() if shuffle else source_dp
+            dp1, dp2 = s_dp.unzip(2)
+            dp1 = dp1.sharding_filter()
+            dp2 = dp2.map(dummy_fn).sharding_filter()
+            dp = dp1.zip(dp2)
+            return dp
+
+        self.assertTrue(_check_shuffle_before_sharding(_multi_path_dp_1(True)))
+        self.assertFalse(_check_shuffle_before_sharding(_multi_path_dp_1(False)))
+
+        def _multi_path_dp_2(shuffle):
+            s_dp = source_dp.shuffle() if shuffle else source_dp
+            dp1, dp2 = s_dp.unzip(2)
+            dp1 = dp1.map(dummy_fn)
+            dp = dp1.zip(dp2).sharding_filter()
+            return dp
+
+        self.assertTrue(_check_shuffle_before_sharding(_multi_path_dp_2(True)))
+        self.assertFalse(_check_shuffle_before_sharding(_multi_path_dp_2(False)))
+
+        def _multi_path_dp_3(shuffle):
+            dp1, dp2 = source_dp.unzip(2)
+            dp1 = dp1.shuffle() if shuffle else dp1
+            dp1 = dp1.map(dummy_fn).sharding_filter()
+            dp2 = dp2.shuffle() if shuffle else dp1
+            dp2 = dp2.sharding_filter()
+            dp = dp1.zip(dp2).map(dummy_fn)
+            return dp
+
+        self.assertTrue(_check_shuffle_before_sharding(_multi_path_dp_3(True)))
+        self.assertFalse(_check_shuffle_before_sharding(_multi_path_dp_3(False)))
+
+        # Partial paths
+        dp1, dp2 = source_dp.unzip(2)
+        dp1 = dp1.shuffle().map(dummy_fn)
+        dp = dp1.zip(dp2).sharding_filter()
+
+        self.assertFalse(_check_shuffle_before_sharding(dp))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torchdata/dataloader2/graph.py
+++ b/torchdata/dataloader2/graph.py
@@ -16,7 +16,7 @@ from ._graph_utils import DataPipeGraph, traverse
 def find_dps(graph: DataPipeGraph, dp_type: Type[IterDataPipe]) -> List[IterDataPipe]:
     dps: List[IterDataPipe] = []
 
-    def helper(g) -> None:
+    def helper(g) -> None:  # pyre-ignore
         for dp in g:
             if type(dp) is dp_type:  # Please not use `isinstance`, there is a bug.
                 dps.append(dp)
@@ -29,7 +29,7 @@ def find_dps(graph: DataPipeGraph, dp_type: Type[IterDataPipe]) -> List[IterData
 
 
 # Given the DataPipe needs to be adapted and the expected DataPipe, return a new graph
-def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: IterDataPipe):
+def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: IterDataPipe):  # pyre-ignore
     if old_datapipe is new_datapipe:
         return graph
     if old_datapipe in graph:
@@ -45,7 +45,7 @@ def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: I
 
 
 # Given the DataPipe needs to be removed, return a new graph
-def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):
+def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):  # pyre-ignore
     if datapipe in graph:
         graph = graph[datapipe]
         if len(graph) == 0:
@@ -63,7 +63,7 @@ def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):
 
 # For each `recv_dp`, find if the source_datapipe needs to be replaced by the new one.
 # If found, find where the `old_dp` is located in `dp` and switch it to the `new_dp`
-def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> None:
+def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> None:  # pyre-ignore
     for send_dp in send_graph:
         if send_dp is datapipe:
             g = send_graph[send_dp]
@@ -79,7 +79,7 @@ def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> No
 
 # For each `recv_dp`, find if the source_datapipe needs to be replaced by the new one.
 # If found, find where the `old_dp` is located in `recv_dp` and switch it to the `new_dp`
-def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe) -> None:
+def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe) -> None:  # pyre-ignore
     for send_dp in send_graph:
         if send_dp is old_dp:
             _assign_attr(recv_dp, old_dp, new_dp, inner_dp=True)
@@ -89,7 +89,7 @@ def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp
 
 # Recursively re-assign datapipe for the sake of nested data structure
 # `inner_dp` is used to prevent recursive call if we have already met `IterDataPipe`
-def _assign_attr(obj, old_dp, new_dp, inner_dp: bool = False):
+def _assign_attr(obj, old_dp, new_dp, inner_dp: bool = False):  # pyre-ignore
     if obj is old_dp:
         return new_dp
     elif isinstance(obj, IterDataPipe):

--- a/torchdata/dataloader2/graph.py
+++ b/torchdata/dataloader2/graph.py
@@ -16,7 +16,7 @@ from ._graph_utils import DataPipeGraph, traverse
 def find_dps(graph: DataPipeGraph, dp_type: Type[IterDataPipe]) -> List[IterDataPipe]:
     dps: List[IterDataPipe] = []
 
-    def helper(g) -> None:  # pyre-ignore
+    def helper(g) -> None:
         for dp in g:
             if type(dp) is dp_type:  # Please not use `isinstance`, there is a bug.
                 dps.append(dp)
@@ -29,7 +29,7 @@ def find_dps(graph: DataPipeGraph, dp_type: Type[IterDataPipe]) -> List[IterData
 
 
 # Given the DataPipe needs to be adapted and the expected DataPipe, return a new graph
-def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: IterDataPipe):  # pyre-ignore
+def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: IterDataPipe):
     if old_datapipe is new_datapipe:
         return graph
     if old_datapipe in graph:
@@ -45,7 +45,7 @@ def replace_dp(graph: DataPipeGraph, old_datapipe: IterDataPipe, new_datapipe: I
 
 
 # Given the DataPipe needs to be removed, return a new graph
-def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):  # pyre-ignore
+def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):
     if datapipe in graph:
         graph = graph[datapipe]
         if len(graph) == 0:
@@ -63,7 +63,7 @@ def remove_dp(graph: DataPipeGraph, datapipe: IterDataPipe):  # pyre-ignore
 
 # For each `recv_dp`, find if the source_datapipe needs to be replaced by the new one.
 # If found, find where the `old_dp` is located in `dp` and switch it to the `new_dp`
-def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> None:  # pyre-ignore
+def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> None:
     for send_dp in send_graph:
         if send_dp is datapipe:
             g = send_graph[send_dp]
@@ -79,7 +79,7 @@ def _remove_dp(recv_dp, send_graph: DataPipeGraph, datapipe: IterDataPipe) -> No
 
 # For each `recv_dp`, find if the source_datapipe needs to be replaced by the new one.
 # If found, find where the `old_dp` is located in `recv_dp` and switch it to the `new_dp`
-def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe) -> None:  # pyre-ignore
+def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp: IterDataPipe) -> None:
     for send_dp in send_graph:
         if send_dp is old_dp:
             _assign_attr(recv_dp, old_dp, new_dp, inner_dp=True)
@@ -89,7 +89,7 @@ def _replace_dp(recv_dp, send_graph: DataPipeGraph, old_dp: IterDataPipe, new_dp
 
 # Recursively re-assign datapipe for the sake of nested data structure
 # `inner_dp` is used to prevent recursive call if we have already met `IterDataPipe`
-def _assign_attr(obj, old_dp, new_dp, inner_dp: bool = False):  # pyre-ignore
+def _assign_attr(obj, old_dp, new_dp, inner_dp: bool = False):
     if obj is old_dp:
         return new_dp
     elif isinstance(obj, IterDataPipe):

--- a/torchdata/dataloader2/linter.py
+++ b/torchdata/dataloader2/linter.py
@@ -15,7 +15,7 @@ def _check_shuffle_before_sharding(datapipe: IterDataPipe) -> bool:
     This function will check if a ``shuffle`` operation is presented before each
     ``sharding_filter`` operation for every single path in the ``DataPipe`` graph.
     """
-    graph: DataPipeGraph = traverse(datapipe)
+    graph: DataPipeGraph = traverse(datapipe)  # type: ignore[arg-type]
     return _check_shuffler_before_sharding_helper(graph)
 
 

--- a/torchdata/dataloader2/linter.py
+++ b/torchdata/dataloader2/linter.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from torchdata.datapipes.iter import IterDataPipe, ShardingFilter, Shuffler
+
+from ._graph_utils import DataPipeGraph, traverse
+
+
+def _check_shuffle_before_sharding(datapipe: IterDataPipe) -> bool:
+    """
+    This function will check if a ``shuffle`` operation is presented before each
+    ``sharding_filter`` operation for every single path in the ``DataPipe`` graph.
+    """
+    graph: DataPipeGraph = traverse(datapipe)
+    return _check_shuffler_before_sharding_helper(graph)
+
+
+def _check_shuffler_before_sharding_helper(graph: DataPipeGraph) -> bool:
+    if not graph:
+        return True
+
+    if len(graph) > 1:
+        for dp in graph:
+            if isinstance(dp, ShardingFilter):
+                if not _has_shuffler(graph[dp]):
+                    return False
+            else:
+                if not _check_shuffler_before_sharding_helper(graph[dp]):
+                    return False
+        return True
+
+    dp, dp_graph = list(graph.items())[0]
+    if isinstance(dp, ShardingFilter):
+        return _has_shuffler(dp_graph)
+
+    return _check_shuffler_before_sharding_helper(dp_graph)
+
+
+def _has_shuffler(graph: DataPipeGraph) -> bool:
+    if not graph:
+        return False
+
+    if len(graph) > 1:
+        for dp in graph:
+            if not (isinstance(dp, Shuffler) or _has_shuffler(graph[dp])):
+                return False
+        return True
+
+    dp, dp_graph = list(graph.items())[0]
+    if isinstance(dp, Shuffler):
+        return True
+
+    return _has_shuffler(dp_graph)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -127,7 +127,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
         )
-        return IterableWrapper(self.dl_)
+        return IterableWrapper(self.dl_)  # type: ignore[return-value]
 
     def finalize(self) -> None:
         if self.persistent_workers and self.dl_ is not None and self.dl_._iterator is not None:


### PR DESCRIPTION
This PR introduces the linter function to validate there is a shuffle operation before sharding. (Required by TorchText in https://github.com/pytorch/text/pull/1729)

- When `sharding_filter` is not presented in the graph, this function always returns `True`
- For single-path graph, `shuffle` needs to be placed before `sharding_filter`.
- For multi-path graph, any `sharding_filter` requires a `shuffle` before along the path

This linter function won't check if there are multiple `sharding_filter` in the graph or `sharding_filter` is at the right place