### PR TITLE
Remove docs from flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,4 @@ exclude =
     ./third_party,
     *.pyi,
     ./examples/text/utils.py, # Copy from TorchText
+    docs/source/conf.py,


### PR DESCRIPTION
In release branch, due to my PR https://github.com/pytorch/data/pull/444. The lint CI is broken because I remove getting version from `torchdata` and `torchdata` is imported but not used in docs anymore.

I don't want to add more burden for ppl whoever takes in charge of release engineering in the future. I believe it's not necessary to check flake8 for docs folder.