### PR TITLE
Disable AWSSDK functional tests

### DIFF
--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -197,6 +197,9 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
             )
             return
 
+        # TODO: Skip the following tests due to https://github.com/pytorch/data/issues/460
+        return
+
         # S3FileLister: different inputs
         input_list = [
             [["s3://ai2-public-datasets"], 71],  # bucket without '/'


### PR DESCRIPTION
This PR will temporarily disable the tests for AWSSDK due to #460

The actual fix requires AWS team's contribution.