### PR TITLE
Add list_file() functional API to FSSpecFileLister and IoPathFileLister

### DIFF
--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -66,7 +66,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
 
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        datapipe = list(datapipe.list_file_by_fsspec())
+        datapipe = datapipe.list_file_by_fsspec()
         for path in datapipe:
             self.assertIn(
                 path,

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -66,8 +66,8 @@ class TestDataPipeFSSpec(expecttest.TestCase):
 
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        listed = list(datapipe.list_file_by_fsspec())
-        for path in listed:
+        datapipe = list(datapipe.list_file_by_fsspec())
+        for path in datapipe:
             self.assertIn(
                 path,
                 {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
@@ -93,9 +93,9 @@ class TestDataPipeFSSpec(expecttest.TestCase):
 
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
-        listed = list(datapipe.list_file_by_fsspec())
-        listed.sort()
-        self.assertEqual(listed, temp_files)
+        datapipe = list(datapipe.list_file_by_fsspec())
+        datapipe.sort()
+        self.assertEqual(datapipe, temp_files)
 
     @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -66,7 +66,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
 
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        datapipe = datapipe.list_file_by_fsspec()
+        datapipe = datapipe.list_files_by_fsspec()
         for path in datapipe:
             self.assertIn(
                 path,
@@ -93,7 +93,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
 
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
-        datapipe = list(datapipe.list_file_by_fsspec())
+        datapipe = datapipe.list_files_by_fsspec()
         datapipe.sort()
         self.assertEqual(datapipe, temp_files)
 

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -83,21 +83,22 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         self.assertEqual(file_lister, temp_files)
 
     @skipIfNoFSSpec
-    def test_fsspec_file_lister_iterdatapipe_list_file(self):
+    def test_fsspec_functional_list_file(self):
         datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
 
         # Should be consistent with test_fsspec_file_lister_iterdatapipe
-        for path in datapipe.list_files():
+        paths = list(datapipe.list_file_by_fsspec())
+        for path in paths:
             self.assertIn(
                 path.split("://")[1],
                 {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
             )
 
     @skipIfNoFSSpec
-    def test_fsspec_file_lister_iterdatapipe_with_list_list_file(self):
+    def test_fsspec_functional_list_file(self):
         datapipe = FSSpecFileLister(root=["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
 
-        paths = datapipe.list_files()
+        paths = list(datapipe.list_file_by_fsspec())
         paths = sorted(map(lambda path: path.split("://")[1], paths))
         temp_files = list(
             map(

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -94,8 +94,8 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         # checks for functional API
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_fsspec()
-        datapipe.sort()
-        self.assertEqual(datapipe, temp_files)
+        res = list(datapipe).sort()
+        self.assertEqual(res, temp_files)
 
     @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -94,13 +94,15 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         # checks for functional API
         datapipe = IterableWrapper(["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_fsspec()
-        res = list(map(lambda path: path.split("://")[1], datapipe)).sort()
+        res = list(map(lambda path: path.split("://")[1], datapipe))
+        res.sort()
         temp_files = list(
             map(
                 lambda file: fsspec.implementations.local.make_path_posix(file),
-                self.temp_sub_dir_files + self.temp_sub_dir_files_2,
+                self.temp_sub_files + self.temp_sub_files_2,
             )
         )
+        temp_files.sort()
         self.assertEqual(res, temp_files)
 
     @skipIfNoFSSpec

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -97,13 +97,6 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         listed.sort()
         self.assertEqual(listed, temp_files)
 
-
-    @skipIfNoFSSpec
-    def test_fsspec_iterdatapipe_list_file_has_protocol(self):
-        datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
-        for path in datapipe.list_files():
-            self.assertIn("file://", path)
-
     @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):
         datapipe1 = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -69,7 +69,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         datapipe = datapipe.list_files_by_fsspec()
         for path in datapipe:
             self.assertIn(
-                path,
+                path.split("://")[1],
                 {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
             )
 

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -94,7 +94,13 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         # checks for functional API
         datapipe = IterableWrapper(["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_fsspec()
-        res = list(datapipe).sort()
+        res = list(map(lambda path: path.split("://")[1], datapipe)).sort()
+        temp_files = list(
+            map(
+                lambda file: fsspec.implementations.local.make_path_posix(file),
+                self.temp_sub_dir_files + self.temp_sub_dir_files_2,
+            )
+        )
         self.assertEqual(res, temp_files)
 
     @skipIfNoFSSpec

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -109,6 +109,12 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         self.assertEqual(paths, temp_files)
 
     @skipIfNoFSSpec
+    def test_fsspec_iterdatapipe_list_file_has_protocol(self):
+        datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
+        for path in datapipe.list_files():
+            self.assertIn("file://", path)
+
+    @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):
         datapipe1 = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
         datapipe2 = FSSpecFileOpener(datapipe1)

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -65,7 +65,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
             )
 
         # checks for functional API
-        datapipe = IterableWrapper([self.temp_sub_dir.name])
+        datapipe = IterableWrapper(["file://" + self.temp_sub_dir.name])
         datapipe = datapipe.list_files_by_fsspec()
         for path in datapipe:
             self.assertIn(
@@ -92,7 +92,7 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         self.assertEqual(file_lister, temp_files)
 
         # checks for functional API
-        datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
+        datapipe = IterableWrapper(["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_fsspec()
         res = list(datapipe).sort()
         self.assertEqual(res, temp_files)

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -64,6 +64,15 @@ class TestDataPipeFSSpec(expecttest.TestCase):
                 {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
             )
 
+        # checks for functional API
+        datapipe = IterableWrapper([self.temp_sub_dir.name])
+        listed = list(datapipe.list_file_by_fsspec())
+        for path in listed:
+            self.assertIn(
+                path,
+                {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
+            )
+
     @skipIfNoFSSpec
     def test_fsspec_file_lister_iterdatapipe_with_list(self):
         datapipe = FSSpecFileLister(root=["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
@@ -82,32 +91,12 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         # check all file paths within sub_folder are listed
         self.assertEqual(file_lister, temp_files)
 
-    @skipIfNoFSSpec
-    def test_fsspec_functional_list_file(self):
-        datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
+        # checks for functional API
+        datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
+        listed = list(datapipe.list_file_by_fsspec())
+        listed.sort()
+        self.assertEqual(listed, temp_files)
 
-        # Should be consistent with test_fsspec_file_lister_iterdatapipe
-        paths = list(datapipe.list_file_by_fsspec())
-        for path in paths:
-            self.assertIn(
-                path.split("://")[1],
-                {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
-            )
-
-    @skipIfNoFSSpec
-    def test_fsspec_functional_list_file(self):
-        datapipe = FSSpecFileLister(root=["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
-
-        paths = list(datapipe.list_file_by_fsspec())
-        paths = sorted(map(lambda path: path.split("://")[1], paths))
-        temp_files = list(
-            map(
-                lambda file: fsspec.implementations.local.make_path_posix(file),
-                self.temp_sub_files + self.temp_sub_files_2,
-            )
-        )
-        temp_files.sort()
-        self.assertEqual(paths, temp_files)
 
     @skipIfNoFSSpec
     def test_fsspec_iterdatapipe_list_file_has_protocol(self):

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -83,6 +83,16 @@ class TestDataPipeFSSpec(expecttest.TestCase):
         self.assertEqual(file_lister, temp_files)
 
     @skipIfNoFSSpec
+    def test_fsspec_file_lister_iterdatapipe_list_file(self):
+        datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
+
+        for path in datapipe.list_files():
+            self.assertIn(
+                path.split("://")[1],
+                {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
+            )
+
+    @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):
         datapipe1 = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
         datapipe2 = FSSpecFileOpener(datapipe1)

--- a/test/test_fsspec.py
+++ b/test/test_fsspec.py
@@ -86,11 +86,27 @@ class TestDataPipeFSSpec(expecttest.TestCase):
     def test_fsspec_file_lister_iterdatapipe_list_file(self):
         datapipe = FSSpecFileLister(root="file://" + self.temp_sub_dir.name)
 
+        # Should be consistent with test_fsspec_file_lister_iterdatapipe
         for path in datapipe.list_files():
             self.assertIn(
                 path.split("://")[1],
                 {fsspec.implementations.local.make_path_posix(file) for file in self.temp_sub_files},
             )
+
+    @skipIfNoFSSpec
+    def test_fsspec_file_lister_iterdatapipe_with_list_list_file(self):
+        datapipe = FSSpecFileLister(root=["file://" + self.temp_sub_dir.name, "file://" + self.temp_sub_dir_2.name])
+
+        paths = datapipe.list_files()
+        paths = sorted(map(lambda path: path.split("://")[1], paths))
+        temp_files = list(
+            map(
+                lambda file: fsspec.implementations.local.make_path_posix(file),
+                self.temp_sub_files + self.temp_sub_files_2,
+            )
+        )
+        temp_files.sort()
+        self.assertEqual(paths, temp_files)
 
     @skipIfNoFSSpec
     def test_fsspec_file_loader_iterdatapipe(self):

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -661,8 +661,8 @@ class TestDataPipeLocalIO(expecttest.TestCase):
             self.assertTrue(path in self.temp_sub_files)
 
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        listed = list(datapipe.list_file_by_iopath())
-        for path in listed:
+        datapipe = list(datapipe.list_file_by_iopath())
+        for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
 
     @skipIfNoIoPath
@@ -678,9 +678,9 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self.assertEqual(file_lister, all_temp_files)
 
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
-        listed = list(datapipe.list_file_by_iopath())
-        listed.sort()
-        self.assertEqual(listed, all_temp_files)
+        datapipe = list(datapipe.list_file_by_iopath())
+        datapipe.sort()
+        self.assertEqual(datapipe, all_temp_files)
 
     @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -679,7 +679,8 @@ class TestDataPipeLocalIO(expecttest.TestCase):
 
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_iopath()
-        results = list(datapipe).sort()
+        results = list(datapipe)
+        results.sort()
         self.assertEqual(results, all_temp_files)
 
     @skipIfNoIoPath

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -661,7 +661,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
             self.assertTrue(path in self.temp_sub_files)
 
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        datapipe = datapipe.list_file_by_iopath()
+        datapipe = datapipe.list_files_by_iopath()
         for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
 
@@ -678,7 +678,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self.assertEqual(file_lister, all_temp_files)
 
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
-        datapipe = list(datapipe.list_file_by_iopath())
+        datapipe = datapipe.list_files_by_iopath()
         datapipe.sort()
         self.assertEqual(datapipe, all_temp_files)
 

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -679,8 +679,8 @@ class TestDataPipeLocalIO(expecttest.TestCase):
 
         datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
         datapipe = datapipe.list_files_by_iopath()
-        datapipe.sort()
-        self.assertEqual(datapipe, all_temp_files)
+        results = list(datapipe).sort()
+        self.assertEqual(results, all_temp_files)
 
     @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -660,15 +660,10 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
 
-    @skipIfNoIoPath
-    def test_io_path_functional_list_files_iterdatapipe(self):
-        datapipe = IoPathFileLister(root=self.temp_sub_dir.name)
-
+        datapipe = IterableWrapper([self.temp_sub_dir.name])
         listed = list(datapipe.list_file_by_iopath())
-        listed.sort()
-        tmp_files = [*self.temp_sub_files]
-        tmp_files.sort()
-        self.assertEqual(listed, tmp_files)
+        for path in listed:
+            self.assertTrue(path in self.temp_sub_files)
 
     @skipIfNoIoPath
     def test_io_path_file_lister_iterdatapipe_with_list(self):
@@ -682,15 +677,9 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         # check all file paths within sub_folder are listed
         self.assertEqual(file_lister, all_temp_files)
 
-    @skipIfNoIoPath
-    def test_io_path_functional_list_files_iterdatapipe_with_list(self):
-        datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
-
+        datapipe = IterableWrapper([self.temp_sub_dir.name, self.temp_sub_dir_2.name])
         listed = list(datapipe.list_file_by_iopath())
         listed.sort()
-        all_temp_files = [*self.temp_sub_files, *self.temp_sub_files_2]
-        all_temp_files.sort()
-
         self.assertEqual(listed, all_temp_files)
 
     @skipIfNoIoPath

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -661,7 +661,7 @@ class TestDataPipeLocalIO(expecttest.TestCase):
             self.assertTrue(path in self.temp_sub_files)
 
         datapipe = IterableWrapper([self.temp_sub_dir.name])
-        datapipe = list(datapipe.list_file_by_iopath())
+        datapipe = datapipe.list_file_by_iopath()
         for path in datapipe:
             self.assertTrue(path in self.temp_sub_files)
 

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -661,6 +661,16 @@ class TestDataPipeLocalIO(expecttest.TestCase):
             self.assertTrue(path in self.temp_sub_files)
 
     @skipIfNoIoPath
+    def test_io_path_list_files_iterdatapipe(self):
+        datapipe = IoPathFileLister(root=self.temp_sub_dir.name)
+
+        listed = datapipe.list_files()
+        listed.sort()
+        tmp_files = [*self.temp_sub_files]
+        tmp_files.sort()
+        self.assertEqual(listed, tmp_files)
+
+    @skipIfNoIoPath
     def test_io_path_file_lister_iterdatapipe_with_list(self):
         datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
 

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -661,10 +661,10 @@ class TestDataPipeLocalIO(expecttest.TestCase):
             self.assertTrue(path in self.temp_sub_files)
 
     @skipIfNoIoPath
-    def test_io_path_list_files_iterdatapipe(self):
+    def test_io_path_functional_list_files_iterdatapipe(self):
         datapipe = IoPathFileLister(root=self.temp_sub_dir.name)
 
-        listed = datapipe.list_files()
+        listed = list(datapipe.list_file_by_iopath())
         listed.sort()
         tmp_files = [*self.temp_sub_files]
         tmp_files.sort()
@@ -683,10 +683,10 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self.assertEqual(file_lister, all_temp_files)
 
     @skipIfNoIoPath
-    def test_io_path_list_files_iterdatapipe_with_list(self):
+    def test_io_path_functional_list_files_iterdatapipe_with_list(self):
         datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
 
-        listed = datapipe.list_files()
+        listed = list(datapipe.list_file_by_iopath())
         listed.sort()
         all_temp_files = [*self.temp_sub_files, *self.temp_sub_files_2]
         all_temp_files.sort()

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -683,6 +683,17 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self.assertEqual(file_lister, all_temp_files)
 
     @skipIfNoIoPath
+    def test_io_path_list_files_iterdatapipe_with_list(self):
+        datapipe = IoPathFileLister(root=[self.temp_sub_dir.name, self.temp_sub_dir_2.name])
+
+        listed = datapipe.list_files()
+        listed.sort()
+        all_temp_files = [*self.temp_sub_files, *self.temp_sub_files_2]
+        all_temp_files.sort()
+
+        self.assertEqual(listed, all_temp_files)
+
+    @skipIfNoIoPath
     def test_io_path_file_loader_iterdatapipe(self):
         datapipe1 = IoPathFileLister(root=self.temp_sub_dir.name)
         datapipe2 = IoPathFileOpener(datapipe1)

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -33,7 +33,7 @@ def _assert_fsspec() -> None:
         )
 
 
-@functional_datapipe("list_file_by_fsspec")
+@functional_datapipe("list_files_by_fsspec")
 class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
     r"""
     Lists the contents of the directory at the provided ``root`` pathname or URL,

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -33,6 +33,7 @@ def _assert_fsspec() -> None:
         )
 
 
+@functional_datapipe("list_file_by_fsspec")
 class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
     r"""
     Lists the contents of the directory at the provided ``root`` pathname or URL,
@@ -99,9 +100,6 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
 
                         if not starts_with:
                             yield abs_path
-
-    def list_files(self) -> List[str]:
-        return [fp for fp in self]
 
 
 @functional_datapipe("open_files_by_fsspec")

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -100,6 +100,9 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
                         if not starts_with:
                             yield abs_path
 
+    def list_files(self) -> List[str]:
+        return [fp for fp in self]
+
 
 @functional_datapipe("open_files_by_fsspec")
 class FSSpecFileOpenerIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -39,7 +39,7 @@ def _create_default_pathmanager():
     return pathmgr
 
 
-@functional_datapipe("list_file_by_iopath")
+@functional_datapipe("list_files_by_iopath")
 class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     r"""
     Lists the contents of the directory at the provided ``root`` pathname or URL,

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -39,6 +39,7 @@ def _create_default_pathmanager():
     return pathmgr
 
 
+@functional_datapipe("list_file_by_iopath")
 class IoPathFileListerIterDataPipe(IterDataPipe[str]):
     r"""
     Lists the contents of the directory at the provided ``root`` pathname or URL,
@@ -94,9 +95,6 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
                 for file_name in self.pathmgr.ls(path):
                     if match_masks(file_name, self.masks):
                         yield os.path.join(path, file_name)
-
-    def list_files(self) -> List[str]:
-        return [path for path in self]
 
 
 @functional_datapipe("open_files_by_iopath")

--- a/torchdata/datapipes/iter/load/iopath.py
+++ b/torchdata/datapipes/iter/load/iopath.py
@@ -95,6 +95,9 @@ class IoPathFileListerIterDataPipe(IterDataPipe[str]):
                     if match_masks(file_name, self.masks):
                         yield os.path.join(path, file_name)
 
+    def list_files(self) -> List[str]:
+        return [path for path in self]
+
 
 @functional_datapipe("open_files_by_iopath")
 class IoPathFileOpenerIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):


### PR DESCRIPTION
Fixes #387

### Changes
- Adds `list_file()` method on `IoPathFileListerIterDataPipe`
- Adds `list_file()` method on `FSSpecFileListerIterDataPipe`
- Add tests for those methods

#### Additional comments
I feel as if the implementation is quite naive. Would appreciate any feedback on it.