### PR TITLE
Fix workspace path (#486)

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -111,11 +111,13 @@ jobs:
         run: |
           if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
             source packaging/manylinux/python_helper.sh
+            # Docker path is /__w by default
+            export WORKSPACE="/__w"
             # See: https://github.com/actions/checkout/issues/760
             git config --global --add safe.directory "$WORKSPACE/data/data"
             # AWSSDK uses $CMAKE_PREFIX_PATH to find openssl
-            export OPENSSL_ROOT_DIR="/__w/ssl"
-            export CURL_ROOT_DIR="/__w/curl"
+            export OPENSSL_ROOT_DIR="$WORKSPACE/ssl"
+            export CURL_ROOT_DIR="$WORKSPACE/curl"
             export CMAKE_PREFIX_PATH="$OPENSSL_ROOT_DIR:$CURL_ROOT_DIR:$CMAKE_PREFIX_PATH"
             export STATIC_DEPS=TRUE
           fi


### PR DESCRIPTION
Ref on main branch: #486

Summary:
Add the missing env variable `WORKSPACE` to the workflow.
See: https://github.com/pytorch/data/runs/6687888202?check_suite_focus=true#step:8:107

Pull Request resolved: https://github.com/pytorch/data/pull/486

Reviewed By: NivekT

Differential Revision: D36810167

Pulled By: ejguan

fbshipit-source-id: 3a82646ebf6ef36fd4586fb543b316045160c346
