### PR TITLE
Improve fsspec DataPipe to accept extra keyword arguments

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,6 +1,7 @@
 pytest
 expecttest
 fsspec
+s3fs
 iopath == 0.1.9
 numpy
 rarfile

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -51,7 +51,7 @@ class S3FileListerIterDataPipe(IterDataPipe[str]):
 
     def __init__(self, source_datapipe: IterDataPipe[str], length: int = -1, request_timeout_ms=-1, region="") -> None:
         if not hasattr(torchdata, "_torchdata") or not hasattr(torchdata._torchdata, "S3Handler"):
-            raise ModuleNotFoundError("Torchdata must be built with BUILD_S3=1 to use this datapipe.")
+            raise ModuleNotFoundError("TorchData must be built with BUILD_S3=1 to use this datapipe.")
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.length: int = length
@@ -113,7 +113,7 @@ class S3FileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
         multi_part_download=None,
     ) -> None:
         if not hasattr(torchdata, "_torchdata") or not hasattr(torchdata._torchdata, "S3Handler"):
-            raise ModuleNotFoundError("Torchdata must be built with BUILD_S3=1 to use this datapipe.")
+            raise ModuleNotFoundError("TorchData must be built with BUILD_S3=1 to use this datapipe.")
 
         self.source_datapipe: IterDataPipe[str] = source_datapipe
         self.handler = torchdata._torchdata.S3Handler(request_timeout_ms, region)


### PR DESCRIPTION
Fixes #494

### Changes

- Add `kwargs` to all `DataPipe`s using `fsspec`
- Fix a bug in `FSSpecFileLister` to prevent joining paths from the root path if the root path has already presented in the paths.
- Add/Fix more tests


I need this PR to test the performance between `fsspec` and native `s3`