### PR TITLE
Always upload TorchData nightly release

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -159,6 +159,7 @@ jobs:
           pip3 install -r test/requirements.txt
           pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
       - name: Upload Wheels to Github
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: torchdata-artifact
@@ -269,7 +270,16 @@ jobs:
           conda activate conda_build_env
           conda install -yq conda-build -c conda-forge
           packaging/build_conda.sh
+      - name: Install TorchData Conda Package
+        shell: bash -l {0}
+        run: conda install --offline conda-bld/*/torchdata-*.tar.bz2
+      - name: Run DataPipes Tests with pytest
+        shell: bash
+        run: |
+          pip3 install -r test/requirements.txt
+          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
       - name: Upload Conda Package to Github
+        if: always()
         uses: actions/upload-artifact@v2
         with:
           name: torchdata-artifact

--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -47,8 +47,6 @@ test:
     # The following packages are not on the default conda channel
     # - iopath
     # - rarfile
-  commands:
-    - pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
 
 about:
   home: https://github.com/pytorch/data


### PR DESCRIPTION
Based on the offline discussion with Vitaly, we want to upload TorchData nightly releases even if tests are failing.

It's required by downstream library when PyTorch Core nightly updated but TorchData nightly not updated (still depends on the previous PT Core nightly)

Validated in: https://github.com/pytorch/data/actions/runs/2463948389
Even the tests are failing, the nightly releases are still uploaded.