### PR TITLE
Validation of  `fn` on `input_col` for Datapipes

### DIFF
--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -96,7 +96,6 @@ class BatchMapperIterDataPipe(IterDataPipe[T_co]):
         assert batch_size > 0, "Batch size is required to be larger than 0!"
         self.batch_size = batch_size
         self.input_col = input_col
-        ensure_fn_works(fn, input_col)
 
     def _apply_fn(self, batch):
         if self.input_col is None:

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -132,11 +132,20 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
 
     def _ensure_fn_works_on_input(self, fn: Callable):
         sig = inspect.signature(fn)
-        if len(sig.parameters) != self.input_col + 1:
-            raise TypeError(
-                f"The function {fn.__name__} takes {len(sig.parameters)} arguments, "
-                f"but {self.input_col + 1} are required."
-            )
+
+        if isinstance(self.input_col, int):
+            if len(sig.parameters) != self.input_col:
+                raise TypeError(
+                    f"The function {fn.__name__} takes {len(sig.parameters)} "
+                    f"arguments, "
+                    f"but {self.input_col} are required."
+                )
+        elif isinstance(self.input_col, (list, tuple)):
+            if len(sig.parameters) != len(self.input_col):
+                raise TypeError(
+                    f"The function {fn.__name__} takes {len(sig.parameters)} arguments, "
+                    f"but {len(self.input_col)} are required."
+                )
 
     def _apply_fn(self, data):
         if self.input_col is None:

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -102,6 +102,8 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
     Args:
         datapipe: Source IterDataPipe
         fn: the function to be applied to each element in the DataPipe, the output must be a Sequence
+        input_col: The index or indices of data which ``fn`` is applied to.
+
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -128,6 +128,7 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
         _check_lambda_fn(fn)
         self.fn = fn  # type: ignore[assignment]
         self.input_col = input_col
+        self._ensure_fn_works_on_input(fn)
 
     def _ensure_fn_works_on_input(self, fn: Callable):
         sig = inspect.signature(fn)

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -129,6 +129,14 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
         self.fn = fn  # type: ignore[assignment]
         self.input_col = input_col
 
+    def _ensure_fn_works_on_input(self, fn: Callable):
+        sig = inspect.signature(fn)
+        if len(sig.parameters) != self.input_col + 1:
+            raise TypeError(
+                f"The function {fn.__name__} takes {len(sig.parameters)} arguments, "
+                f"but {self.input_col + 1} are required."
+            )
+
     def _apply_fn(self, data):
         if self.input_col is None:
             return self.fn(data)

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -9,6 +9,8 @@ from typing import Callable, Iterator, List, TypeVar
 from torch.utils.data import functional_datapipe, IterDataPipe
 from torch.utils.data.datapipes.utils.common import _check_lambda_fn
 
+import inspect
+
 T_co = TypeVar("T_co", covariant=True)
 
 
@@ -102,7 +104,10 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
     Args:
         datapipe: Source IterDataPipe
         fn: the function to be applied to each element in the DataPipe, the output must be a Sequence
-        input_col: The index or indices of data which ``fn`` is applied to.
+        input_col: Index or indices of data which ``fn`` is applied, such as:
+            - ``None`` as default to apply ``fn`` to the data directly.
+            - Integer(s) is used for list/tuple.
+            - Key(s) is used for dict.
 
 
     Example:

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -4,12 +4,11 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import inspect
 from typing import Callable, Iterator, List, TypeVar
 
 from torch.utils.data import functional_datapipe, IterDataPipe
 from torch.utils.data.datapipes.utils.common import _check_lambda_fn
-
-import inspect
 
 T_co = TypeVar("T_co", covariant=True)
 
@@ -143,7 +142,8 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
         elif isinstance(self.input_col, (list, tuple)):
             if len(sig.parameters) != len(self.input_col):
                 raise TypeError(
-                    f"The function {fn.__name__} takes {len(sig.parameters)} arguments, "
+                    f"The function {fn.__name__} takes {len(sig.parameters)} "
+                    f"arguments, "
                     f"but {len(self.input_col)} are required."
                 )
 


### PR DESCRIPTION
Fixes #362 

### Changes

- Document input_col behavior on `FlatMapperIterDataPipe`
- Checks the arguments of mapping function against `input_col` in `FlatMapperIterDataPipe`
