### PR TITLE
Add instructions about ImportError for portalocker (#506)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ only be responsible for multiprocessing, distributed, and similar functionalitie
 processing features, such as the shuffling and batching, will be moved out of DataLoader to DataPipe. At the same time,
 the current/old version of DataLoader should still be available and you can use DataPipes with that as well.
 
+Q: Why is there an Error saying the specified DLL could not be found at the time of importing `portalocker`?
+
+A: It only happens for people who runs `torchdata` on Windows OS as a common problem with `pywin32`. And, you can find
+the reason and the solution for it in the
+[link](https://github.com/mhammond/pywin32#the-specified-procedure-could-not-be-found--entry-point-not-found-errors).
+
 ## Contributing
 
 We welcome PRs! See the [CONTRIBUTING](CONTRIBUTING.md) file.

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -16,7 +16,16 @@ from collections import deque
 from functools import partial
 from typing import Any, Callable, Deque, Dict, Iterator, List, Optional, TypeVar
 
-import portalocker
+try:
+    import portalocker
+except ImportError as e:
+    if os.name == "nt" and str(e).startswith("DLL load failed while importing"):
+        print(
+            "Please take a look at FAQ in https://github.com/pytorch/data#frequently-asked-questions-faq"
+            "for the solution of this Error."
+        )
+    raise
+
 
 from torch.utils.data.datapipes.utils.common import _check_lambda_fn, DILL_AVAILABLE
 


### PR DESCRIPTION
Ref on main branch: #506

Summary:
Partially fixes: https://github.com/pytorch/data/issues/441

Add instructions on how to solve `ImportError` for `portalocker`.

Pull Request resolved: https://github.com/pytorch/data/pull/506

Reviewed By: NivekT

Differential Revision: D37045053

Pulled By: ejguan

fbshipit-source-id: a365be88cfea9f05e155d09cf476ca89b6579205