### PR TITLE
Use PyTorch RC release on release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - release/*
+    tags:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches:
@@ -30,6 +31,16 @@ jobs:
           - 3.8
           - 3.9
     steps:
+      - name: Get PyTorch Channel
+        shell: bash
+        run: |
+          if [[ "${{ github.base_ref }}" == release/* ]] || [[ "${{ github.ref }}" == refs/heads/release/* ]] || [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            PT_CHANNEL="https://download.pytorch.org/whl/test/cpu/torch_test.html"
+          else
+            PT_CHANNEL="https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"
+          fi
+          echo "::set-output name=value::$PT_CHANNEL"
+        id: pytorch_channel
       - name: Setup additional system libraries
         if: startsWith( matrix.os, 'ubuntu' )
         run: |
@@ -55,7 +66,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install -r requirements.txt
-          pip3 install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
           pip3 install cmake ninja
           echo "/home/runner/.local/bin" >> $GITHUB_PATH
       - name: Build TorchData

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -9,7 +9,7 @@ on:
       - main
       # For PR created by ghstack
       - gh/*/*/base
-      - release/*
+      # - release/*
 
 jobs:
   torchvision:


### PR DESCRIPTION
Ref on main branch: #514

Currently the CI tests on release branch use the nightly PyTorch release. This PR changes tests to use RC PyTorch release when the target branch of PR is the release branch or a commit is pushed to release branch.

See the CI result for when the PR is landed (nightly channel): https://github.com/pytorch/data/runs/6867662390?check_suite_focus=true#step:8:3
See the CI result of the PR for release branch (test channel): https://github.com/pytorch/data/runs/6867788289?check_suite_focus=true#step:8:3