### PR TITLE
Add OSS example and test of data loader v2 load state dict

### DIFF
--- a/test/test_dataloader2.py
+++ b/test/test_dataloader2.py
@@ -5,6 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import pickle
+import unittest
 from unittest import TestCase
 
 from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService, ReadingServiceInterface
@@ -61,3 +63,42 @@ class DataLoader2Test(TestCase):
         for batch in iter(data_loader):
             self.assertEqual(batch, expected_batch)
             expected_batch += 1
+
+    def test_dataloader2_load_state_dict(self) -> None:
+        test_data_pipe = IterableWrapper(range(3))
+        reading_service = TestReadingService()
+        data_loader = DataLoader2(datapipe=test_data_pipe, reading_service=reading_service)
+
+        batch = next(iter(data_loader))
+        self.assertEqual(batch, 0)
+
+        state = data_loader.state_dict()
+        self.assertIsNotNone(state)
+        self.assertIsNotNone(state[SERIALIZED_DATAPIPE_KEY_NAME])
+        self.assertIsNone(state[READING_SERVICE_STATE_KEY_NAME])
+        data_loader.shutdown()
+
+        test_data_pipe_2 = IterableWrapper(range(5))
+        restored_data_loader = DataLoader2(datapipe=test_data_pipe_2, reading_service=reading_service)
+        restored_data_loader.load_state_dict(state)
+
+        restored_data_loader_datapipe = restored_data_loader.datapipe
+        deserialized_datapipe = pickle.loads(state[SERIALIZED_DATAPIPE_KEY_NAME])
+        for batch_1, batch_2 in zip(restored_data_loader_datapipe, deserialized_datapipe):
+            self.assertEqual(batch_1, batch_2)
+
+        self.assertNotEqual(
+            len(restored_data_loader.datapipe),
+            len(test_data_pipe_2),
+        )
+
+        self.assertEqual(
+            restored_data_loader.reading_service_state,
+            state[READING_SERVICE_STATE_KEY_NAME],
+        )
+
+        restored_data_loader.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
* Add initial OSS tests and examples for data loader v2 with load state dict.
* We need OSS unit tests and examples for data loader v2. TODO: will add more tests and examples for DLv2.

Differential Revision: D37016541

