### PR TITLE
Pass through kwargs to json.loads call

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ class JsonParserIterDataPipe(IterDataPipe):
     def __iter__(self):
         for file_name, stream in self.source_datapipe:
             data = stream.read()
-            yield file_name, json.loads(data)
+            yield file_name, json.loads(data, **self.kwargs)
 
     def __len__(self):
         return len(self.source_datapipe)

--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -309,6 +309,14 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         with self.assertRaisesRegex(TypeError, "len"):
             len(json_dp)
 
+        # kwargs Test:
+        json_dp = JsonParser(datapipe_nonempty, parse_int=str)
+        expected_res = [
+            ("1.json", ["foo", {"bar": ["baz", None, 1.0, "2"]}]),
+            ("2.json", {"__complex__": True, "real": "1", "imag": "2"}),
+        ]
+        self.assertEqual(expected_res, list(json_dp))
+
     def test_saver_iterdatapipe(self):
         # Functional Test: Saving some data
         name_to_data = {"1.txt": b"DATA1", "2.txt": b"DATA2", "3.txt": b"DATA3"}

--- a/torchdata/datapipes/iter/util/jsonparser.py
+++ b/torchdata/datapipes/iter/util/jsonparser.py
@@ -41,7 +41,7 @@ class JsonParserIterDataPipe(IterDataPipe[Tuple[str, Dict]]):
         for file_name, stream in self.source_datapipe:
             data = stream.read()
             stream.close()
-            yield file_name, json.loads(data)
+            yield file_name, json.loads(data, **self.kwargs)
 
     def __len__(self) -> int:
         return len(self.source_datapipe)


### PR DESCRIPTION
Summary:
The comment of this class suggests the keyword arguments in the constructor will be passed through to the json.loads call. However, `self.kwargs` is not actually passed through to the call.

Updated the example in the README too

Differential Revision: D37162608

