### PR TITLE
Fix conda install local package for nightly release

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -270,11 +270,18 @@ jobs:
           conda activate conda_build_env
           conda install -yq conda-build -c conda-forge
           packaging/build_conda.sh
+          conda index ./conda-bld
       - name: Install TorchData Conda Package
         shell: bash -l {0}
-        run: conda install --offline conda-bld/*/torchdata-*.tar.bz2
+        run: |
+          if [[ ${{ needs.get_release_type.outputs.type }} == 'official' ]]; then
+            CONDA_CHANNEL=pytorch
+          else
+            CONDA_CHANNEL=pytorch-${{ needs.get_release_type.outputs.type }}
+          fi
+          conda install pytorch torchdata cpuonly -c $(pwd)/conda-bld/ -c "$CONDA_CHANNEL"
       - name: Run DataPipes Tests with pytest
-        shell: bash
+        shell: bash -l {0}
         run: |
           pip3 install -r test/requirements.txt
           pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py


### PR DESCRIPTION
This is a follow-up PR for #503 to fix the nightly conda release workflow
Before this PR, the conda workflow fails because `torchdata` and `torch` is not installed in the test environment. See: https://github.com/pytorch/data/actions/runs/2515100032

After this PR, the conda workflow will use the same conda environment installed with `torchdata` and `torch` for testing. See manually triggered workflow: https://github.com/pytorch/data/actions/runs/2516410338