### PR TITLE
[DataLoader2] Fix issue related to duplicate collation

### DIFF
--- a/test/test_dataloader2.py
+++ b/test/test_dataloader2.py
@@ -100,5 +100,26 @@ class DataLoader2Test(TestCase):
         restored_data_loader.shutdown()
 
 
+class DataLoader2ConsistencyTest(TestCase):
+    r"""
+    These tests ensure that the behaviors of `DataLoader2` are consistent across `ReadingServices` and potentially
+    with `DataLoaderV1`.
+    """
+
+    def test_dataloader2_batch_collate(self) -> None:
+        dp: IterDataPipe = IterableWrapper(range(10)).batch(2).collate()  # type: ignore[assignment]
+
+        dl_no_rs: DataLoader2 = DataLoader2(dp)
+
+        rs = MultiProcessingReadingService(num_workers=0)
+        dl_multi_rs: DataLoader2 = DataLoader2(dp, reading_service=rs)
+
+        self.assertTrue(all(x.eq(y).all() for x, y in zip(dl_no_rs, dl_multi_rs)))
+
+    def test_dataloader2_shuffle(self) -> None:
+        # TODO
+        pass
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -88,6 +88,10 @@ class CheckpointableReadingServiceInterface(ReadingServiceInterface):
         pass
 
 
+def _collate_no_op(batch):
+    return batch[0]
+
+
 class MultiProcessingReadingService(ReadingServiceInterface):
     num_workers: int
     pin_memory: bool
@@ -126,6 +130,8 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             multiprocessing_context=self.multiprocessing_context,
             prefetch_factor=self.prefetch_factor,
             persistent_workers=self.persistent_workers,
+            # TODO: `collate_fn` is necessary until we stop using DLv1 https://github.com/pytorch/data/issues/530
+            collate_fn=_collate_no_op,
         )
         return IterableWrapper(self.dl_)  # type: ignore[return-value]
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -132,6 +132,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             persistent_workers=self.persistent_workers,
             # TODO: `collate_fn` is necessary until we stop using DLv1 https://github.com/pytorch/data/issues/530
             collate_fn=_collate_no_op,
+            batch_size=1,  # This reading service assume batching is done via DataPipe
         )
         return IterableWrapper(self.dl_)  # type: ignore[return-value]
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #531

Since we want users to always provide their own collation in the DataPipe graph, we add this function to avoid duplicate collation. It will no longer be needed once this reading service no longer relies on DLv1.

Separately, the [linter issue](https://github.com/pytorch/data/issues/364) is modified to track the fact that we want users to always provide a `Collator`.

Fixes part of https://github.com/pytorch/data/issues/530

Differential Revision: [D37348504](https://our.internmc.facebook.com/intern/diff/D37348504)