### PR TITLE
DataFrameMakerIterDataPipe now allows dtype_generator to be passed.

### DIFF
--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -30,7 +30,7 @@ T_co = TypeVar("T_co")
 def _construct_dataframe(data, dtype=None, dtype_generator=None, columns=None, device=None):
     if dtype is None:
         dtype = dtype_generator()
-    return torcharrow.DataFrame(data, dtype=dtype, columns=columns, device=device)
+    return torcharrow.dataframe(data, dtype=dtype, columns=columns, device=device)
 
 
 @functional_datapipe("dataframe")

--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -47,6 +47,9 @@ class DataFrameMakerIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IData
         source_dp: IterDataPipe containing rows of data
         dataframe_size: number of rows of data within each DataFrame, page size can be option
         dtype: specify the `TorchArrow` dtype for the DataFrame, use ``torcharrow.dtypes.DType``
+        dtype_generator: function with no input argument that generates a torcharrow.dtypes.DType,
+            which overrides dtype if both are given. This is useful for when the desired dtype is
+            not serializable.
         columns: List of str that specifies the column names of the DataFrame
         device: specify the device on which the DataFrame will be stored
 
@@ -71,7 +74,7 @@ class DataFrameMakerIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IData
         source_dp: IterDataPipe[T_co],
         dataframe_size: int = 1000,  # or Page Size
         dtype=None,  # Optional[torcharrow.dtypes.DType]
-        dtype_generator = None,
+        dtype_generator=None,
         columns: Optional[List[str]] = None,
         device: str = "",
     ):
@@ -82,7 +85,9 @@ class DataFrameMakerIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IData
             )
         # In this version, DF tracing is not available, which would allow DataPipe to run DataFrame operations
         batch_dp = source_dp.batch(dataframe_size)
-        df_dp = batch_dp.map(partial(_construct_dataframe, dtype=dtype, dtype_generator=dtype_generator, columns=columns, device=device))
+        df_dp = batch_dp.map(
+            partial(_construct_dataframe, dtype=dtype, dtype_generator=dtype_generator, columns=columns, device=device)
+        )
         return df_dp
 
 

--- a/torchdata/datapipes/iter/util/dataframemaker.py
+++ b/torchdata/datapipes/iter/util/dataframemaker.py
@@ -72,7 +72,7 @@ class DataFrameMakerIterDataPipe(IterDataPipe):  # IterDataPipe[torcharrow.IData
     def __new__(
         cls,
         source_dp: IterDataPipe[T_co],
-        dataframe_size: int = 1000,  # or Page Size
+        dataframe_size: int = 1000,
         dtype=None,  # Optional[torcharrow.dtypes.DType]
         dtype_generator=None,
         columns: Optional[List[str]] = None,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #537

This is required for the usecases when dtype itself is not serializable and can't be part of the graph.

Differential Revision: [D37522091](https://our.internmc.facebook.com/intern/diff/D37522091)