### PR TITLE
[Core] Moving Queues, Protocols and Evenloops from PyTorch core.

### DIFF
--- a/test/test_dataloader2.py
+++ b/test/test_dataloader2.py
@@ -117,10 +117,18 @@ class DataLoader2ConsistencyTest(TestCase):
 
     @staticmethod
     def _get_mp_reading_service():
-        return MultiProcessingReadingService(num_workers=0)
+        return MultiProcessingReadingService(num_workers=2)
 
     @staticmethod
     def _get_proto_reading_service():
+        return PrototypeMultiProcessingReadingService(num_workers=2)
+
+    @staticmethod
+    def _get_mp_reading_service_zero_workers():
+        return MultiProcessingReadingService(num_workers=0)
+
+    @staticmethod
+    def _get_proto_reading_service_zero_workers():
         return PrototypeMultiProcessingReadingService(num_workers=0)
 
     def _collect_data(self, datapipe, reading_service_gen):
@@ -133,15 +141,25 @@ class DataLoader2ConsistencyTest(TestCase):
             result.append(row)
         return result
 
+    @staticmethod
+    def _no_op(x):
+        return x
+
     def test_dataloader2_batch_collate(self) -> None:
-        dp: IterDataPipe = IterableWrapper(range(100)).batch(2).collate()  # type: ignore[assignment]
+        dp: IterDataPipe = IterableWrapper(range(100)).batch(2).sharding_filter().collate(self._no_op)  # type: ignore[assignment]
         expected = self._collect_data(dp, reading_service_gen=self._get_no_reading_service)
 
-        reading_service_generators = (self._get_mp_reading_service, self._get_proto_reading_service)
+        reading_service_generators = (
+            self._get_mp_reading_service,
+            self._get_proto_reading_service,
+            self._get_mp_reading_service_zero_workers,
+            self._get_proto_reading_service_zero_workers,
+        )
         for reading_service_gen in reading_service_generators:
             actual = self._collect_data(dp, reading_service_gen=reading_service_gen)
             # TODO(VitalyFedyunin): This comparison only indicates that somethings is broken and not helping with debug
-            self.assertTrue(all(x.eq(y).all() for x, y in zip(expected, actual)))
+            self.assertEqual(expected, actual, reading_service_gen)
+            # self.assertTrue(all(x.eq(y).all() for x, y in zip(expected, actual)), reading_service_gen)
 
     def test_dataloader2_shuffle(self) -> None:
         # TODO

--- a/test/test_dataloader2.py
+++ b/test/test_dataloader2.py
@@ -9,7 +9,12 @@ import pickle
 import unittest
 from unittest import TestCase
 
-from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService, ReadingServiceInterface
+from torchdata.dataloader2 import (
+    DataLoader2,
+    MultiProcessingReadingService,
+    PrototypeMultiProcessingReadingService,
+    ReadingServiceInterface,
+)
 from torchdata.dataloader2.dataloader2 import READING_SERVICE_STATE_KEY_NAME, SERIALIZED_DATAPIPE_KEY_NAME
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
@@ -106,15 +111,37 @@ class DataLoader2ConsistencyTest(TestCase):
     with `DataLoaderV1`.
     """
 
+    @staticmethod
+    def _get_no_reading_service():
+        return None
+
+    @staticmethod
+    def _get_mp_reading_service():
+        return MultiProcessingReadingService(num_workers=0)
+
+    @staticmethod
+    def _get_proto_reading_service():
+        return PrototypeMultiProcessingReadingService(num_workers=0)
+
+    def _collect_data(self, datapipe, reading_service_gen):
+        dl: DataLoader2 = DataLoader2(datapipe, reading_service=reading_service_gen())
+        result = []
+        # Testing how RS handles partial reading and reiterations
+        for row, _ in zip(dl, range(10)):
+            result.append(row)
+        for row in dl:
+            result.append(row)
+        return result
+
     def test_dataloader2_batch_collate(self) -> None:
-        dp: IterDataPipe = IterableWrapper(range(10)).batch(2).collate()  # type: ignore[assignment]
+        dp: IterDataPipe = IterableWrapper(range(100)).batch(2).collate()  # type: ignore[assignment]
+        expected = self._collect_data(dp, reading_service_gen=self._get_no_reading_service)
 
-        dl_no_rs: DataLoader2 = DataLoader2(dp)
-
-        rs = MultiProcessingReadingService(num_workers=0)
-        dl_multi_rs: DataLoader2 = DataLoader2(dp, reading_service=rs)
-
-        self.assertTrue(all(x.eq(y).all() for x, y in zip(dl_no_rs, dl_multi_rs)))
+        reading_service_generators = (self._get_mp_reading_service, self._get_proto_reading_service)
+        for reading_service_gen in reading_service_generators:
+            actual = self._collect_data(dp, reading_service_gen=reading_service_gen)
+            # TODO(VitalyFedyunin): This comparison only indicates that somethings is broken and not helping with debug
+            self.assertTrue(all(x.eq(y).all() for x, y in zip(expected, actual)))
 
     def test_dataloader2_shuffle(self) -> None:
         # TODO

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -7,13 +7,18 @@
 
 from .dataloader2 import DataLoader2
 from .error import PauseIteration
-from .reading_service import MultiProcessingReadingService, ReadingServiceInterface
+from .reading_service import (
+    MultiProcessingReadingService,
+    PrototypeMultiProcessingReadingService,
+    ReadingServiceInterface,
+)
 from .shuffle_spec import ShuffleSpec
 
 __all__ = [
     "DataLoader2",
     "MultiProcessingReadingService",
     "PauseIteration",
+    "PrototypeMultiProcessingReadingService",
     "ReadingServiceInterface",
     "ShuffleSpec",
 ]

--- a/torchdata/dataloader2/communication/__init__.py
+++ b/torchdata/dataloader2/communication/__init__.py
@@ -1,0 +1,1 @@
+from . import eventloop, iter, map, messages, protocol, queue

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -1,0 +1,79 @@
+import pickle
+import threading
+
+import torch
+
+from torch.utils.data import IterDataPipe, MapDataPipe
+from torchdata.dataloader2 import communication
+
+try:
+    import dill
+
+    # XXX: By default, dill writes the Pickler dispatch table to inject its
+    # own logic there. This globally affects the behavior of the standard library
+    # pickler for any user who transitively depends on this module!
+    # Undo this extension to avoid altering the behavior of the pickler globally.
+    dill.extend(use_dill=False)
+    HAS_DILL = True
+except ImportError:
+    HAS_DILL = False
+
+__all__ = [
+    "DataPipeToQueuesLoop",
+    "SpawnProcessForDataPipeline",
+    "SpawnThreadForDataPipeline",
+]
+
+
+def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_locally_fn=None):
+    if call_locally_fn is not None:
+        call_locally_fn(source_datapipe)
+    if isinstance(source_datapipe, IterDataPipe):
+        pipe_type = communication.iter
+        protocol_type = communication.protocol.IterDataPipeQueueProtocolServer
+    elif isinstance(source_datapipe, MapDataPipe):
+        pipe_type = communication.map  # type: ignore[misc]
+        protocol_type = communication.protocol.MapDataPipeQueueProtocolServer  # type: ignore[assignment]
+    else:
+        raise Exception("Only supports IterDataPipe or MapDataPipe, got", source_datapipe)
+
+    # torch.utils.data.graph_settings.apply_sharding(source_datapipe, self.num_workers, worker_id)
+
+    torch.set_num_threads(1)
+    for _ in pipe_type.DataPipeBehindQueues(
+        source_datapipe, protocol_type(req_queue, res_queue), blocking_request_get=True
+    ):
+        pass
+
+
+def SpawnProcessForDataPipeline(multiprocessing_ctx, datapipe, call_locally_fn=None):
+    req_queue = multiprocessing_ctx.Queue()
+    res_queue = multiprocessing_ctx.Queue()
+    process = multiprocessing_ctx.Process(
+        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, call_locally_fn)
+    )
+    return process, req_queue, res_queue
+
+
+def SpawnThreadForDataPipeline(datapipe):
+    r"""
+    Given a DataPipe, creates a copy of the DataPipe, starts a new Thread with DataPipeToQueuesLoop as target,
+    and return the process, req_queue, res_queue, thread_local_datapipe.
+    """
+    req_queue = communication.queue.ThreadingQueue()
+    res_queue = communication.queue.ThreadingQueue()
+
+    try:
+        new_datapipe = pickle.loads(pickle.dumps(datapipe))
+    except Exception as pe:
+        if HAS_DILL:
+            try:
+                new_datapipe = dill.loads(dill.dumps(datapipe))
+            except Exception as de:
+                raise Exception("Unable to dill DataPipe to make thread local copy", de)
+
+        else:
+            raise Exception("Unable to pickle DataPipe to make thread local copy (consider installing `dill`)", pe)
+
+    process = threading.Thread(target=DataPipeToQueuesLoop, args=(new_datapipe, req_queue, res_queue), daemon=True)
+    return process, req_queue, res_queue, new_datapipe

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -1,0 +1,185 @@
+import time
+import types
+
+from torch.utils.data import IterDataPipe
+from torchdata.dataloader2 import communication
+
+DEFAULT_NON_BLOCKING_SLEEP = 0.001
+
+__all__ = [
+    "DataPipeBehindQueues",
+    "EnsureNonBlockingDataPipe",
+    "InvalidStateResetRequired",
+    "NonBlocking",
+    "NotAvailable",
+    "QueueWrapper",
+    "default_not_available_hook",
+]
+
+
+def default_not_available_hook():
+    time.sleep(DEFAULT_NON_BLOCKING_SLEEP)
+
+
+class NotAvailable(Exception):
+    pass
+
+
+class InvalidStateResetRequired(Exception):
+    """
+    Returned by DataPipe when it is expecting to get reset request,
+    for example RouterDataPipe expecting all workers to request reset'
+    """
+
+    pass
+
+
+class NonBlocking(IterDataPipe):
+    not_available_hook = default_not_available_hook
+
+    def __iter__(self):
+        self.reset_iterator()
+        return self
+
+    def __next__(self):
+        while True:
+            try:
+                return self.nonblocking_next()
+            except StopIteration:
+                raise StopIteration
+            except NotAvailable:
+                if NonBlocking.not_available_hook is not None:
+                    NonBlocking.not_available_hook()
+
+    def nonblocking_next(self):
+        raise NotImplementedError("nonblocking_next is not implemented for %s" % self.__class__)
+
+    def reset_iterator(self):
+        raise NotImplementedError("reset_iterator is not implemented for %s" % self.__class__)
+
+    @staticmethod
+    def register_not_available_hook(hook_function):
+        NonBlocking.not_available_hook = hook_function
+
+
+def EnsureNonBlockingDataPipe(validated_datapipe):
+    if not isinstance(validated_datapipe, IterDataPipe):
+        raise Exception("Not Iterable DataPipe " + str(validated_datapipe.__class__))
+    if isinstance(validated_datapipe, NonBlocking):
+        return validated_datapipe
+    if not hasattr(validated_datapipe, "_as_iterator"):
+        validated_datapipe._as_iterator = None  # type: ignore[attr-defined]
+    if not hasattr(validated_datapipe, "nonblocking_next"):
+
+        def nonblocking_next(self):
+            if self._as_iterator is None:
+                self._as_iterator = iter(self)
+            return next(self._as_iterator)
+
+        validated_datapipe.nonblocking_next = types.MethodType(  # type: ignore[attr-defined]
+            nonblocking_next, validated_datapipe
+        )
+    if not hasattr(validated_datapipe, "reset_iterator"):
+
+        def reset_iterator(self):
+            self._as_iterator = None
+
+        validated_datapipe.reset_iterator = types.MethodType(  # type: ignore[attr-defined]
+            reset_iterator, validated_datapipe
+        )
+    return validated_datapipe
+
+
+def DataPipeBehindQueues(source_datapipe, protocol, full_stop=False, blocking_request_get=False):
+    """
+    Indefinitely iterates over req_queue and passing values from source_datapipe to res_queue
+    If raise_stop is true, raises exception when StopIteration received from the source_datapipe
+    """
+    if not isinstance(protocol, communication.protocol.IterDataPipeQueueProtocolServer):
+        raise Exception("Expecting IterDataPipeQueueProtocolServer, got", protocol)
+    source_datapipe = EnsureNonBlockingDataPipe(source_datapipe)
+    forever = True
+    while forever:
+        try:
+            # Non-blocking call is Extremely slow here for python.mp, need to figure out a good workaround
+            request = protocol.get_new_request(block=blocking_request_get)
+        except communication.protocol.EmptyQueue:
+            yield True
+            continue
+
+        if isinstance(request, communication.messages.ResetIteratorRequest):
+            source_datapipe.reset_iterator()
+            protocol.response_reset_iterator()
+
+        elif isinstance(request, communication.messages.TerminateRequest):
+            forever = False
+            protocol.response_terminate()
+
+        elif isinstance(request, communication.messages.GetNextRequest):
+            while forever:
+                try:
+                    value = source_datapipe.nonblocking_next()
+                except NotAvailable:
+                    yield True
+                    continue
+                except StopIteration:
+                    protocol.response_stop_iteration()
+                    if full_stop:
+                        forever = False
+                    else:
+                        yield True
+                    break
+                except InvalidStateResetRequired:
+                    protocol.response_invalid_state()
+                    if full_stop:
+                        forever = False
+                    else:
+                        yield True
+                    break
+                protocol.response_next(value)
+                yield True  # Returns control
+                break
+        else:
+            raise Exception("Unrecognized type of request received", request)
+
+
+class QueueWrapper(NonBlocking):
+    """
+    Creates iter.DataPipe which reads data from the DataLoader.Queue
+    """
+
+    def __init__(self, protocol, response_wait_time=0.00001):
+        if not isinstance(protocol, communication.protocol.IterDataPipeQueueProtocolClient):
+            raise Exception("Got", protocol)
+        self.protocol = protocol
+        self.counter = 0
+        self._stop_iteration = False
+        self._response_wait_time = response_wait_time
+
+    def reset_iterator(self):
+        self._stop_iteration = False
+        self.counter = 0
+        self.protocol.request_reset_iterator()
+        while True:
+            try:
+                self.protocol.get_response_reset_iterator()
+                break
+            except communication.protocol.EmptyQueue:
+                if NonBlocking.not_available_hook is not None:
+                    NonBlocking.not_available_hook()
+
+    def nonblocking_next(self):
+        if self._stop_iteration:
+            raise Exception("`next` or `nonblocking_next` called after receiving StopIteration")
+        if self.protocol.can_take_request():
+            self.protocol.request_next()
+        try:
+            response = self.protocol.get_response_next(block=True, timeout=self._response_wait_time)
+        except communication.protocol.EmptyQueue:
+            raise NotAvailable
+        if isinstance(response, communication.messages.StopIterationResponse):
+            self._stop_iteration = True
+            raise StopIteration
+        if isinstance(response, communication.messages.InvalidStateResponse):
+            raise NotAvailable
+        return response.value

--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -1,0 +1,163 @@
+import time
+import types
+
+from torch.utils.data import MapDataPipe
+from torchdata.dataloader2 import communication
+
+DEFAULT_NON_BLOCKING_SLEEP = 0.001
+
+__all__ = [
+    "DataPipeBehindQueues",
+    "EnsureNonBlockingMapDataPipe",
+    "NonBlockingMap",
+    "NotAvailable",
+    "QueueWrapperForMap",
+    "default_not_available_hook",
+]
+
+
+def default_not_available_hook():
+    time.sleep(DEFAULT_NON_BLOCKING_SLEEP)
+
+
+class NotAvailable(Exception):
+    pass
+
+
+class NonBlockingMap(MapDataPipe):
+    not_available_hook = default_not_available_hook
+
+    def __getitem__(self, index):
+        while True:
+            try:
+                return self.nonblocking_getitem(index)
+            except NotAvailable:
+                if NonBlockingMap.not_available_hook is not None:
+                    NonBlockingMap.not_available_hook()
+
+    def __len__(self):
+        try:
+            return self.nonblocking_len()
+        except NotAvailable:
+            if NonBlockingMap.not_available_hook is not None:
+                NonBlockingMap.not_available_hook()
+
+    def nonblocking_len(self):
+        raise NotImplementedError("nonblocking_len is not implemented for %s" % self.__class__)
+
+    def nonblocking_getitem(self, index):
+        raise NotImplementedError("nonblocking_getitem is not implemented for %s" % self.__class__)
+
+    @staticmethod
+    def register_not_available_hook(hook_function):
+        NonBlockingMap.not_available_hook = hook_function
+
+
+def EnsureNonBlockingMapDataPipe(validated_datapipe):
+    if not isinstance(validated_datapipe, MapDataPipe):
+        raise Exception(f"Not Map DataPipe - got {validated_datapipe.__class__}")
+    if isinstance(validated_datapipe, NonBlockingMap):
+        return validated_datapipe
+    if not hasattr(validated_datapipe, "nonblocking_len"):
+
+        def nonblocking_len(self):
+            return self.__len__()
+
+        validated_datapipe.nonblocking_len = types.MethodType(  # type: ignore[attr-defined]
+            nonblocking_len, validated_datapipe
+        )
+    if not hasattr(validated_datapipe, "nonblocking_getitem"):
+
+        def nonblocking_getitem(self, index):
+            return self.__getitem__(index)
+
+        validated_datapipe.nonblocking_getitem = types.MethodType(  # type: ignore[attr-defined]
+            nonblocking_getitem, validated_datapipe
+        )
+    return validated_datapipe
+
+
+def DataPipeBehindQueues(source_datapipe, protocol, full_stop=False, blocking_request_get=False):
+    """
+    Indefinitely iterates over req_queue and passing values from source_datapipe to res_queue
+    If raise_stop is true, raises exception when StopIteration received from the source_datapipe
+    """
+    if not isinstance(protocol, communication.protocol.MapDataPipeQueueProtocolServer):
+        raise Exception("Expecting MapDataPipeQueueProtocolServer, got", protocol)
+    source_datapipe = EnsureNonBlockingMapDataPipe(source_datapipe)
+    forever = True
+    while forever:
+        try:
+            # Non-blocking call is Extremely slow here for python.mp, need to figure out a good workaround
+            request = protocol.get_new_request(block=blocking_request_get)
+        except communication.protocol.EmptyQueue:
+            yield True
+            continue
+
+        if isinstance(request, communication.messages.TerminateRequest):
+            forever = False
+            protocol.response_terminate()
+
+        elif isinstance(request, communication.messages.LenRequest):
+            size = source_datapipe.nonblocking_len()
+            protocol.response_len(size)
+
+        elif isinstance(request, communication.messages.GetItemRequest):
+            while forever:
+                try:
+                    value = source_datapipe.nonblocking_getitem(request.key)
+                except NotAvailable:
+                    yield True
+                    continue
+                except IndexError:
+                    # Alternatively, we can just allow the underlying DataPipe to throw an exception?
+                    protocol.response_index_out_of_bound()
+                    if full_stop:
+                        forever = False
+                    else:
+                        yield True
+                    break
+                protocol.response_item(request.key, value)
+                yield True  # Returns control
+                break
+        else:
+            raise Exception("Unrecognized type of request received", request)
+
+
+class QueueWrapperForMap(NonBlockingMap):
+    """
+    Creates map.DataPipe which reads data from the DataLoader.Queue
+    """
+
+    def __init__(self, protocol, response_wait_time=0.00001):
+        if not isinstance(protocol, communication.protocol.MapDataPipeQueueProtocolClient):
+            raise Exception("Got", protocol)
+        self.protocol = protocol
+        self.counter = 0
+        self._stop_iteration = False
+        self._response_wait_time = response_wait_time
+
+    def nonblocking_getitem(self, index):
+        if self._stop_iteration:
+            raise Exception("`getitem` or `nonblocking_getitem` called after receiving StopIteration")
+        if self.protocol.can_take_request():
+            self.protocol.request_item(index)
+        try:
+            response = self.protocol.get_response_item(block=True, timeout=self._response_wait_time)
+        except communication.protocol.EmptyQueue:
+            raise NotAvailable
+        if isinstance(response, communication.messages.StopIterationResponse):
+            self._stop_iteration = True
+            raise IndexError(f"Index {index} is out of bound.")
+        return response.key, response.value
+
+    def nonblocking_len(self):
+        if self._stop_iteration:
+            raise Exception("`len` or `nonblocking_len` called after receiving StopIteration")
+        if self.protocol.can_take_request():
+            self.protocol.request_len()
+        try:
+            response = self.protocol.get_response_len(block=True, timeout=self._response_wait_time)
+        except communication.protocol.EmptyQueue:
+            raise NotAvailable
+        return response.len

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -1,0 +1,76 @@
+class DataLoaderQueueMessage:
+    pass
+
+
+class Request(DataLoaderQueueMessage):
+    pass
+
+
+class Response(DataLoaderQueueMessage):
+    pass
+
+
+class ResetIteratorRequest(Request):
+    pass
+
+
+class ResetIteratorResponse(Response):
+    pass
+
+
+class TerminateRequest(Request):
+    pass
+
+
+class TerminateResponse(Response):
+    pass
+
+
+class LenRequest(Request):
+    pass
+
+
+class LenResponse(Response):
+    __slots__ = "len"
+
+    def __init__(self, len):
+        self.len = len
+
+
+class GetItemRequest(Request):
+    __slots__ = "key"
+
+    def __init__(self, key):
+        self.key = key
+
+
+class GetItemResponse(Response):
+    __slots__ = ("key", "value")
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+
+class GetNextRequest(Request):
+    pass
+
+
+class GetNextResponse(Response):
+    __slots__ = "value"
+
+    def __init__(self, value):
+        self.value = value
+
+
+class StopIterationResponse(Response):
+    pass
+
+
+class InvalidStateResponse(Response):
+    """
+    Returned by DataPipe when it is expecting to get reset request,
+    for example RouterDataPipe expecting all workers to request reset'
+    """
+
+    pass

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -1,0 +1,203 @@
+from torchdata.dataloader2 import communication
+
+
+class Protocol:
+    __slots__ = ("request_queue", "response_queue")
+
+    def __init__(self, request_queue, response_queue):
+        self.request_queue = request_queue
+        self.response_queue = response_queue
+
+
+class ProtocolClient(Protocol):
+    """
+    ProtocolClient takes charge of putting requests into req_queue and returning results from res_queue.
+    """
+
+    _req_sent = None
+
+    def __init__(self, request_queue, response_queue):
+        self.request_queue = request_queue
+        self.response_queue = response_queue
+        self._req_sent = None
+
+    def can_take_request(self):
+        return self._req_sent is None
+
+    def waiting_for_response(self):
+        return self._req_sent is not None
+
+    def request_sent(self, request=True):
+        if not self.can_take_request():
+            raise Exception("Protocol only supports one request in the Queue")
+        self._req_sent = request
+
+    def request_served(self, result=None):
+        if not self.waiting_for_response():
+            raise Exception("Expected no peding requests, but something got served", result)
+        self._req_sent = None
+
+
+class ProtocolServer(Protocol):
+    """
+    ProtocolServer takes charge of getting requests from req_queue and fetching data from source datapipe.
+    """
+
+    _req_received = None
+
+    def __init__(self, request_queue, response_queue):
+        self.request_queue = request_queue
+        self.response_queue = response_queue
+        self._req_received = None
+
+    def have_pending_request(self):
+        return self._req_received is not None
+
+    def get_new_request(self, block=False):
+        if self.have_pending_request():
+            raise Exception("Trying to get next request, while having one unserved")
+        try:
+            response = self.request_queue.get(block=block)
+        except Exception:  # TODO: Catch only timeout exceptions
+            raise EmptyQueue("queue is empty")
+        self._req_received = response
+        return response
+        # TODO: Validate supported requests
+
+    def response_terminate(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        if not isinstance(self._req_received, communication.messages.TerminateRequest):
+            raise Exception("Replaying with terminate status to other type of message")
+        self.response_queue.put(communication.messages.TerminateResponse())
+        self._req_received = None
+
+
+class MapDataPipeQueueProtocolServer(ProtocolServer):
+    def response_item(self, key, value):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.GetItemResponse(key, value))
+        self._req_received = None
+
+    def response_len(self, size):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.LenResponse(size))
+        self._req_received = None
+
+    def response_index_out_of_bound(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.StopIterationResponse())
+        self._req_received = None
+
+
+class MapDataPipeQueueProtocolClient(ProtocolClient):
+    def request_len(self):
+        if not self.can_take_request():
+            raise Exception("Can not request len while we are still waiting response for previous request")
+        request = communication.messages.LenRequest()
+        self.request_queue.put(request)
+        self.request_sent(request)
+
+    def request_item(self, index):
+        if not self.can_take_request():
+            raise Exception("Can not request item while we are still waiting response for previous request")
+        request = communication.messages.GetItemRequest(index)
+        self.request_queue.put(request)
+        self.request_sent(request)
+
+    def get_response_len(self, block=False, timeout=None):
+        if not self.waiting_for_response():
+            raise Exception("Can not expect any response without submitted request")
+        try:
+            response = self.response_queue.get(block=block, timeout=timeout)
+        except TimeoutError:
+            raise EmptyQueue("queue is empty")
+        self.request_served(response)
+        if not isinstance(response, communication.messages.LenResponse):
+            raise Exception("Invalid response received")
+        return response
+
+    def get_response_item(self, block=False, timeout=None):
+        if not self.waiting_for_response():
+            raise Exception("Can not expect any response without submitted request")
+        try:
+            response = self.response_queue.get(block=block, timeout=timeout)
+        except TimeoutError:
+            raise EmptyQueue("queue is empty")
+        self.request_served(response)
+        # if not isinstance(response, communication.messages.GetItemResponse):
+        #     raise Exception('Invalid response received')
+        return response
+
+
+class EmptyQueue(Exception):
+    pass
+
+
+class IterDataPipeQueueProtocolServer(ProtocolServer):
+    def response_reset_iterator(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        if not isinstance(self._req_received, communication.messages.ResetIteratorRequest):
+            raise Exception("Replaying with reset status to other type of message")
+        self.response_queue.put(communication.messages.ResetIteratorResponse())
+        self._req_received = None
+
+    def response_next(self, value):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.GetNextResponse(value))
+        self._req_received = None
+
+    def response_stop_iteration(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.StopIterationResponse())
+        self._req_received = None
+
+    def response_invalid_state(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.InvalidStateResponse())
+        self._req_received = None
+
+
+class IterDataPipeQueueProtocolClient(ProtocolClient):
+    def request_reset_iterator(self):
+        if not self.can_take_request():
+            raise Exception("Can not reset while we are still waiting response for previous request")
+        request = communication.messages.ResetIteratorRequest()
+        self.request_queue.put(request)
+        self.request_sent(request)
+
+    def request_next(self):
+        if not self.can_take_request():
+            raise Exception("Can not request next item while we are still waiting response for previous request")
+        request = communication.messages.GetNextRequest()
+        self.request_queue.put(request)
+        self.request_sent(request)
+
+    def get_response_reset_iterator(self, block=False):
+        try:
+            response = self.response_queue.get(block=block)
+        except Exception:  # TODO: Catch only timeout exceptions
+            raise EmptyQueue("queue is empty")
+        self.request_served(response)
+
+        if not isinstance(response, communication.messages.ResetIteratorResponse):
+            raise Exception("Invalid response received")
+
+    def get_response_next(self, block=False, timeout=None):
+        if not self.waiting_for_response():
+            raise Exception("Can not expect any response without submitted request")
+        try:
+            response = self.response_queue.get(block=block, timeout=timeout)
+        except Exception:  # TODO: Catch only timeout exceptions
+            raise EmptyQueue("queue is empty")
+        self.request_served(response)
+
+        # TODO(VitalyFedyunin): Add possible response types validation here
+        return response

--- a/torchdata/dataloader2/communication/queue.py
+++ b/torchdata/dataloader2/communication/queue.py
@@ -1,0 +1,51 @@
+import threading
+import time
+
+
+class LocalQueue:
+    ops = 0
+    stored = 0
+    uid = 0
+    empty = 0
+
+    def __init__(self, name="unnamed"):
+        self.items = []
+        self.name = name
+        self.uid = LocalQueue.uid
+        LocalQueue.uid += 1
+
+    def put(self, item, block=True):
+        LocalQueue.ops += 1
+        LocalQueue.stored += 1
+        self.items.append(item)
+
+    def get(self, block=True, timeout=0):
+        # TODO(VitalyFedyunin): Add support of block and timeout arguments
+        LocalQueue.ops += 1
+        if not len(self.items):
+            LocalQueue.empty += 1
+            raise Exception("LocalQueue is empty")
+        LocalQueue.stored -= 1
+        return self.items.pop()
+
+
+class ThreadingQueue:
+    def __init__(self, name="unnamed"):
+        self.lock = threading.Lock()
+        self.items = []
+        self.name = name
+
+    def put(self, item, block=True):
+        with self.lock:
+            self.items.append(item)
+
+    def get(self, block=True, timeout=0):
+        # TODO(VitalyFedyunin): Add support of block and timeout arguments
+        while True:
+            with self.lock:
+                if len(self.items) > 0:
+                    return self.items.pop()
+            if not block:
+                raise Exception("Not available")
+            # TODO(VitalyFedyunin): Figure out what to do if nothing in the queue
+            time.sleep(0.000001)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -137,6 +137,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         multiprocessing_context=None,
     ) -> None:
         self.num_workers = num_workers
+        # TODO(VitalyFedyunin): Should be one of 'fork', 'spawn'
         self.multiprocessing_context = multiprocessing_context
         self.processes = []
         self.datapipes = []

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -5,10 +5,16 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import functools
+import multiprocessing as mp
+import time
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
+import torch
 from torch.utils.data import DataLoader
+
+from torchdata.dataloader2 import communication
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
 
@@ -90,6 +96,104 @@ class CheckpointableReadingServiceInterface(ReadingServiceInterface):
 
 def _collate_no_op(batch):
     return batch[0]
+
+
+class _IterateQueueDataPipes:
+    def __init__(self, datapipes):
+        self.datapipes = datapipes
+
+    def __iter__(self):
+        # TODO(VitalyFedyunin): This can traverse pipes in any order, so undeterministic
+        not_available = False
+        exclude_datapipes: List[Any] = []
+        while len(exclude_datapipes) < len(self.datapipes):
+            for dp in self.datapipes:
+                if dp not in exclude_datapipes:
+                    try:
+                        value = dp.nonblocking_next()
+                        yield value
+                    except StopIteration:
+                        exclude_datapipes.append(dp)
+                    except communication.iter.NotAvailable:
+                        not_available = True
+            if not_available:
+                time.sleep(0.001)
+
+
+class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
+    num_workers: int
+    #   pin_memory: bool
+    #   timeout: float
+    #   worker_init_fn: Optional[Callable[[int], None]]
+    #   prefetch_factor: int
+    #   persistent_workers: bool
+
+    processes: List
+    datapipes: List
+
+    def __init__(
+        self,
+        num_workers: int = 0,
+        #        pin_memory: bool = False,
+        #        timeout: float = 0,
+        #        worker_init_fn: Optional[Callable[[int], None]] = None,
+        multiprocessing_context=None,
+        #        prefetch_factor: int = 2,
+        #        persistent_workers: bool = False,
+    ) -> None:
+        self.num_workers = num_workers
+        #       self.pin_memory = pin_memory
+        #       self.timeout = timeout
+        #       self.worker_init_fn = worker_init_fn
+        self.multiprocessing_context = multiprocessing_context or mp.get_context("fork")
+        #       self.prefetch_factor = prefetch_factor
+        #       self.persistent_workers = persistent_workers
+        #       self.dl_: Optional[DataLoader] = None
+        self.processes = []
+        self.datapipes = []
+
+    @staticmethod
+    def init_datapipe_process(num_workers, worker_id, datapipe):
+        # TODO(VitalyFedyunin): Add distributed support
+        # TODO(VitalyFedyunin): Add shuffle determinism support
+        torch.utils.data.graph_settings.apply_sharding(datapipe, num_workers, worker_id)
+
+    def initialize(self, datapipe: IterDataPipe) -> IterDataPipe:
+        for worker_id in range(self.num_workers):
+            # TODO(VitalyFedyunin): Separate into function, because we also need to apply distributed seed and call it inside process
+            call_inside_process = functools.partial(self.init_datapipe_process, self.num_workers, worker_id)
+            (process, req_queue, res_queue) = communication.eventloop.SpawnProcessForDataPipeline(
+                self.multiprocessing_context, datapipe, call_inside_process
+            )
+            process.start()
+            self.processes.append((process, req_queue, res_queue))  # These queues are independent
+            local_datapipe = communication.iter.QueueWrapper(
+                communication.protocol.IterDataPipeQueueProtocolClient(req_queue, res_queue)
+            )
+            self.datapipes.append(local_datapipe)
+
+        return IterableWrapper(_IterateQueueDataPipes(self.datapipes), deepcopy=False)  # type: ignore[return-value]
+
+    def initialize_iteration(self) -> None:
+        for dp in self.datapipes:
+            dp.reset_iterator()
+
+    def __del__(self):
+        self.finalize()
+
+    def finalize(self) -> None:
+        # TODO(VitalyFedyunin): Check if anyone stuck with messages
+        def clean_me(process, req_queue, res_queue):
+            # TODO(VitalyFedyunin): Can send terminations simulteniously
+            # TODO(VitalyFedyunin): Make termination a function of QueueWrapperDataPipe (similar to reset)
+            req_queue.put(communication.messages.TerminateRequest())
+            _ = res_queue.get()
+            process.join()
+
+        for process, req_queue, res_queue in self.processes:
+            clean_me(process, req_queue, res_queue)
+
+        self.processes = []
 
 
 class MultiProcessingReadingService(ReadingServiceInterface):

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -149,6 +149,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
 
     def initialize(self, datapipe: IterDataPipe) -> IterDataPipe:
         if self.num_workers == 0:
+            # TODO(VitalyFedyunin): Warn and recommend usage of InPorcessReadingService
             return datapipe
         for worker_id in range(self.num_workers):
             # TODO(VitalyFedyunin): Separate into function, because we also need to apply distributed seed and call it inside process

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -9,7 +9,7 @@ import functools
 import multiprocessing as mp
 import time
 from abc import ABC, abstractmethod
-from typing import Callable, List, Optional
+from typing import Any, Callable, List, Optional
 
 import torch
 from torch.utils.data import DataLoader

--- a/torchdata/datapipes/iter/load/online.py
+++ b/torchdata/datapipes/iter/load/online.py
@@ -40,9 +40,9 @@ def _get_response_from_http(
         with requests.Session() as session:
             proxies = _get_proxies()
             if timeout is None:
-                r = session.get(url, stream=True, proxies=proxies, **query_params)
+                r = session.get(url, stream=True, proxies=proxies, **query_params)  # type: ignore[arg-type]
             else:
-                r = session.get(url, timeout=timeout, stream=True, proxies=proxies, **query_params)
+                r = session.get(url, timeout=timeout, stream=True, proxies=proxies, **query_params)  # type: ignore[arg-type]
         return url, StreamWrapper(r.raw)
     except HTTPError as e:
         raise Exception(f"Could not get the file. [HTTP Error] {e.response}.")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #544

Adding PrototypeMultiProcessingReadingService as a candidate to replace MultiProcessingReadingService and remote DLv1 dependency

Differential Revision: [D37467653](https://our.internmc.facebook.com/intern/diff/D37467653)