### PR TITLE
Fix mypy for IterDataPipe.collate

### DIFF
--- a/torchdata/datapipes/iter/__init__.pyi.in
+++ b/torchdata/datapipes/iter/__init__.pyi.in
@@ -9,7 +9,7 @@ ${init_base}
 
 from .util.decompressor import CompressionType
 from torchdata.datapipes.map import MapDataPipe
-from torch.utils.data import DataChunk, IterableDataset
+from torch.utils.data import DataChunk, IterableDataset, default_collate
 from torch.utils.data.datapipes._typing import _DataPipeMeta
 
 from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union


### PR DESCRIPTION
Add `default_collate` to mypy stub file to make sure `default_collate` is imported for `IterDataPipe.collate`. See current broken main branch: https://github.com/pytorch/data/runs/7287540702?check_suite_focus=true

Sister PR from PyTorch Core: https://github.com/pytorch/pytorch/pull/81275