### PR TITLE
Fix Lint Error for unused `IterDataPipe`

### DIFF
--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -16,7 +16,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data.graph import DataPipe
 
 from torchdata.dataloader2 import communication
-from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
+from torchdata.datapipes.iter import IterableWrapper
 
 
 class ReadingServiceInterface(ABC):


### PR DESCRIPTION
Per title

I have investigated the another CI failure for torchtext on macos, and the problem is caused by TorchText has not built nightly for macos < 11 with x86_64 after 2022-07-07. Opened an issue from TorchText