### PR TITLE
Fix buffer overflow for unzip with columns_to_skip

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -744,7 +744,7 @@ class TestIterDataPipe(expecttest.TestCase):
         self.assertEqual(list(range(10, 20)), list(dp2))
         self.assertEqual(list(range(20, 30)), list(dp3))
 
-        (dp2,) = source_dp.unzip(sequence_length=3, columns_to_skip=[0, 2])
+        (dp2,) = source_dp.unzip(sequence_length=3, columns_to_skip=[0, 2], buffer_size=0)
         self.assertEqual(list(range(10, 20)), list(dp2))
 
         source_dp = IterableWrapper([(i, i + 10, i + 20, i + 30) for i in range(10)])
@@ -754,12 +754,16 @@ class TestIterDataPipe(expecttest.TestCase):
 
         # Functional Test: one child DataPipe yields all value first, but buffer_size = 5 being too small, raises error
         source_dp = IterableWrapper([(i, i + 10) for i in range(10)])
-        dp1, dp2 = source_dp.unzip(sequence_length=2, buffer_size=5)
+        dp1, dp2 = source_dp.unzip(sequence_length=2, buffer_size=4)
         it1 = iter(dp1)
-        for _ in range(5):
+        for _ in range(4):
             next(it1)
         with self.assertRaises(BufferError):
             next(it1)
+        with self.assertRaises(BufferError):
+            list(dp2)
+
+        dp1, dp2 = source_dp.unzip(sequence_length=2, buffer_size=4)
         with self.assertRaises(BufferError):
             list(dp2)
 

--- a/torchdata/datapipes/iter/util/unzipper.py
+++ b/torchdata/datapipes/iter/util/unzipper.py
@@ -78,7 +78,7 @@ class _UnZipperIterDataPipe(_ForkerIterDataPipe):
     def get_next_element_by_instance(self, instance_id: int):
         r"""
         Note:
-            Each element returned from datapipe is required to be a sequnce that can
+            Each element returned from the source datapipe is required to be a sequnce that can
             be subscribed with a column index
         """
         for return_val in super().get_next_element_by_instance(instance_id):

--- a/torchdata/datapipes/iter/util/unzipper.py
+++ b/torchdata/datapipes/iter/util/unzipper.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import deque
 from typing import List, Optional, Sequence, TypeVar
 
 from torch.utils.data.datapipes.iter.combining import _ChildDataPipe, _ForkerIterDataPipe
@@ -85,27 +84,9 @@ class _UnZipperIterDataPipe(_ForkerIterDataPipe):
             yield return_val[self.instance_ids[instance_id]]
 
     def __getstate__(self):
-        if IterDataPipe.getstate_hook is not None:
-            return IterDataPipe.getstate_hook(self)
-
-        state = (
-            self.main_datapipe,
-            self.num_instances,
-            self.buffer_size,
-            self.instance_ids,
-        )
-        return state
+        state = super().__getstate__()
+        return (*state, self.instance_ids)
 
     def __setstate__(self, state):
-        (
-            self.main_datapipe,
-            self.num_instances,
-            self.buffer_size,
-            self.instance_ids,
-        ) = state
-        self._datapipe_iterator = None
-        self.buffer = deque()
-        self.child_pointers = [0] * self.num_instances
-        self.slowest_ptr = 0
-        self.leading_ptr = 0
-        self.end_ptr = None
+        super().__setstate__(state[:-1])
+        self.instance_ids = state[-1]

--- a/torchdata/datapipes/iter/util/unzipper.py
+++ b/torchdata/datapipes/iter/util/unzipper.py
@@ -71,9 +71,14 @@ class UnZipperIterDataPipe(IterDataPipe[T]):
 
 class _UnZipperIterDataPipe(_ForkerIterDataPipe):
     def __init__(self, datapipe: IterDataPipe, instance_ids: List[int], buffer_size: int = 1000):
-        super().__init__(datapipe, len(instance_ids), buffer_size)
+        super().__init__(datapipe, len(instance_ids), buffer_size)  # type: ignore[arg-type]
         self.instance_ids = instance_ids
 
     def get_next_element_by_instance(self, instance_id: int):
+        r"""
+        Note:
+            Each element returned from datapipe is required to be a sequnce that can
+            be subscribed with a column index
+        """
         for return_val in super().get_next_element_by_instance(instance_id):
             yield return_val[self.instance_ids[instance_id]]


### PR DESCRIPTION
When `unzip` has `columns_to_skip`, we should only create `ChildDataPipe` corresponding to `instance_ids`. And `Unzipper` should also handle mapping `instance_ids` to 0-based indices.

This is one of the root causes for the issue reported internally. See: https://fburl.com/2k0et1gv