### PR TITLE
[Release 0.4.1] Improve release workflow

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -137,8 +137,13 @@ jobs:
               pkginfo $pkg
               if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
                 auditwheel show $pkg
+                auditwheel repair $pkg --plat manylinux2014_x86_64 -w wheelhouse
               fi
           done
+          if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
+            mv dist temp
+            mv wheelhousr dist
+          fi
       - name: Install TorchData Wheel
         shell: bash
         env:

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -3,13 +3,11 @@ on:
   push:
     branches:
       - main
-      - release/*
   pull_request:
     branches:
       - main
       # For PR created by ghstack
       - gh/*/*/base
-      # - release/*
 
 jobs:
   torchvision:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,16 @@ jobs:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Get PyTorch Channel
+        shell: bash
+        run: |
+          if [[ "${{ github.base_ref }}" == release/* ]] || [[ "${{ github.ref }}" == refs/heads/release/* ]] || [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            PT_CHANNEL="https://download.pytorch.org/whl/test/cpu/torch_test.html"
+          else
+            PT_CHANNEL="https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html"
+          fi
+          echo "::set-output name=value::$PT_CHANNEL"
+        id: pytorch_channel
       - name: Setup Python environment
         uses: actions/setup-python@v2
         with:
@@ -40,18 +50,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Install PyTorch
         run: |
-          set -eux
-          python -m pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html --user
+          pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
       - name: Install dependencies
         run: |
-          set -eux
-          python -m pip install requests --user
-          python -m pip install mypy==0.812 --user
-          python -m pip install graphviz --user
+          pip3 install requests mypy==0.812 graphviz
       - name: Build TorchData
         run: |
-          set -eux
-          python setup.py develop --user
+          python setup.py develop
       - name: Run mypy
         env:
           MYPY_FORCE_COLOR: 1


### PR DESCRIPTION
Cherry-pick the PR #558

This should resolve the CI failure for mypy


Summary:
This is a follow-up PR to help resolve a few issues that I have encountered during the official release.
- Making sure the wheels for linux always following manylinux by using `auditwheel` to repair them
- Disable domain tests on release branch for both PRs and pushes
- Improve lint CI to install PyTorch from the corresponding urls for nightly/RC/official releases

Pull Request resolved: https://github.com/pytorch/data/pull/558

Reviewed By: NivekT

Differential Revision: D37496522

Pulled By: ejguan

fbshipit-source-id: d768f656734d34420a08d82e68f29af5f14cb2a7