### PR TITLE
fix newline windows issue in generate_csv

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -73,7 +73,7 @@ For this example, we will first have a helper function that generates some CSV f
 
     def generate_csv(file_label, num_rows: int = 5000, num_features: int = 20) -> None:
         fieldnames = ['label'] + [f'c{i}' for i in range(num_features)]
-        writer = csv.DictWriter(open(f"sample_data{file_label}.csv", "w"), fieldnames=fieldnames)
+        writer = csv.DictWriter(open(f"sample_data{file_label}.csv", "w", newline=''), fieldnames=fieldnames)
         writer.writeheader()
         for i in range(num_rows):
             row_data = {col: random.random() for col in fieldnames}


### PR DESCRIPTION
Fixes #674 

### Changes

updated tutorial in documentation to specify the newline explitly
`writer = csv.DictWriter(open(f"sample_data{file_label}.csv", "w", newline=''), fieldnames=fieldnames)`

instead of:
`writer = csv.DictWriter(open(f"sample_data{file_label}.csv", "w"), fieldnames=fieldnames)`

## Testing
- tested by running the generate_csv function before and after on a windows machine, before was creating newlines between lines and throwing errors, after the created files don't have newlines and full tutorial works
