### PR TITLE
Fix TarArchiveLoader to skip `open` for TarFile stream

### DIFF
--- a/test/test_local_io.py
+++ b/test/test_local_io.py
@@ -383,6 +383,11 @@ class TestDataPipeLocalIO(expecttest.TestCase):
         self._compressed_files_comparison_helper(self.temp_files, tar_loader_dp, check_length=False)
         self._compressed_files_comparison_helper(self.temp_files, gz_reader_dp, check_length=False)
 
+        # Load from decompressed file stream
+        decomp_dp = datapipe_gz_2.decompress()
+        decomp_reader_dp = TarArchiveLoader(decomp_dp)
+        self._compressed_files_comparison_helper(self.temp_files, decomp_reader_dp, check_length=False)
+
         # Functional Test: Read extracted files after reaching the end of the tarfile
         data_refs = list(tar_loader_dp)
         self._compressed_files_comparison_helper(self.temp_files, data_refs)

--- a/torchdata/datapipes/iter/util/tararchiveloader.py
+++ b/torchdata/datapipes/iter/util/tararchiveloader.py
@@ -57,9 +57,7 @@ class TarArchiveLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             validate_pathname_binary_tuple(data)
             pathname, data_stream = data
             try:
-                if isinstance(data_stream, tarfile.TarFile):
-                    tar = data_stream
-                elif isinstance(data_stream, StreamWrapper) and isinstance(data_stream.file_obj, tarfile.TarFile):
+                if isinstance(data_stream, StreamWrapper) and isinstance(data_stream.file_obj, tarfile.TarFile):
                     tar = data_stream.file_obj
                 else:
                     reading_mode = (


### PR DESCRIPTION
Fixes #673

If `data_stream` is either a `tafile.TarFile` object (wrapped by `StreamWrapper`), `TarArchiveLoader` should directly load from `data_stream` without `open` it again.