### PR TITLE
Cloud benchmarks

### DIFF
--- a/benchmarks/cloud/README.md
+++ b/benchmarks/cloud/README.md
@@ -1,12 +1,15 @@
 This folder contains templates that are useful for cloud setups
 
-Idea would be to provision a machine by configuring it in a YAML file and then running a benchmark script on it automatically. This is critical both for ad hoc benchmarking that are reproducible but also including real world benchmarks in a release.
+Idea would be to provision a machine by configuring it in a YAML file and then running a benchmark script on it
+automatically. This is critical both for ad hoc benchmarking that are reproducible but also including real world
+benchmarks in a release.
 
 We've provided some useful `yml` templates for you to get started
 
 https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html
 
 ## Setup aws cli
+
 `aws configure` and enter your credentials
 
 ## Setup stack (machine configuration)
@@ -18,7 +21,8 @@ https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-cre
   --parameters ParameterKey=InstanceTypeParameter,ParameterValue=p3.2xlarge ParameterKey=DiskType,ParameterValue=gp3
 ```
 
-## Ssh into machine and run job 
+## Ssh into machine and run job
+
 ```
 ssh elastic_ip
 git clone https://github.com/pytorch/data

--- a/benchmarks/cloud/README.md
+++ b/benchmarks/cloud/README.md
@@ -1,0 +1,33 @@
+This folder contains templates that are useful for cloud setups
+
+Idea would be to provision a machine by configuring it in a YAML file and then running a benchmark script on it automatically. This is critical both for ad hoc benchmarking that are reproducible but also including real world benchmarks in a release.
+
+We've provided some useful `yml` templates for you to get started
+
+https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-cli-creating-stack.html
+
+## Setup aws cli
+`aws configure` and enter your credentials
+
+## Setup stack (machine configuration)
+
+```sh
+ aws cloudformation create-stack \
+  --stack-name torchdatabenchmark \
+  --template-body ec2.yml \
+  --parameters ParameterKey=InstanceTypeParameter,ParameterValue=p3.2xlarge ParameterKey=DiskType,ParameterValue=gp3
+```
+
+## Ssh into machine and run job 
+```
+ssh elastic_ip
+git clone https://github.com/pytorch/data
+cd data/benchmarks
+python run_benchmark.py
+```
+
+Visually inspect logs
+
+## Shut down stack
+
+`aws cloudformation delete-stack --stack-name torchdatabenchmark`

--- a/benchmarks/cloud/ec2.yml
+++ b/benchmarks/cloud/ec2.yml
@@ -1,5 +1,3 @@
-
-
 # This script sets up an Ec2 instance with elastic IP and a disk volume
 Parameters:
   InstanceTypeParameter:
@@ -34,7 +32,7 @@ Resources:
     Properties:
       AvailabilityZone: us-west-2a
       ImageId: ami-0306d46d05aaf8663 # Deep Learning AMI
-      InstanceType: 
+      InstanceType:
         Ref: InstanceTypeParameter
       SecurityGroups:
         - !Ref SSHSecurityGroup
@@ -51,16 +49,15 @@ Resources:
     Properties:
       GroupDescription: Enable SSH access via port 22
       SecurityGroupIngress:
-      - CidrIp: 0.0.0.0/0
-        FromPort: 22
-        IpProtocol: tcp
-        ToPort: 22
-
+        - CidrIp: 0.0.0.0/0
+          FromPort: 22
+          IpProtocol: tcp
+          ToPort: 22
 
   NewVolume:
     Type: AWS::EC2::Volume
     Properties:
-      Size: 
+      Size:
         Ref: DiskSize
       VolumeType:
         Ref: DiskType

--- a/benchmarks/cloud/ec2.yml
+++ b/benchmarks/cloud/ec2.yml
@@ -1,0 +1,78 @@
+
+
+# This script sets up an Ec2 instance with elastic IP and a disk volume
+Parameters:
+  InstanceTypeParameter:
+    Type: String
+    Default: c5n.large
+    AllowedValues:
+      - c5n.large
+      - p2.2xlarge
+      - p3.2xlarge
+      - p3.8xlarge
+    Description: Instance type CPU, GPU
+  DiskSize:
+    Type: Number
+    Default: 100
+    Description: Disk size in GB
+  DiskType:
+    Type: String
+    Default: gp2
+    AllowedValues:
+      - gp2
+      - gp3
+      - io1
+      - io2
+      - sc1
+      - st1
+      - standard
+    Description: Enter Disk type SSD, HDD
+
+Resources:
+  MyInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone: us-west-2a
+      ImageId: ami-0306d46d05aaf8663 # Deep Learning AMI
+      InstanceType: 
+        Ref: InstanceTypeParameter
+      SecurityGroups:
+        - !Ref SSHSecurityGroup
+
+  # Elastic IP so I can easily ssh into the machine
+  MyEIP:
+    Type: AWS::EC2::EIP
+    Properties:
+      InstanceId: !Ref MyInstance
+
+  # Open security group for SSH
+  SSHSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Enable SSH access via port 22
+      SecurityGroupIngress:
+      - CidrIp: 0.0.0.0/0
+        FromPort: 22
+        IpProtocol: tcp
+        ToPort: 22
+
+
+  NewVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: 
+        Ref: DiskSize
+      VolumeType:
+        Ref: DiskType
+      AvailabilityZone: !GetAtt MyInstance.AvailabilityZone
+      Tags:
+        - Key: MyTag
+          Value: TagValue
+    DeletionPolicy: Snapshot
+
+  MountPoint:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      InstanceId: !Ref MyInstance
+      VolumeId: !Ref NewVolume
+      Device: /dev/sdh


### PR DESCRIPTION
Per our offline discussion, I am separating out the cloud part of #422 which will allow us to provision an AWS infra from the command line for offline benchmarks and potentially integrate into CI and release decisions.

In followup PRs, I will make the template more interesting and revisit the logger discussion so we can build this. (This PR is the middle node)
![Screen Shot 2022-07-25 at 10 14 40 AM](https://user-images.githubusercontent.com/3282513/180836193-f75e25c4-c2ed-4d8d-8f14-67849e232a44.png)

Here's a test that the template works

![Screen Shot 2022-07-25 at 10 15 13 AM](https://user-images.githubusercontent.com/3282513/180836270-0d26c697-eb8f-46bb-9f76-db76761555d2.png)

