### PR TITLE
Fix typo breaking nightly build (#578)

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -142,7 +142,7 @@ jobs:
           done
           if ${{ startsWith( matrix.os, 'ubuntu' ) }}; then
             mv dist temp
-            mv wheelhousr dist
+            mv wheelhouse dist
           fi
       - name: Install TorchData Wheel
         shell: bash


### PR DESCRIPTION
Cherry-pick #578


### Changes

Linux nightly releases are broken for some days now due to a small typo in the workflow file.

Pull Request resolved: https://github.com/pytorch/data/pull/578

Reviewed By: bearzx

Differential Revision: D37716058

Pulled By: ejguan

fbshipit-source-id: 00e03b287a0483d1769182a17817267f3ea14b9f