### PR TITLE
Fix target folder for official release

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -432,6 +432,9 @@ jobs:
           elif [[ $TARGET_FOLDER == tags/* ]]; then
             TARGET_FOLDER=${TARGET_FOLDER:5}
           elif [[ $TARGET_FOLDER == v* ]] && [[ ${{ inputs.pre_dev_release }} == false ]]; then
+            if [[ $TARGET_FOLDER == v*.*.* ]]; then
+              TARGET_FOLDER=${TARGET_FOLDER%.*}
+            fi
             TARGET_FOLDER=${TARGET_FOLDER:1}
           fi
           echo "::set-output name=value::$TARGET_FOLDER"


### PR DESCRIPTION
During preparing the minor release, the document folder is changed from `0.4.0` to `0.4`. For the official release, the workflow to extract target folder from tag for the official release should be modified correspondingly.