### PR TITLE
Fix target folder for official release (#687)

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -415,6 +415,9 @@ jobs:
           elif [[ $TARGET_FOLDER == tags/* ]]; then
             TARGET_FOLDER=${TARGET_FOLDER:5}
           elif [[ $TARGET_FOLDER == v* ]] && [[ ${{ inputs.pre_dev_release }} == false ]]; then
+            if [[ $TARGET_FOLDER == v*.*.* ]]; then
+              TARGET_FOLDER=${TARGET_FOLDER%.*}
+            fi
             TARGET_FOLDER=${TARGET_FOLDER:1}
           fi
           echo "::set-output name=value::$TARGET_FOLDER"


### PR DESCRIPTION
Summary:
During preparing the minor release, the document folder is changed from `0.4.0` to `0.4`. For the official release, the workflow to extract target folder from tag for the official release should be modified correspondingly.

Pull Request resolved: https://github.com/pytorch/data/pull/687

Reviewed By: NivekT

Differential Revision: D38128675

Pulled By: ejguan

fbshipit-source-id: a1e7a83881c9d4c7ab7610629da44b8dca99bb0a
