### PR TITLE
Add conda env for upload and extend timeout for S3 to reduce flakiness

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -398,6 +398,9 @@ jobs:
           CONDA_NIGHTLY_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_NIGHTLY_PYTORCHBOT_TOKEN }}
           CONDA_TEST_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_TEST_PYTORCHBOT_TOKEN }}
         run: |
+          conda create -y --name conda_upload_env
+          conda activate conda_upload_env
+
           conda install -yq anaconda-client
           conda install -c conda-forge -yq jq
 

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -290,7 +290,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
             "s3://aft-vbi-pds/bin-images/111",
             "s3://aft-vbi-pds/bin-images/222",
         ]
-        s3_lister_dp = S3FileLister(IterableWrapper(file_urls), region="us-east-1")
+        s3_lister_dp = S3FileLister(IterableWrapper(file_urls), request_timeout_ms=10000, region="us-east-1")
         self.assertEqual(sum(1 for _ in s3_lister_dp), 2212, f"{input} failed")
 
         # S3FileLister: incorrect inputs


### PR DESCRIPTION
### Changes

- Fix conda environment for conda upload
- Extend timeout from 3 seconds to 10 seconds for S3 Lister to reduce recent flakiness of the test
