### PR TITLE
[DataLoader2] Implementing single iterator constraint

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -43,6 +43,38 @@ class ConcurrencySpec:
     persistent_workers: bool = False
 
 
+class _DataLoader2Iterator(Iterator):
+    def __init__(self, dataloader: "DataLoader2", iterator_id: int):
+        self.dataloader = dataloader
+        self.iterator_id = iterator_id
+
+    def __next__(self) -> T_co:
+        if self.iterator_id == self.dataloader.valid_iterator_id:
+            self.dataloader._reset_iter = True
+            try:
+                return next(self.dataloader._datapipe_iter)  # type: ignore[arg-type]
+            except PauseIteration:
+                raise StopIteration
+            except StopIteration:
+                if self.dataloader.reading_service is not None:
+                    self.dataloader.reading_service.finalize_iteration()
+                raise
+        else:
+            raise RuntimeError(
+                "This iterator has been invalidated because another iterator has been created "
+                "from the same DataLoader2.\n"
+                "This may be caused multiple references to the same DataLoader2. "
+                "For feedback regarding this single iterator per DataLoader2 constraint, feel free "
+                "to comment on this issue: https://github.com/pytorch/data/issues/45."
+            )
+
+    def __getattr__(self, name):
+        """
+        To delegate operations such as `limit`, `pause`, `resume`, `__getstate__`
+        """
+        return getattr(self.dataloader, name)
+
+
 class DataLoader2(Generic[T_co]):
     def __init__(
         self,
@@ -53,7 +85,7 @@ class DataLoader2(Generic[T_co]):
         self.datapipe = datapipe
         self._adapted: bool = False
         self._datapipe_iter: Optional[Iterator[T_co]] = None
-        self._reset_iter: bool = True
+        self._reset_iter: bool = True  # Sets to `False` when __iter__ starts, and `True` when `StopIteration``
         # TODO(630): Some ReadingServices might want to validate adapters, we can add this feature
         if datapipe_adapter_fn is None:
             self.datapipe_adapter_fns = None
@@ -62,8 +94,9 @@ class DataLoader2(Generic[T_co]):
         else:
             self.datapipe_adapter_fns = [datapipe_adapter_fn]
         self.reading_service = reading_service
-        self.reading_service_state: Optional[bytes] = None
+        self.reading_service_state: Optional[bytes] = None  # is not `None` when `load_state_dict` is called
         self._terminated: bool = False
+        self.valid_iterator_id: Optional[int] = None
 
         if self.datapipe_adapter_fns is not None:
             for adapter_fn in self.datapipe_adapter_fns:
@@ -88,25 +121,16 @@ class DataLoader2(Generic[T_co]):
                 self.reading_service.initialize_iteration()
 
             self._datapipe_iter = iter(self.datapipe)
-
             self._reset_iter = False
 
-        return self
-
-    def __next__(self) -> T_co:
-        if self._reset_iter:
-            raise StopIteration
-        try:
-            return next(self._datapipe_iter)  # type: ignore[arg-type]
-        except PauseIteration:
-            raise StopIteration
-        except StopIteration:
-            if self.reading_service is not None:
-                self.reading_service.finalize_iteration()
-            self._reset_iter = True
-            raise
+        self.valid_iterator_id = 0 if self.valid_iterator_id is None else self.valid_iterator_id + 1
+        return _DataLoader2Iterator(self, self.valid_iterator_id)
 
     def __getattr__(self, name: str) -> Any:
+        """
+        Delegate methods (e.g. `limit`, `pause`, `resume`, etc) to the iterator
+        created by the ReadingService and DataPipe.
+        """
         if self._datapipe_iter is None:
             raise AttributeError
         return getattr(self._datapipe_iter, name)
@@ -175,7 +199,8 @@ class DataLoader2(Generic[T_co]):
         # iterator has already been created: 1) iterator is just created 2) iterator is created and iter is exhausted
         if self._datapipe_iter is not None:
             raise RuntimeError(
-                "DataLoaderV2 iterator has already been created, `load_state_dict()` can’t be called. Please create a new dataloader in order to use load state dict."
+                "DataLoaderV2 iterator has already been created, `load_state_dict()` can’t be called. "
+                "Please create a new dataloader in order to use load state dict."
             )
 
         serialized_datapipe = state[SERIALIZED_DATAPIPE_KEY_NAME]

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -146,10 +146,11 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
 
     def initialize(self, datapipe: DataPipe) -> DataPipe:
         if self.num_workers == 0:
-            # TODO(616): Warn and recommend usage of InPorcessReadingService
+            # TODO(616): Warn and recommend usage of InProcessReadingService
             return datapipe
         for worker_id in range(self.num_workers):
-            # TODO(617): Separate into function, because we also need to apply distributed seed and call it inside process
+            # TODO(617): Separate into function, because we also need to apply distributed seed
+            #            and call it inside process
             call_inside_process = functools.partial(self.init_datapipe_process, self.num_workers, worker_id)
             ctx = mp.get_context(self.multiprocessing_context)
             (process, req_queue, res_queue) = communication.eventloop.SpawnProcessForDataPipeline(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #700

Changes:
* Imposing the single iterator constraint on `DataLoader2` by having its `__iter__` method returns a wrapper that can track if an iterator is valid or not
* Previously, `__iter__` returns `self`, but now it will return an instance of `_DataLoader2Iterator`
* Aside from the behavior related to reset (see below), we expect other behaviors to stay the same.

Prior behavior:
```python
dl = DataLoader2(IterableWrapper(range(10)))
it1 = iter(dl)
print(next(it1))  # 0
it2 = iter(dl)  # No reset here
print(next(it2))  # 1
print(next(it1))  # 2
```

New behavior with this PR:
```python
dl = DataLoader2(IterableWrapper(range(10)))
it1 = iter(dl)
print(next(it1))  # 0
it2 = iter(dl)  # DataLoader2 resets with the creation of a new iterator
print(next(it2))  # 0
print(next(it1))  # Raises exception, since it1 is no longer valid
```

Differential Revision: [D38262867](https://our.internmc.facebook.com/intern/diff/D38262867)