### PR TITLE
Change release_type on release branch for testing workflow

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -43,7 +43,11 @@ jobs:
           elif [[ "${{ inputs.branch }}" == release/* ]] && [[ ${{ inputs.pre_dev_release }} == true ]]; then
             RELEASE_TYPE=test
           else
-            RELEASE_TYPE=nightly
+            if [[ "${{ github.base_ref }}" == release/* ]]; then
+              RELEASE_TYPE=test
+            else
+              RELEASE_TYPE=nightly
+            fi
           fi
           echo "Release Type: $RELEASE_TYPE"
           echo "::set-output name=type::$RELEASE_TYPE"


### PR DESCRIPTION
When `input_branch` is empty, the testing workflow should determine which PyTorch release type should be used for testing PR.

You can find the testing result from the cherry-picking PR #716