### PR TITLE
[WIP][DataPipe] Add RandomSplitter (with buffer)

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -1,3 +1,4 @@
+
 Iterable-style DataPipes
 ==========================
 
@@ -178,6 +179,7 @@ A miscellaneous set of DataPipes with different functionalities.
     IterableWrapper
     MapToIterConverter
     OnDiskCacheHolder
+    RandomSplitter
     ShardingFilter
 
 Selecting DataPipes

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -945,6 +945,38 @@ class TestIterDataPipe(expecttest.TestCase):
         # __len__ Test: length matches the length of the shortest input
         self.assertEqual(len(output_dp), 10)
 
+    def test_random_splitter_iterdatapipe(self):
+
+        n_epoch = 2
+
+        # Functional Test: Split results are the same across epochs
+        dp = IterableWrapper(range(10))
+        train, validation = dp.random_split(total_length=10, weights=[0.5, 0.5], seed=0)
+        results = []
+        for _ in range(n_epoch):
+            res = list(train)
+            self.assertEqual(5, len(res))
+            results.append(res)
+        self.assertEqual(results[0], results[1])
+        valid_res = list(validation)
+        self.assertEqual(5, len(valid_res))
+        self.assertEqual(list(range(10)), sorted(results[0] + valid_res))
+
+        # Functional Test: DataPipe can split into 3 DataPipes
+        dp = IterableWrapper(range(10))
+        train, validation, test = dp.random_split(total_length=10, weights=[0.6, 0.2, 0.2], seed=0)
+        results = []
+        for _ in range(n_epoch):
+            res = list(train)
+            self.assertEqual(6, len(res))
+            results.append(res)
+        self.assertEqual(results[0], results[1])
+        valid_res = list(validation)
+        self.assertEqual(2, len(valid_res))
+        test_res = list(test)
+        self.assertEqual(2, len(test_res))
+        self.assertEqual(list(range(10)), sorted(results[0] + valid_res + test_res))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/gen_pyi.py
+++ b/tools/gen_pyi.py
@@ -71,6 +71,7 @@ def gen_pyi() -> None:
         "dataframe": "torcharrow.DataFrame",
         "end_caching": "IterDataPipe",
         "unzip": "List[IterDataPipe]",
+        "random_split": "List[IterDataPipe]",
         "read_from_tar": "IterDataPipe",
         "read_from_xz": "IterDataPipe",
         "read_from_zip": "IterDataPipe",

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -102,6 +102,7 @@ from torchdata.datapipes.iter.util.plain_text_reader import (
     CSVParserIterDataPipe as CSVParser,
     LineReaderIterDataPipe as LineReader,
 )
+from torchdata.datapipes.iter.util.randomsplitter import RandomSplitterIterDataPipe as RandomSplitter
 from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterDataPipe as RarArchiveLoader
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
@@ -181,6 +182,7 @@ __all__ = [
     "OnlineReader",
     "ParagraphAggregator",
     "ParquetDataFrameLoader",
+    "RandomSplitter",
     "RarArchiveLoader",
     "RoutedDecoder",
     "Rows2Columnar",

--- a/torchdata/datapipes/iter/util/randomsplitter.py
+++ b/torchdata/datapipes/iter/util/randomsplitter.py
@@ -1,0 +1,92 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+from copy import deepcopy
+from functools import partial
+from typing import List, Sequence, TypeVar, Union
+
+from torch.utils.data.datapipes.iter.combining import _ChildDataPipe, _DemultiplexerIterDataPipe
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+K = TypeVar("K")
+
+
+@functional_datapipe("random_split")
+class RandomSplitterIterDataPipe(IterDataPipe):
+    r"""
+    Randomly split samples from a source DataPipe into multiple DataPipes (functional name: ``random_split``).
+    Samples are temporily stored in a buffer such that child DataPipes can be used simultaneously.
+    Note that multiple iterations of this DataPipe will yield the same split for consistency across epochs.
+
+    Args:
+        source_datapipe: Iterable DataPipe being split
+        total_length: Length of the source
+        weights: a list of weights; the length of this list determines how many output DataPipes there will be.
+        seed: random seed used to determine the split
+        buffer_size: determines the maximum number of unread
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(range(10))
+        >>> train, validation = dp.random_split(total_length=10, weights=[0.5, 0.5], seed=0)
+        >>> list(train)
+        [1, 3, 4, 5, 9]
+    """
+
+    def __new__(
+        cls,
+        source_datapipe: IterDataPipe[K],
+        total_length: int,
+        weights: Sequence[Union[int, float]],
+        seed,
+        buffer_size: int = 1000,
+    ):
+        norm_weights = cls.normalize_weights(weights, total_length)
+        instance_ids = list(range(len(weights)))
+
+        # The implementation basically uses Demux but with a custom classifier function and additional reset operation
+        container = _RandomSplitterIterDataPipe(
+            source_datapipe, instance_ids, seed, norm_weights, buffer_size
+        )  # type: ignore[arg-type]
+        return [_ChildDataPipe(container, i) for i in range(len(instance_ids))]
+
+    @staticmethod
+    def normalize_weights(weights, total_length):
+        total_weight = sum(weights)
+        return [round(float(w) * total_length / total_weight) for w in weights]
+
+
+class _RandomSplitterIterDataPipe(_DemultiplexerIterDataPipe):
+    def __init__(
+        self,
+        datapipe: IterDataPipe,
+        instance_ids: List[int],
+        seed,
+        initial_weights: Sequence[Union[int, float]],
+        buffer_size: int = 1000,
+    ):
+        super().__init__(
+            datapipe, len(instance_ids), classifier_fn=None, drop_none=False, buffer_size=buffer_size
+        )  # type: ignore[arg-type]
+        self.instance_ids = instance_ids
+        self.seed = seed
+        self.initial_weights = initial_weights
+
+        self.rng = random.Random(self.seed)
+        self.classifier_fn = partial(self.draw, instance_ids, deepcopy(self.initial_weights), self.rng)
+
+    def reset(self):
+        super().reset()
+        self.rng = random.Random(self.seed)
+        self.classifier_fn = partial(self.draw, self.instance_ids, deepcopy(self.initial_weights), self.rng)
+
+    @staticmethod
+    def draw(population, weights, rng, _):
+        idx = rng.choices(population, weights)[0]
+        weights[idx] -= 1
+        return idx


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #723

This PR adds RandomSplitter with an implementation that uses a buffer through `demux`, thus allowing all child DataPipes to be used simultaneously. This may not work for the memory-bound cases.

TODO:
* Decide if we like a buffer-less version better. Or we can add both.
* Determines if the API related to randomness needs further extension (we might need to add `set_seed`)
* More tests.

See https://github.com/pytorch/data/issues/712 for related discussion.
See #724 for the version WITHOUT buffer.