### PR TITLE
[DataPipe] Add RandomSplitter (without buffer)

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -1,3 +1,4 @@
+
 Iterable-style DataPipes
 ==========================
 
@@ -178,6 +179,7 @@ A miscellaneous set of DataPipes with different functionalities.
     IterableWrapper
     MapToIterConverter
     OnDiskCacheHolder
+    RandomSplitter
     ShardingFilter
 
 Selecting DataPipes

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -945,44 +945,6 @@ class TestIterDataPipe(expecttest.TestCase):
         # __len__ Test: length matches the length of the shortest input
         self.assertEqual(len(output_dp), 10)
 
-    # def test_random_splitter_iterdatapipe(self):
-    #
-    #     n_epoch = 2
-    #
-    #     # Functional Test: Split results are the same across epochs
-    #     dp = IterableWrapper(range(10))
-    #     train = dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="train")
-    #     results = []
-    #     for _ in range(n_epoch):
-    #         res = list(train)
-    #         self.assertEqual(5, len(res))
-    #         results.append(res)
-    #     self.assertEqual(results[0], results[1])
-    #     valid_res = list(dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="valid"))
-    #     self.assertEqual(5, len(valid_res))
-    #     self.assertEqual(list(range(10)), sorted(results[0] + valid_res))
-    #
-    #     # Functional Test: DataPipe can split into 3 DataPipes
-    #     dp = IterableWrapper(range(10))
-    #     train = dp.random_split(
-    #         total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="train"
-    #     )
-    #     results = []
-    #     for _ in range(n_epoch):
-    #         res = list(train)
-    #         self.assertEqual(6, len(res))
-    #         results.append(res)
-    #     self.assertEqual(results[0], results[1])
-    #     valid_res = list(
-    #         dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="valid")
-    #     )
-    #     self.assertEqual(2, len(valid_res))
-    #     test_res = list(
-    #         dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="test")
-    #     )
-    #     self.assertEqual(2, len(test_res))
-    #     self.assertEqual(list(range(10)), sorted(results[0] + valid_res + test_res))
-
     def test_random_splitter_iterdatapipe(self):
 
         n_epoch = 2

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -945,6 +945,44 @@ class TestIterDataPipe(expecttest.TestCase):
         # __len__ Test: length matches the length of the shortest input
         self.assertEqual(len(output_dp), 10)
 
+    def test_random_splitter_iterdatapipe(self):
+
+        n_epoch = 2
+
+        # Functional Test: Split results are the same across epochs
+        dp = IterableWrapper(range(10))
+        train = dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="train")
+        results = []
+        for _ in range(n_epoch):
+            res = list(train)
+            self.assertEqual(5, len(res))
+            results.append(res)
+        self.assertEqual(results[0], results[1])
+        valid_res = list(dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="valid"))
+        self.assertEqual(5, len(valid_res))
+        self.assertEqual(list(range(10)), sorted(results[0] + valid_res))
+
+        # Functional Test: DataPipe can split into 3 DataPipes
+        dp = IterableWrapper(range(10))
+        train = dp.random_split(
+            total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="train"
+        )
+        results = []
+        for _ in range(n_epoch):
+            res = list(train)
+            self.assertEqual(6, len(res))
+            results.append(res)
+        self.assertEqual(results[0], results[1])
+        valid_res = list(
+            dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="valid")
+        )
+        self.assertEqual(2, len(valid_res))
+        test_res = list(
+            dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.2, "test": 0.2}, seed=0, target="test")
+        )
+        self.assertEqual(2, len(test_res))
+        self.assertEqual(list(range(10)), sorted(results[0] + valid_res + test_res))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/gen_pyi.py
+++ b/tools/gen_pyi.py
@@ -71,6 +71,7 @@ def gen_pyi() -> None:
         "dataframe": "torcharrow.DataFrame",
         "end_caching": "IterDataPipe",
         "unzip": "List[IterDataPipe]",
+        "random_split": "List[IterDataPipe]",
         "read_from_tar": "IterDataPipe",
         "read_from_xz": "IterDataPipe",
         "read_from_zip": "IterDataPipe",

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -102,6 +102,7 @@ from torchdata.datapipes.iter.util.plain_text_reader import (
     CSVParserIterDataPipe as CSVParser,
     LineReaderIterDataPipe as LineReader,
 )
+from torchdata.datapipes.iter.util.randomsplitter import RandomSplitterIterDataPipe as RandomSplitter
 from torchdata.datapipes.iter.util.rararchiveloader import RarArchiveLoaderIterDataPipe as RarArchiveLoader
 from torchdata.datapipes.iter.util.rows2columnar import Rows2ColumnarIterDataPipe as Rows2Columnar
 from torchdata.datapipes.iter.util.samplemultiplexer import SampleMultiplexerDataPipe as SampleMultiplexer
@@ -181,6 +182,7 @@ __all__ = [
     "OnlineReader",
     "ParagraphAggregator",
     "ParquetDataFrameLoader",
+    "RandomSplitter",
     "RarArchiveLoader",
     "RoutedDecoder",
     "Rows2Columnar",

--- a/torchdata/datapipes/iter/util/randomsplitter.py
+++ b/torchdata/datapipes/iter/util/randomsplitter.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+from typing import Dict, TypeVar, Union
+
+from torchdata.datapipes import functional_datapipe
+from torchdata.datapipes.iter import IterDataPipe
+
+K = TypeVar("K")
+
+
+@functional_datapipe("random_split")
+class RandomSplitterIterDataPipe(IterDataPipe):
+    r"""
+    Randomly split samples from a source DataPipe into groups(functional name: ``random_split``).
+    Since there is no buffer, only one group of samples can be accessed at any time.
+    Note that multiple iterations of this DataPipe will yield the same split for consistency across epochs.
+
+    Args:
+        source_datapipe: Iterable DataPipe being split
+        total_length: Length of the source
+        weights: Dict of weights; the length of this list determines how many output DataPipes there will be.
+        seed: random seed used to determine the split
+        target: key of the group that will be yielded in the current iteration
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(range(10))
+        >>> train = dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="train")
+        >>> list(train)
+        [1, 3, 4, 5, 9]
+        >>> valid = dp.random_split(total_length=10, weights={"train": 0.5, "valid": 0.5}, seed=0, target="valid")
+        >>> list(valid)
+        [2, 8, 6, 7, 0]
+    """
+
+    def __init__(
+        self,
+        source_datapipe: IterDataPipe,
+        total_length: int,
+        weights: Dict[K, Union[int, float]],
+        seed,
+        target: K,
+    ):
+        self.source_datapipe = source_datapipe
+        self.total_length = total_length
+        self.seed = seed
+        self.norm_weights = self.normalize_weights(weights, total_length)
+        self.keys = list(weights.keys())
+        self.key_to_index = {k: i for i, k in enumerate(self.keys)}
+        self.weights = [self.norm_weights[k] for k in self.keys]
+        assert target in self.keys
+        self.target = target
+        self.rng = random.Random(self.seed)
+
+    def __iter__(self):
+        for sample in self.source_datapipe:
+            if self.draw() == self.target:
+                yield sample
+
+    def draw(self):
+        selected_key = self.rng.choices(self.keys, self.weights)[0]
+        self.weights[self.key_to_index[selected_key]] -= 1
+        return selected_key
+
+    @staticmethod
+    def normalize_weights(weights, total_length: int):
+        total_weight = sum(weights.values())
+        return {k: round(float(w) * total_length / total_weight) for k, w in weights.items()}
+
+    def reset(self):
+        self.rng = random.Random(self.seed)
+        self.weights = [self.norm_weights[k] for k in self.keys]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #724

This PR adds RandomSplitter without a buffer. The upside is that this uses less memory (good for memory-bound cases) but the downside are 1) only one group can be iterated through at a time and 2) it skips over all the groups that do not match the target (which is potentially wasteful).

Implementation note:
* I decided against reusing `_ChildDataPipe` since its features are overly complicated for this use case.
* I also decided against having an option to change seed automatically after each iteration, because there are situations where the first iteration is for `test` and the second iteration is for `valid`. Changing seed will be confusing and causes inconsistency.

See #712 for related discussion.
See #723 for the version with buffer.

Differential Revision: [D38675266](https://our.internmc.facebook.com/intern/diff/D38675266)