### PR TITLE
Unify implementation of in_batch_shuffle with `IterDataPipe.shuffle`

### DIFF
--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -61,10 +61,11 @@ class InBatchShufflerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
                 yield DataChunk(new_batch)
 
     def reset(self) -> None:
-        if self._enabled and self._seed is None:
-            self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
-        self._rng.seed(self._seed)
-        self._seed = None
+        if self._enabled:
+            if self._seed is None:
+                self._seed = int(torch.empty((), dtype=torch.int64).random_().item())
+            self._rng.seed(self._seed)
+            self._seed = None
 
     def __len__(self) -> int:
         return len(self.datapipe)


### PR DESCRIPTION
Fixes #519

This PR takes reference from the modification from [my PR](https://github.com/pytorch/pytorch/pull/83535) for `IterDataPipe.shuffle`.
- Add `set_seed`
- Add `set_shuffle`
- Make `RNG` lazily seeded
- Make serialization works

There will be another PR in PyTorch core to make `shuffle` related functions ([`apply_shuffle_settings`](https://github.com/pytorch/pytorch/blob/38348362608a47371c65d7fd52db138b4c6a5d65/torch/utils/data/graph_settings.py#L48), [`apply_shuffle_seed`](https://github.com/pytorch/pytorch/blob/38348362608a47371c65d7fd52db138b4c6a5d65/torch/utils/data/graph_settings.py#L69)) working with all `DataPipe` that has `set_seed` and `set_shuffle` APIs rather than only `iter.Shuffler` or `map.Shuffler`.