### PR TITLE
[DataPipe] Adding LengthSetterIterDataPipe

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -176,6 +176,7 @@ A miscellaneous set of DataPipes with different functionalities.
     HashChecker
     InMemoryCacheHolder
     IterableWrapper
+    LengthSetter
     MapToIterConverter
     OnDiskCacheHolder
     ShardingFilter

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -1146,6 +1146,25 @@ class TestIterDataPipe(expecttest.TestCase):
         self.assertEqual(expected_res[:n_elements_before_reset], res_before_reset)
         self.assertEqual(expected_res, res_after_reset)
 
+    def test_length_setter_iterdatapipe(self):
+        input_dp = IterableWrapper(range(10))
+
+        # Functional Test: Setting length doesn't change the content of the DataPipe
+        dp: IterDataPipe = input_dp.set_length(3)
+        self.assertEqual(list(range(10)), list(dp))
+
+        # __len__ Test: Length is as specified and propagates through
+        dp = input_dp.set_length(3).map(lambda x: x + 1)
+        self.assertEqual(3, len(dp))
+
+        # Reset Test:
+        n_elements_before_reset = 2
+        dp = input_dp.set_length(3)
+        expected_res = list(range(10))
+        res_before_reset, res_after_reset = reset_after_n_next_calls(dp, n_elements_before_reset)
+        self.assertEqual(expected_res[:n_elements_before_reset], res_before_reset)
+        self.assertEqual(expected_res, res_after_reset)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -165,6 +165,8 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
         self._serialization_test_helper(dp2, use_dill=use_dill)
 
     def test_serializable(self):
+        # A tuple of 4 objects
+        # (DataPipeConstructor, custom_input_datapipe=None, dp_args=(), dp_kwargs={})
         picklable_datapipes: List = [
             (iterdp.BatchMapper, IterableWrapper([(0, 0), (0, 0), (0, 0), (0, 0)]), (_fake_batch_fn, 2, 1), {}),
             (iterdp.BucketBatcher, IterableWrapper([0, 0, 0, 0, 0, 0, 0]), (5,), {}),
@@ -234,6 +236,7 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
                 (),
                 {},
             ),
+            (iterdp.LengthSetter, None, (3,), {}),
             (
                 iterdp.LineReader,
                 IterableWrapper(

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -92,7 +92,7 @@ from torchdata.datapipes.iter.util.decompressor import (
     ExtractorIterDataPipe as Extractor,
 )
 from torchdata.datapipes.iter.util.hashchecker import HashCheckerIterDataPipe as HashChecker
-from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header
+from torchdata.datapipes.iter.util.header import HeaderIterDataPipe as Header, LengthSetterIterDataPipe as LengthSetter
 from torchdata.datapipes.iter.util.indexadder import (
     EnumeratorIterDataPipe as Enumerator,
     IndexAdderIterDataPipe as IndexAdder,
@@ -177,6 +177,7 @@ __all__ = [
     "IterKeyZipper",
     "IterableWrapper",
     "JsonParser",
+    "LengthSetter",
     "LineReader",
     "MapKeyZipper",
     "MapToIterConverter",

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -17,8 +17,9 @@ T_co = TypeVar("T_co", covariant=True)
 class HeaderIterDataPipe(IterDataPipe[T_co]):
     r"""
     Yields elements from the source DataPipe from the start, up to the specfied limit (functional name: ``header``).
-    This DataPipe can also be used to manually set the length of a DataPipe to a certain value; you
-    can do so by calling ``dp.header(desired_len)``.
+
+    If you would like to manually set the length of a DataPipe to a certain value; we recommend you to
+    use :class:`.LengthSetter`.
 
     Args:
         source_datapipe: the DataPipe from which elements will be yielded
@@ -60,3 +61,37 @@ class HeaderIterDataPipe(IterDataPipe[T_co]):
                 "The actual value may be smaller if the actual length of source_datapipe is smaller than the limit."
             )
             return self.limit
+
+
+@functional_datapipe("set_length")
+class LengthSetterIterDataPipe(IterDataPipe[T_co]):
+    r"""
+    Set the length attribute of the DataPipe, which is returned by ``__len__`` (functional name: ``set_length``).
+    This can be used after DataPipes whose final length cannot be known in advance (e.g. ``filter``). If you
+    know the final length with certainty, you can manually set it for usages by DataLoader or other DataPipes.
+
+    This DataPipe differs from :class:`.Header` in that this doesn't restrict the number of elements that
+    can be yielded from the DataPipe; this is strictly used for setting an attribute so that it can be used later.
+
+    Args:
+        source_datapipe: a DataPipe
+        length: the integer value that will be set as the length
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper
+        >>> dp = IterableWrapper(range(10)).filter(lambda x: x < 5).set_length(5)
+        >>> list(dp)
+        [0, 1, 2, 3, 4]
+        >>> len(dp)
+        5
+    """
+
+    def __init__(self, source_datapipe: IterDataPipe[T_co], length: int) -> None:
+        self.source_datapipe: IterDataPipe[T_co] = source_datapipe
+        self.length: int = length
+
+    def __iter__(self) -> Iterator[T_co]:
+        yield from self.source_datapipe
+
+    def __len__(self) -> int:
+        return self.length


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #747

This DataPipe allows users to manually set length of an `IterDataPipe` with no other side effect. This is useful for DataPipes whose final length cannot be known in advance (e.g. ``filter``). If you know the final length with certainty, you can manually set it for usages by DataLoader or other DataPipes.

Previously, users theoretically could use `.header(length)` to manually set length. However, the UX is suboptimal in that 1) the name is not obvious, and 2) warnings are raised unless the HeaderDataPipe has been fully traversed once to confirm the length.

Differential Revision: [D38989359](https://our.internmc.facebook.com/intern/diff/D38989359)