### PR TITLE
Added default no-op function for flatmap

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -697,6 +697,7 @@ class TestIterDataPipe(expecttest.TestCase):
 
         flatmapped_dp = source_dp.flatmap(fn)
         expected_list = list(itertools.chain(*[(e, e * 10) for e in source_dp]))
+
         self.assertEqual(expected_list, list(flatmapped_dp))
 
         # Funtional Test: Specify input_col
@@ -712,6 +713,19 @@ class TestIterDataPipe(expecttest.TestCase):
 
         input_col_2_dp = tuple_source_dp.flatmap(mul_fn, input_col=(0, 2))
         self.assertEqual(list(itertools.chain(*[(-2, 2) for _ in range(20)])), list(input_col_2_dp))
+
+        # flatmap with no fn specified
+        default_dp = tuple_source_dp.flatmap()
+        self.assertEqual(list(itertools.chain(*[(n - 1, n, n + 1) for n in range(20)])), list(default_dp))
+
+        # flatmap with no fn specified, multiple input_col
+        default_dp = tuple_source_dp.flatmap(input_col=(0, 2))
+        self.assertEqual(list(itertools.chain(*[(n - 1, n + 1) for n in range(20)])), list(default_dp))
+
+        # flatmap with no fn specified, some special input
+        tuple_source_dp = IterableWrapper([[1, 2, [3, 4]], [5, 6, [7, 8]]])
+        default_dp = tuple_source_dp.flatmap(input_col=(0, 2))
+        self.assertEqual([1, [3, 4], 5, [7, 8]], list(default_dp))
 
         # Reset Test: reset the DataPipe after reading part of it
         n_elements_before_reset = 5

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -99,6 +99,7 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
 
     Note:
         The output from ``fn`` must be a Sequence. Otherwise, an error will be raised.
+        If no ``fn``, source DataPipe will be just flattened vertically.
 
     Args:
         datapipe: Source IterDataPipe
@@ -116,9 +117,11 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
     datapipe: IterDataPipe
     fn: Callable
 
-    def __init__(self, datapipe: IterDataPipe, fn: Callable, input_col=None) -> None:
+    def __init__(self, datapipe: IterDataPipe, fn: Callable = None, input_col=None) -> None:
         self.datapipe = datapipe
 
+        if fn is None:
+            fn = self._no_op_fn
         _check_unpickable_fn(fn)
         self.fn = fn  # type: ignore[assignment]
         self.input_col = input_col
@@ -138,6 +141,9 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
 
     def __len__(self) -> int:
         raise TypeError(f"{type(self).__name__}'s length relies on the output of its function.")
+
+    def _no_op_fn(self, e):
+        return e
 
 
 @functional_datapipe("drop")

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -15,13 +15,10 @@ T_co = TypeVar("T_co", covariant=True)
 
 def _no_op_fn(*args):
     """
-    No-operation function, returns passed arguments , always as iterable.
+    No-operation function, returns passed arguments.
     """
     if len(args) == 1:
-        try:
-            return iter(args[0])
-        except TypeError:
-            pass
+        return args[0]
     return args
 
 
@@ -111,7 +108,7 @@ class FlatMapperIterDataPipe(IterDataPipe[T_co]):
 
     Note:
         The output from ``fn`` must be a Sequence. Otherwise, an error will be raised.
-        If ``fn`` is ``None``, source DataPipe will be just flattened vertically.
+        If ``fn`` is ``None``, source DataPipe will be just flattened vertically, provided that items can be unpacked.
 
     Args:
         datapipe: Source IterDataPipe

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -9,9 +9,20 @@ from typing import Callable, Hashable, Iterator, List, Optional, Set, Sized, Typ
 
 from torch.utils.data import functional_datapipe, IterDataPipe
 from torch.utils.data.datapipes.utils.common import _check_unpickable_fn
-from torchdata.datapipes.utils.common import _no_op_fn
 
 T_co = TypeVar("T_co", covariant=True)
+
+
+def _no_op_fn(*args):
+    """
+    No-operation function, returns passed arguments , always as iterable.
+    """
+    if len(args) == 1:
+        try:
+            return iter(args[0])
+        except TypeError:
+            pass
+    return args
 
 
 @functional_datapipe("map_batches")

--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -24,5 +24,11 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
         )
 
 
-def _no_op_fn(e):
-    return e
+def _no_op_fn(*args):
+    """
+    No-operation function, returns passed arguments , always as iterable.
+    """
+    if len(args) == 1 and isinstance(args[0], (list, tuple)):
+        return args[0]
+    else:
+        return args

--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -22,3 +22,7 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
             f"binary stream within the tuple should have IOBase or"
             f"its subclasses as type, but it is type {type(data[1])}"
         )
+
+
+def _no_op_fn(e):
+    return e

--- a/torchdata/datapipes/utils/common.py
+++ b/torchdata/datapipes/utils/common.py
@@ -22,13 +22,3 @@ def validate_pathname_binary_tuple(data: Tuple[str, IOBase]):
             f"binary stream within the tuple should have IOBase or"
             f"its subclasses as type, but it is type {type(data[1])}"
         )
-
-
-def _no_op_fn(*args):
-    """
-    No-operation function, returns passed arguments , always as iterable.
-    """
-    if len(args) == 1 and isinstance(args[0], (list, tuple)):
-        return args[0]
-    else:
-        return args


### PR DESCRIPTION
Fixes #738 

### Changes

in datapipe's common functions:
- added _no_op_fn definition 

in FlatMapperIterDataPipe class
- added _no_op_fn method use for default callable use

