### PR TITLE
[DataPipe] Adding IterCallableWrapper

### DIFF
--- a/docs/source/torchdata.datapipes.iter.rst
+++ b/docs/source/torchdata.datapipes.iter.rst
@@ -178,6 +178,7 @@ A miscellaneous set of DataPipes with different functionalities.
     HashChecker
     InMemoryCacheHolder
     IterableWrapper
+    IterCallableWrapper
     LengthSetter
     MapToIterConverter
     OnDiskCacheHolder

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -219,6 +219,7 @@ class TestIterDataPipeSerialization(expecttest.TestCase):
                 (),
                 {"mode": "wb", "filepath_fn": partial(_filepath_fn, dir=self.temp_dir.name)},
             ),
+            (iterdp.IterCallableWrapper, partial(range, 10), (), {}),
             (
                 iterdp.IterKeyZipper,
                 IterableWrapper([("a", 100), ("b", 200), ("c", 300)]),

--- a/torchdata/datapipes/iter/__init__.py
+++ b/torchdata/datapipes/iter/__init__.py
@@ -97,6 +97,7 @@ from torchdata.datapipes.iter.util.indexadder import (
     EnumeratorIterDataPipe as Enumerator,
     IndexAdderIterDataPipe as IndexAdder,
 )
+from torchdata.datapipes.iter.util.itercallablewrapper import IterCallableWrapperIterDataPipe as IterCallableWrapper
 from torchdata.datapipes.iter.util.jsonparser import JsonParserIterDataPipe as JsonParser
 from torchdata.datapipes.iter.util.mux_longest import MultiplexerLongestIterDataPipe as MultiplexerLongest
 from torchdata.datapipes.iter.util.paragraphaggregator import ParagraphAggregatorIterDataPipe as ParagraphAggregator

--- a/torchdata/datapipes/iter/util/itercallablewrapper.py
+++ b/torchdata/datapipes/iter/util/itercallablewrapper.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torchdata.datapipes.iter import IterDataPipe
+
+
+class IterCallableWrapperIterDataPipe(IterDataPipe):
+    r"""
+    Given a callable that returns an iterable object, this IterDataPipe
+    creates the object and yields from it for each iteration.
+
+    This is different from :class:`.IterableWrapper` in that the callable is invoked once
+    for every new iteration. Whereas the ``iterable`` in :class:`.IterableWrapper` is
+    stored (possibly deep copied) once and re-read for each iteration; :class:`.IterableWrapper`
+    may be empty in the second iteration if ``iterable`` is an iterator.
+
+    Args:
+        callable: serializable Callable that returns an Iterable object
+
+    Example:
+        >>> from torchdata.datapipes.iter import IterableWrapper, IterCallableWrapper
+        >>> from itertools import compress, dropwhile
+        >>> from functools import partial
+        >>> data_dp = IterableWrapper(range(10))
+        >>> selector_dp = IterableWrapper([1, 0] * 5)
+        >>> compress_fn = partial(compress, data_dp, selector_dp)
+        >>> compress_dp = IterCallableWrapper(compress_fn)
+        >>> list(compress_dp)
+        [0, 2, 4, 6, 8]
+        >>> list(compress_dp)  # Repeat without issue in the second iteration
+        [0, 2, 4, 6, 8]
+        >>> dropwhile_dp = IterCallableWrapper(partial(dropwhile, lambda x: x < 5, data_dp))
+        >>> list(dropwhile_dp)
+        [5, 6, 7, 8, 9]
+    """
+
+    def __init__(self, callable):
+        self.callable = callable
+
+    def __iter__(self):
+        yield from self.callable()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #757

I was looking into ways to allow users to more easily use existing functions from other libraries to compose a IterDataPipe that they would like.

This DataPipe will allow users to more easily create an `IterDataPipe` from functions that output an iterable (e.g. `functools`  ongoing discussion in #756). Please see the examples in the docstring for use cases.

Any thoughts? I am open to changing the API and/or add more functionalities. From the snapshotting perspective, if the callable is stateless (e.g. `itertools.compress`), this DataPipe can easily be restored. If it is stateful, then we will have to fallback onto fast-forward for snapshot restoration.

Context:

`IterableWrapper` has some shortcomings; for instance, this can only be iterated through once:
```python
data_dp = IterableWrapper(range(10))
selector_dp = IterableWrapper([1, 0] * 5)
compress_dp = IterableWrapper(compress(data_dp, selector_dp))
list(compress_dp)  # [0, 2, 4, 6, 8]
list(compress_dp)  # [] - empty
```
This implementation allows multiple iterations:
```python
data_dp = IterableWrapper(range(10))
selector_dp = IterableWrapper([1, 0] * 5)
compress_fn = partial(compress, data_dp, selector_dp)
compress_dp = IterCallableWrapper(compress_fn)
list(compress_dp)  # [0, 2, 4, 6, 8]
list(compress_dp)  # [0, 2, 4, 6, 8]
```