### PR TITLE
Fix setup dependencies for building wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,11 @@ first_party_detection = false
 
 line-length = 120
 target-version = ["py37"]
+
+[build-system]
+requires = [
+	"setuptools",
+	"wheel",
+	"cmake",
+	"torch",
+]


### PR DESCRIPTION
Newer `setuptools` enforce strict subset of dependencies available when building the wheel. Thus `torch` needs to be listed as it's included in `setup.py`.

Tested by `pip install .` which was failing before and passes now.