### PR TITLE
Fix TorchVision tests caused by file renaming

### DIFF
--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -56,7 +56,7 @@ jobs:
           path: vision
 
       - name: Run torchvision builtin datasets tests
-        run: pytest --no-header -v vision/test/test_prototype_builtin_datasets.py
+        run: pytest --no-header -v vision/test/test_prototype_datasets_builtin.py
 
   torchtext:
     if: ${{ github.repository_owner == 'pytorch' }}


### PR DESCRIPTION
This PR is required since https://github.com/pytorch/vision/pull/6587 has been landed and shipped to TorchVision nightly.