### PR TITLE
Enable 3.10 tests & fix bad protobuf version for MacOS Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           - 3.7
           - 3.8
           - 3.9
+          - "3.10"
     steps:
       - name: Get PyTorch Channel
         shell: bash

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,5 +5,8 @@ s3fs
 iopath == 0.1.9
 numpy
 rarfile
-protobuf < 4
+# TODO: Revert the change after protobuf (3.20.2) is fixed for MacOS Python 3.10
+# See: https://github.com/protocolbuffers/protobuf/issues/10571
+protobuf < 4; sys_platform != 'darwin' or python_version != '3.10'
+protobuf == 3.20.1; sys_platform == 'darwin' and python_version == '3.10'
 datasets


### PR DESCRIPTION
Fixes #775

### Changes

- Enable CI for Python 3.10
- Fix the version of protobuf in test to 3.20.1 when it's MacOS and Python 3.10
