### PR TITLE
add `padden_tokens` so max_token_count is not exceeded

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -714,7 +714,7 @@ class TestIterDataPipe(expecttest.TestCase):
         # Functional test: Padded tokens not exceeding max_token_count
         source_data = ["111", "1111", "11111"]  # 3, 4, 5
         source_dp = IterableWrapper(source_data)
-        batch_dp = source_dp.max_token_bucketize(max_token_count=7, padded_tokens=True)
+        batch_dp = source_dp.max_token_bucketize(max_token_count=7, count_padding=True)
         exp_batch = [["111"], ["1111"], ["11111"]]
         self.assertEqual(list(batch_dp), exp_batch)
 

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -712,7 +712,7 @@ class TestIterDataPipe(expecttest.TestCase):
         self.assertEqual(list(batch_dp), exp_batch)
 
         # Functional test: Padded tokens not exceeding max_token_count
-        source_data = ["111", "111", "111", "1111", ]  # 3, 3, 3, 4
+        source_data = ["111", "111", "111", "1111"]  # 3, 3, 3, 4
         source_dp = IterableWrapper(source_data)
         batch_dp = source_dp.max_token_bucketize(max_token_count=7, include_padding=True)
         exp_batch = [["111", "111"], ["111"], ["1111"]]

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -712,10 +712,10 @@ class TestIterDataPipe(expecttest.TestCase):
         self.assertEqual(list(batch_dp), exp_batch)
 
         # Functional test: Padded tokens not exceeding max_token_count
-        source_data = ["111", "1111", "11111"]  # 3, 4, 5
+        source_data = ["111", "111", "111", "1111", ]  # 3, 3, 3, 4
         source_dp = IterableWrapper(source_data)
-        batch_dp = source_dp.max_token_bucketize(max_token_count=7, count_padding=True)
-        exp_batch = [["111"], ["1111"], ["11111"]]
+        batch_dp = source_dp.max_token_bucketize(max_token_count=7, include_padding=True)
+        exp_batch = [["111", "111"], ["111"], ["1111"]]
         self.assertEqual(list(batch_dp), exp_batch)
 
         # Functional test: sample length exceeding max_token_count

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -703,6 +703,20 @@ class TestIterDataPipe(expecttest.TestCase):
         self.assertEqual(res_before_reset, exp_before_reset)
         self.assertEqual(res_after_reset, exp_after_reset)
 
+        # Functional test: Padded tokens exceeding max_token_count
+        source_data = ["111", "1111", "11111"]  # 3, 4, 5
+        source_dp = IterableWrapper(source_data)
+        batch_dp = source_dp.max_token_bucketize(max_token_count=6)
+        exp_batch = [['111', '1111'], ['11111']]
+        self.assertEqual(list(batch_dp), exp_batch)
+
+        # Functional test: Padded tokens not exceeding max_token_count
+        source_data = ["111", "1111", "11111"]  # 3, 4, 5
+        source_dp = IterableWrapper(source_data)
+        batch_dp = source_dp.max_token_bucketize(max_token_count=6, padded_tokens=True)
+        exp_batch = [['111'], ['1111'], ['11111']]
+        self.assertEqual(list(batch_dp), exp_batch)
+
         # __len__ Test: returns the number of batches
         with self.assertRaises(TypeError):
             len(batch_dp)

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -706,15 +706,16 @@ class TestIterDataPipe(expecttest.TestCase):
         # Functional test: Padded tokens exceeding max_token_count
         source_data = ["111", "1111", "11111"]  # 3, 4, 5
         source_dp = IterableWrapper(source_data)
-        batch_dp = source_dp.max_token_bucketize(max_token_count=6)
-        exp_batch = [['111', '1111'], ['11111']]
+        batch_dp = source_dp.max_token_bucketize(max_token_count=7)
+        exp_batch = [["111", "1111"], ["11111"]]
+
         self.assertEqual(list(batch_dp), exp_batch)
 
         # Functional test: Padded tokens not exceeding max_token_count
         source_data = ["111", "1111", "11111"]  # 3, 4, 5
         source_dp = IterableWrapper(source_data)
-        batch_dp = source_dp.max_token_bucketize(max_token_count=6, padded_tokens=True)
-        exp_batch = [['111'], ['1111'], ['11111']]
+        batch_dp = source_dp.max_token_bucketize(max_token_count=7, padded_tokens=True)
+        exp_batch = [["111"], ["1111"], ["11111"]]
         self.assertEqual(list(batch_dp), exp_batch)
 
         # __len__ Test: returns the number of batches

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -718,6 +718,13 @@ class TestIterDataPipe(expecttest.TestCase):
         exp_batch = [["111"], ["1111"], ["11111"]]
         self.assertEqual(list(batch_dp), exp_batch)
 
+        # Functional test: sample length exceeding max_token_count
+        source_data = ["111"]
+        source_dp = IterableWrapper(source_data)
+        batch_dp = source_dp.max_token_bucketize(max_token_count=2)
+        exp_batch = []
+        self.assertEqual(list(batch_dp), exp_batch)
+
         # __len__ Test: returns the number of batches
         with self.assertRaises(TypeError):
             len(batch_dp)

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -279,7 +279,11 @@ class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
                     batch_size = 0
                     max_length = 0
                 batch.append(token)
-                batch_size += length
+                if self.padded_tokens:
+                    max_length = length # was set to 0 if we yielded
+                    batch_size = len(batch) * max_length
+                else:
+                    batch_size += length
         while buffer:
             length, token = heapq.heappop(buffer)
             max_length = max(length, max_length)
@@ -291,6 +295,10 @@ class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
                 batch_size = 0
                 max_length = 0
             batch.append(token)
-            batch_size += length
+            if self.padded_tokens:
+                max_length = length  # was set to 0 if we yielded
+                batch_size = len(batch) * max_length
+            else:
+                batch_size += length
         if batch:
             yield DataChunk(batch)

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -204,7 +204,7 @@ class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
     For an example in the audio domain, it may be batching samples with similar length. Then, given the
     ``max_token_count``, each batch may be concatenated to a Tensor with the same size and minimum padding.
 
-    If ``count_padding`` is set to ``True``, the token count of each batch includes the padding a succeeding
+    If ``include_padding`` is set to ``True``, the token count of each batch includes the padding a succeeding
     DataPipe could add. This guarentees that even after the batch is padded, ``max_token_count`` will not be exceeded.
     This can prevent out-of-memory issues for data with large variations in length.
 

--- a/torchdata/datapipes/iter/transform/bucketbatcher.py
+++ b/torchdata/datapipes/iter/transform/bucketbatcher.py
@@ -210,7 +210,7 @@ class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
 
     Note that batches are bucketized starting from the smallest size in a buffer.
     This can limit the variablity of batches if ``buffer_size`` is large.
-    To increase variablity, apply ``torchdata.datapipes.iter.Shuffler`` before this DataPipe,
+    To increase variablity, apply ``torchdata.datapipes.iter.Shuffler`` before and after this DataPipe,
     and keep ``buffer_size`` small.
 
 
@@ -221,8 +221,7 @@ class MaxTokenBucketizerIterDataPipe(IterDataPipe[DataChunk[T_co]]):
         min_len: Optional minimum length to be included into each batch
         max_len: Optional maximum length to be included into each batch.
         buffer_size: This restricts how many tokens are taken from prior DataPipe to bucketize
-        include_padding: If true, assume data will be padded to the largest length in batch in succeeding DataPipes.
-
+        include_padding: If True, the size of each batch includes the extra padding to the largest length in the batch.
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper


### PR DESCRIPTION
Fixes #788 

### Changes

- Add `include_padding` argument to `MaxTokenBucketizer`
