### PR TITLE
Align protobuf version with Tensorflow for TFRecordDataPipe

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -5,8 +5,9 @@ s3fs
 iopath == 0.1.9
 numpy
 rarfile
-# TODO: Revert the change after protobuf (3.20.2) is fixed for MacOS Python 3.10
+# Protobuf 4.0 is binary incompatible with what C++ TF uses.
+# See: https://github.com/tensorflow/tensorflow/blob/8dcaf6b98a6a49c85eb470140ba8506e71a3b5af/tensorflow/tools/pip_package/setup.py#L88-L94
+# Protobuf 3.20.2 is also broken on MacOS Python 3.10
 # See: https://github.com/protocolbuffers/protobuf/issues/10571
-protobuf < 4; sys_platform != 'darwin' or python_version != '3.10'
-protobuf == 3.20.1; sys_platform == 'darwin' and python_version == '3.10'
+protobuf >= 3.9.2, < 3.20
 datasets


### PR DESCRIPTION
Fixes https://github.com/pytorch/data/security/dependabot/1

### Changes

- Protobuf version from 3.20.1 to less than 3.20 as suggested by [Tensorflow](https://github.com/tensorflow/tensorflow/blob/8dcaf6b98a6a49c85eb470140ba8506e71a3b5af/tensorflow/tools/pip_package/setup.py#L88-L94) 
- This would also fix the dependabot [alert](https://github.com/pytorch/data/security/dependabot/1) 