### PR TITLE
Skip TFRecord test on macos M1

### DIFF
--- a/test/_utils/_common_utils_for_test.py
+++ b/test/_utils/_common_utils_for_test.py
@@ -6,6 +6,7 @@
 
 import hashlib
 import os
+import platform
 import sys
 import tempfile
 from typing import List, Tuple, TypeVar
@@ -19,6 +20,8 @@ T_co = TypeVar("T_co", covariant=True)
 IS_LINUX = sys.platform == "linux"
 IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
+
+IS_M1 = IS_MACOS and "arm" in platform.platform()
 
 
 class IDP_NoLen(IterDataPipe):

--- a/test/test_tfrecord.py
+++ b/test/test_tfrecord.py
@@ -13,7 +13,7 @@ import expecttest
 
 import torch
 
-from _utils._common_utils_for_test import reset_after_n_next_calls
+from _utils._common_utils_for_test import IS_M1, reset_after_n_next_calls
 from torchdata.datapipes.iter import (
     FileLister,
     FileOpener,
@@ -65,6 +65,9 @@ class TestDataPipeTFRecord(expecttest.TestCase):
             }
 
     @skipIfNoPROTOBUF
+    @unittest.skipIf(
+        IS_M1, "Protobuf 3.19.* is not supported on MacOS M1, but Tensorflow is incompatible with Protobuf 4"
+    )
     @torch.no_grad()
     def test_tfrecord_loader_example_iterdatapipe(self):
         filename = f"{self.temp_dir}/example.tfrecord"
@@ -161,6 +164,9 @@ class TestDataPipeTFRecord(expecttest.TestCase):
             len(tfrecord_parser)
 
     @skipIfNoPROTOBUF
+    @unittest.skipIf(
+        IS_M1, "Protobuf 3.19.* is not supported on MacOS M1, but Tensorflow is incompatible with Protobuf 4"
+    )
     @torch.no_grad()
     def test_tfrecord_loader_sequence_example_iterdatapipe(self):
         filename = f"{self.temp_dir}/sequence_example.tfrecord"


### PR DESCRIPTION
My [fix](https://github.com/pytorch/data/pull/790) to align protobuf version with tensorflow raises another problem with protobuf that it doesn't officially support MacOS M1. And, it causes our nightly release workflow failing especially for PyThon 3.10.

This PR would skip all TFRecord tests on MacOS M1 until Tensorflow officially supports protobuf 4.