### PR TITLE
Unblock ProtoMPRS to control determinism of DataPipe in single/multi-processing and dist/non-dist env

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
       - name: Install dependencies
         run: |
-          pip3 install requests mypy==0.812 graphviz
+          pip3 install requests mypy==0.812 graphviz numpy
       - name: Build TorchData
         run: |
           python setup.py develop

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+import unittest
+
+from unittest import TestCase
+
+import torch
+
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
+from torchdata.dataloader2 import DataLoader2, DistributedReadingService, PrototypeMultiProcessingReadingService
+from torchdata.datapipes.iter import IterableWrapper
+
+
+class DeterminismTest(TestCase):
+    @parametrize("num_workers", [0, 8])
+    def test_proto_rs_determinism(self, num_workers):
+        data_length = 64
+        exp = list(range(data_length))
+
+        data_source = IterableWrapper(exp)
+        dp = data_source.shuffle().sharding_filter()
+        rs = PrototypeMultiProcessingReadingService(num_workers=num_workers)
+        dl = DataLoader2(dp, reading_service=rs)
+
+        # No seed
+        res = []
+        for d in dl:
+            res.append(d)
+        self.assertEqual(sorted(res), exp)
+
+        # Shuffle with seed
+        results = []
+        for _ in range(2):
+            res = []
+            torch.manual_seed(123)
+            for d in dl:
+                res.append(d)
+            self.assertEqual(sorted(res), exp)
+            results.append(res)
+        self.assertEqual(results[0], results[1])
+
+        # Different seed
+        res = []
+        torch.manual_seed(321)
+        for d in dl:
+            res.append(d)
+        self.assertEqual(sorted(res), exp)
+        self.assertNotEqual(results[0], res)
+
+
+instantiate_parametrized_tests(DeterminismTest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -5,15 +5,28 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import random
 import unittest
 
 from unittest import TestCase
+
+import numpy as np
 
 import torch
 
 from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
 from torchdata.dataloader2 import DataLoader2, DistributedReadingService, PrototypeMultiProcessingReadingService
 from torchdata.datapipes.iter import IterableWrapper
+
+
+def _random_fn(data):
+    r"""
+    Used to validate the randomness of subprocess-local RNGs are set deterministically.
+    """
+    py_random_num = random.randint(0, 2 ** 32)
+    np_random_num = np.random.randint(0, 2 ** 32)
+    torch_random_num = torch.randint(0, 2 ** 32, size=[]).item()
+    return (data, py_random_num, np_random_num, torch_random_num)
 
 
 class DeterminismTest(TestCase):
@@ -23,13 +36,13 @@ class DeterminismTest(TestCase):
         exp = list(range(data_length))
 
         data_source = IterableWrapper(exp)
-        dp = data_source.shuffle().sharding_filter()
+        dp = data_source.shuffle().sharding_filter().map(_random_fn)
         rs = PrototypeMultiProcessingReadingService(num_workers=num_workers)
         dl = DataLoader2(dp, reading_service=rs)
 
         # No seed
         res = []
-        for d in dl:
+        for d, *_ in dl:
             res.append(d)
         self.assertEqual(sorted(res), exp)
 
@@ -37,20 +50,32 @@ class DeterminismTest(TestCase):
         results = []
         for _ in range(2):
             res = []
+            ran_res = []
             torch.manual_seed(123)
-            for d in dl:
+            random.seed(123)
+            np.random.seed(123)
+            for d, *ran_nums in dl:
                 res.append(d)
+                ran_res.append(ran_nums)
             self.assertEqual(sorted(res), exp)
-            results.append(res)
+            results.append((res, ran_res))
+        # Same seed generate the same order of data and the same random state
         self.assertEqual(results[0], results[1])
 
         # Different seed
         res = []
+        ran_res = []
         torch.manual_seed(321)
-        for d in dl:
+        random.seed(321)
+        np.random.seed(321)
+        for d, *ran_nums in dl:
             res.append(d)
+            ran_res.append(ran_nums)
         self.assertEqual(sorted(res), exp)
-        self.assertNotEqual(results[0], res)
+        # Different shuffle order
+        self.assertNotEqual(results[0][0], res)
+        # Different subprocess-local random state
+        self.assertNotEqual(results[0][1], ran_res)
 
 
 instantiate_parametrized_tests(DeterminismTest)

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -33,8 +33,8 @@ if not dist.is_available():
 
 
 _backends = ["gloo"]
-#  if dist.is_mpi_available():
-#      _backends.append("mpi")
+if dist.is_mpi_available():
+    _backends.append("mpi")
 if dist.is_nccl_available() and torch.cuda.device_count() > 0:
     _backends.append("nccl")
 

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -122,6 +122,8 @@ def _finalize_distributed_queue(rank, q):
     if rank == 0:
         q.put(TerminateSignal())
 
+    dist.destroy_process_group(pg)
+
 
 def _random_fn(data):
     r"""
@@ -159,6 +161,7 @@ def _test_proto_distributed_training(rank, world_size, backend, q, num_workers):
     q.put((3, rank, res))
 
     _finalize_distributed_queue(rank, q)
+    dl.shutdown()
 
 
 class DistributedTest(TestCase):
@@ -234,6 +237,8 @@ class DistributedTest(TestCase):
         assert results[0] != results[2]
 
         _finalize_distributed_queue(rank, q)
+        if dl2:
+            dl.shutdown()
 
     @backend_parametrize
     def test_distributed_dl2(self, backend) -> None:

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -31,9 +31,9 @@ __all__ = [
 ]
 
 
-def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_locally_fn=None, call_on_reset_epoch=None):
-    if call_locally_fn is not None:
-        call_locally_fn(source_datapipe)
+def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_on_process_init=None, call_on_epoch_reset=None):
+    if call_on_process_init is not None:
+        call_on_process_init(source_datapipe)
     if isinstance(source_datapipe, IterDataPipe):
         pipe_type = communication.iter
         protocol_type = communication.protocol.IterDataPipeQueueProtocolServer
@@ -48,16 +48,16 @@ def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_locally_fn=
         source_datapipe,
         protocol_type(req_queue, res_queue),
         blocking_request_get=True,
-        reset_epoch_fn=call_on_reset_epoch,
+        reset_epoch_fn=call_on_epoch_reset,
     ):
         pass
 
 
-def SpawnProcessForDataPipeline(multiprocessing_ctx, datapipe, call_locally_fn=None, call_on_reset_epoch=None):
+def SpawnProcessForDataPipeline(multiprocessing_ctx, datapipe, call_on_process_init=None, call_on_epoch_reset=None):
     req_queue = multiprocessing_ctx.Queue()
     res_queue = multiprocessing_ctx.Queue()
     process = multiprocessing_ctx.Process(
-        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, call_locally_fn, call_on_reset_epoch)
+        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, call_on_process_init, call_on_epoch_reset)
     )
     return process, req_queue, res_queue
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -7,6 +7,7 @@
 
 import functools
 import multiprocessing as mp
+import random
 
 from abc import ABC, abstractmethod
 
@@ -206,7 +207,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         torch.utils.data.graph_settings.apply_sharding(datapipe, total_num_workers, global_worker_id)
 
     @staticmethod
-    def _process_reset_fn(world_size, rank, num_workers, worker_id, datapipe, shared_seed, *args):
+    def _process_reset_fn(world_size, rank, num_workers, worker_id, datapipe, shared_seed):
         # This function will receive worker local copy of datapipe and args value from initialize_iteration
         worker_seed_generator = torch.Generator()
         worker_seed_generator.manual_seed(shared_seed)
@@ -217,8 +218,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         # Set different seeds across distributed workers
         global_worker_id = worker_id * world_size + rank
         worker_seed_generator.manual_seed(shared_seed + global_worker_id)
-
-        import random
 
         py_seed = _generate_random_seed(worker_seed_generator).item()
         random.seed(py_seed)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -274,7 +274,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
 
         self.end_datapipe = _IterateQueueDataPipes(self.datapipes)  # type: ignore[assignment]
         if self.prefetch_mainloop > 0:
-            self.end_datapipe = self.end_datapipe.prefetch(self.prefetch_mainloop)
+            self.end_datapipe = self.end_datapipe.prefetch(self.prefetch_mainloop)  # type: ignore[union-attr]
         return self.end_datapipe  # type: ignore[return-value]
 
     def initialize_iteration(self) -> None:
@@ -289,11 +289,12 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             _seed_generator,
         )
 
+        assert self.end_datapipe is not None
         if self._mp:
             if self.prefetch_mainloop > 0:
                 # Stop prefetching first
-                self.end_datapipe.reset()
-                end_datapipe = self.end_datapipe.source_datapipe
+                self.end_datapipe.reset()  # type: ignore[union-attr]
+                end_datapipe: DataPipe = self.end_datapipe.source_datapipe
             else:
                 end_datapipe = self.end_datapipe
             # Send the shared seed to subprocesses


### PR DESCRIPTION
This PR temporarily extend `PrototypingMultiProcessingReadingService` to fully control the determinism of the pipeline in the combinations of:
- Single/Multi-processing
- Distributed/Non-distributed
When we have `SequentialReadingService` ready to combine `DistributedReadingService` and `PrototypingMultiProcessingReadingService`, a few code should be removed. And, for in-process reading service, we still need a method to isolate global RNGs to prevent data-pipeline interferes randomness against model.

For multiprocessing case, it will set the same random seed for `Shuffler` and set different deterministic seeds for global RNGs including `python.random`, `torch` and `numpy` within each subprocess.
For distributed case, it will share the same random seed for `Shuffler` across all distributed subprocesses to guarantee the shuffle order before sharding.

Tests:
All tests are executed in the combinations of the above environments
- [x] Validate the same seed will generate the same order of data
- [x] Validate different seeds will generate different order of data
- [x] Validate the data after shuffle and sharding in each worker are mutually exclusive and collectively exhaustive with/without manual seed

There is one missing test I will add tmrw
- [x] Validate subprocess-local RNGs like `random`, `torch` and `numpy` are properly set with different seeds.