### PR TITLE
Update gha version to utilize Node16

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -76,13 +76,13 @@ jobs:
             python-version: 3.7
     steps:
       - name: Checkout Source Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
           submodules: recursive
       - name: Setup Python ${{ matrix.python-version }}
         if: ${{ startsWith( matrix.os, 'windows' ) }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Add temp runner environment variables
@@ -291,7 +291,7 @@ jobs:
             python-version: 3.7
     steps:
       - name: Checkout Source Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
           submodules: recursive
@@ -463,11 +463,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ inputs.branch }}
           submodules: recursive

--- a/.github/workflows/aistore_ci.yml
+++ b/.github/workflows/aistore_ci.yml
@@ -39,11 +39,11 @@ jobs:
           echo "::set-output name=value::$PT_CHANNEL"
         id: pytorch_channel
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           pip3 install -r requirements.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           sudo apt update
           sudo apt install rar unrar libssl-dev libcurl4-openssl-dev zlib1g-dev
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup msbuild on Windows
@@ -61,7 +61,7 @@ jobs:
         with:
           arch: x64
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install dependencies

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -26,7 +26,7 @@ jobs:
           - 3.9
     steps:
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -34,7 +34,7 @@ jobs:
         run: pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install torchdata
         run: |
@@ -49,7 +49,7 @@ jobs:
         run: echo "::set-output name=ref::$(python -c 'import torchvision; print(torchvision.version.git_version)')"
 
       - name: Check out torchvision repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: pytorch/vision
           ref: ${{ steps.torchvision.outputs.ref }}
@@ -74,7 +74,7 @@ jobs:
           - 3.9
     steps:
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -82,7 +82,7 @@ jobs:
         run: pip install --pre torch torchtext -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install torchdata
         run: |
@@ -117,7 +117,7 @@ jobs:
           - 3.9
     steps:
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -125,7 +125,7 @@ jobs:
         run: pip install --pre torch torchaudio -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install torchdata
         run: |
@@ -160,7 +160,7 @@ jobs:
           - 3.9
     steps:
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -168,7 +168,7 @@ jobs:
         run: pip install --pre torch torcharrow -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install torchdata
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install lint utilities
         run: |
           pip install pre-commit
@@ -43,11 +43,11 @@ jobs:
           echo "::set-output name=value::$PT_CHANNEL"
         id: pytorch_channel
       - name: Setup Python environment
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Check out source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install PyTorch
         run: |
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"


### PR DESCRIPTION
This PR would remove all the annoying warnings from all GHA workflows.
See more detail in https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/