### PR TITLE
[Documentation] Simplify long type names

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -118,6 +118,8 @@ signature_replacements = {
     "torchdata.datapipes.iter.util.header.T_co": "T_co",
     "<class 'torch.utils.data.datapipes.datapipe.DataChunk'>": "List",
     "typing.": "",
+    "Union[IterDataPipe, MapDataPipe]": "DataPipe",
+    "Dict[int, Tuple[DataPipe, DataPipeGraph]": "DataPipeGraph",
 }
 
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #838

Certain [DataPipe functions](https://pytorch.org/data/main/generated/torchdata.dataloader2.graph.traverse_dps.html#torchdata.dataloader2.graph.traverse_dps) have long (not very readable) type names. This simplifies them.