### PR TITLE
[DataLoader2] Moving worker timeout constant to proper file

### DIFF
--- a/torchdata/_constants.py
+++ b/torchdata/_constants.py
@@ -6,3 +6,5 @@
 
 # Use the same timeout as PyTorch Distributed
 default_timeout_in_s = 30 * 60
+
+default_dl2_worker_join_timeout_in_s = 20

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -18,7 +18,7 @@ import torch.distributed as dist
 
 from torch.utils.data import DataLoader
 
-from torchdata._constants import default_timeout_in_s
+from torchdata._constants import default_dl2_worker_join_timeout_in_s, default_timeout_in_s
 from torchdata.dataloader2 import communication
 from torchdata.dataloader2.graph import DataPipe
 from torchdata.datapipes.iter import FullSync, IterableWrapper, IterDataPipe
@@ -253,7 +253,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             # TODO(620): Make termination a function of QueueWrapperDataPipe (similar to reset)
             req_queue.put(communication.messages.TerminateRequest())
             _ = res_queue.get()
-            process.join(20)
+            process.join(default_dl2_worker_join_timeout_in_s)
 
         for process, req_queue, res_queue in self.processes:
             try:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* (to be filled)

