### PR TITLE
[DataLoader2] Ensure finalize and finalize_iteration are called during shutdown/exception

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -68,9 +68,8 @@ class DataLoader2Iterator(Iterator[T_co]):
                     self.dataloader.reading_service.finalize_iteration()
                 raise
             except Exception:
-                if self.dataloader.reading_service is not None:
-                    self.dataloader.reading_service.finalize_iteration()
-                    self.dataloader.reading_service.finalize()
+                if self.dataloader:
+                    self.dataloader.shutdown()
                 raise
         else:
             if self.dataloader.reading_service is not None:

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -67,6 +67,11 @@ class DataLoader2Iterator(Iterator[T_co]):
                 if self.dataloader.reading_service is not None:
                     self.dataloader.reading_service.finalize_iteration()
                 raise
+            except Exception:
+                if self.dataloader.reading_service is not None:
+                    self.dataloader.reading_service.finalize_iteration()
+                    self.dataloader.reading_service.finalize()
+                raise
         else:
             if self.dataloader.reading_service is not None:
                 self.dataloader.reading_service.finalize_iteration()
@@ -198,6 +203,7 @@ class DataLoader2(Generic[T_co]):
             self._datapipe_iter = None
         if not self._terminated:
             if self.reading_service is not None:
+                self.reading_service.finalize_iteration()
                 self.reading_service.finalize()
             self._terminated = True
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #846

Fixes #821

1. Ensure `finalize_iteration` is called during `DataLoader2.shutdown()`
2. If an uncaught exception is raised by `DataLoader2Iterator.next()`, ensure finalization calls are made

Differential Revision: [D40569566](https://our.internmc.facebook.com/intern/diff/D40569566)