### PR TITLE
Fix is_local for paths starting with `az://`

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -12,3 +12,4 @@ rarfile
 protobuf >= 3.9.2, < 3.20
 datasets
 graphviz
+adlfs

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -213,6 +213,21 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         res = list(fsspec_loader_dp)
         self.assertEqual(len(res), 18, f"{input} failed")
 
+    @skipIfNoFSSpecS3
+    def test_fsspec_azure_blob(self):
+        url = "public/curated/covid-19/ecdc_cases/latest/ecdc_cases.csv"
+        account_name = "pandemicdatalake"
+        azure_prefixes = ["abfs", "az"]
+        fsspec_loader_dp = {}
+
+        for prefix in azure_prefixes:
+            fsspec_lister_dp = FSSpecFileLister(f"{prefix}://{url}", account_name=account_name)
+            fsspec_loader_dp[prefix] = FSSpecFileOpener(fsspec_lister_dp, account_name=account_name).parse_csv()
+
+        res_abfs = list(fsspec_loader_dp["abfs"])[0]
+        res_az = list(fsspec_loader_dp["az"])[0]
+        self.assertEqual(res_abfs, res_az, f"{input} failed")
+
     @skipIfAWS
     def test_disabled_s3_io_iterdatapipe(self):
         file_urls = ["s3://ai2-public-datasets"]

--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -79,6 +79,10 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
             else:
                 protocol_list = fs.protocol
 
+            # fspec.core.url_to_fs will return "abfs" for both, "az://" and "abfs://" urls
+            if "abfs" in protocol_list:
+                protocol_list.append("az")
+
             is_local = fs.protocol == "file" or not any(root.startswith(protocol) for protocol in protocol_list)
             if fs.isfile(path):
                 yield root


### PR DESCRIPTION
Signed-off-by: Marco Pfirrmann <marco.pfirrmann@tngtech.com>

Fixes #840. 
The module used to extract the protocol does not differentiate between `abfs://` and `az://` paths, always returning `abfs`. This fix adds `az` to the protocol list to be checked. 
