### PR TITLE
Make conda use manylinux image from pytorch to support lower glibc

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -272,6 +272,7 @@ jobs:
   conda_build_test:
     needs: get_release_type
     runs-on: ${{ matrix.os }}
+    container: ${{ startsWith( matrix.os, 'ubuntu' ) && 'pytorch/manylinux-cpu' || null }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is the attempt to fix `GLIBC` issue for conda by using pytorch provided image