### PR TITLE
Temporarily skip distributed testing for ProtoMPRS on Windows

### DIFF
--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -30,6 +30,7 @@ def _random_fn(data):
 
 
 class DeterminismTest(TestCase):
+    @unittest.skipIf(IS_WINDOWS, "Remove when https://github.com/pytorch/data/issues/857 is fixed")
     @parametrize("num_workers", [0, 8])
     def test_proto_rs_determinism(self, num_workers):
         data_length = 64

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -293,6 +293,7 @@ class DistributedTest(TestCase):
             ],
         )
 
+    @unittest.skipIf(IS_WINDOWS, "Remove when https://github.com/pytorch/data/issues/857 is fixed")
     @backend_parametrize
     @parametrize("num_workers", [0, 8])
     def test_proto_rs_dl2(self, backend, num_workers) -> None:


### PR DESCRIPTION
See the issue https://github.com/pytorch/data/issues/857