### PR TITLE
Support for recursive datatypes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
       - name: Install dependencies
         run: |
-          pip3 install requests mypy==0.982 graphviz numpy
+          pip3 install requests mypy==0.981 graphviz numpy
       - name: Build TorchData
         run: |
           python setup.py develop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 
 on:
   push:
+    branches:
+      - main
+      - release/*
+      -abhi-glitchhg
   pull_request:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: Lint
 
 on:
   push:
-    branches:
-      - main
-      - release/*
   pull_request:
 
 jobs:
@@ -53,7 +50,7 @@ jobs:
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
       - name: Install dependencies
         run: |
-          pip3 install requests mypy==0.812 graphviz numpy
+          pip3 install requests mypy==0.982 graphviz numpy
       - name: Build TorchData
         run: |
           python setup.py develop

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - release/*
-      -abhi-glitchhg
   pull_request:
 
 jobs:

--- a/torchdata/datapipes/iter/util/tfrecordloader.py
+++ b/torchdata/datapipes/iter/util/tfrecordloader.py
@@ -45,7 +45,7 @@ TFRecordExampleSpec = Dict[str, TFRecordFeatureSpec]
 #  Note, reccursive types not supported by mypy at the moment
 # TODO(640): uncomment as soon as it becomes supported
 #  https://github.com/python/mypy/issues/731
-#  BinaryData = Union[str, List['BinaryData']]
+BinaryData = Union[str, List['BinaryData']]
 TFRecordBinaryData = Union[str, List[str], List[List[str]], List[List[List[Any]]]]
 TFRecordExampleFeature = Union[torch.Tensor, List[torch.Tensor], TFRecordBinaryData]
 TFRecordExample = Dict[str, TFRecordExampleFeature]


### PR DESCRIPTION
since release of mypy 0.981 recursive types are supported; i have just removed the `#` as per suggestion in the TODO comment and have changed the mypy version in the ci jobs. 

This PR is to check if ci is breaking with the changes are not.

Let me know if any further changes need to be made
thanks..