### PR TITLE
Fix `to_graph` DataPipeGraph visualization function

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -11,3 +11,4 @@ rarfile
 # See: https://github.com/protocolbuffers/protobuf/issues/10571
 protobuf >= 3.9.2, < 3.20
 datasets
+graphviz

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -19,12 +19,7 @@ from torchdata.datapipes.utils import to_graph
 
 T_co = TypeVar("T_co", covariant=True)
 
-try:
-    import graphviz
-
-    HAS_GRAPHVIZ = True
-except ImportError:
-    HAS_GRAPHVIZ = False
+import graphviz
 
 
 class Adaptor(IterDataPipe[T_co]):
@@ -213,7 +208,6 @@ class TestGraph(expecttest.TestCase):
 
 
 class TestGraphVisualization(expecttest.TestCase):
-    @unittest.skipIf(not HAS_GRAPHVIZ, "Package `graphviz` is required to test graph visualization functionalities.")
     def test_to_graph(self):
         dp1 = IterableWrapper(range(10))
         dp2 = dp1.map(lambda x: x + 1)

--- a/torchdata/datapipes/utils/_visualization.py
+++ b/torchdata/datapipes/utils/_visualization.py
@@ -57,7 +57,7 @@ class Node:
 
 def to_nodes(dp, *, debug: bool) -> Set[Node]:
     def recurse(dp_graph, child=None):
-        for dp_node, dp_parents in dp_graph.items():
+        for _dp_id, (dp_node, dp_parents) in dp_graph.items():
             node = Node(dp_node)
             if child is not None:
                 node.add_child(child)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #872

Fixes #869 and adds tests to ensure `to_graph` can execute without raising exception

Differential Revision: [D40956306](https://our.internmc.facebook.com/intern/diff/D40956306)