### PR TITLE
[DataPipe] Make lengths of DataPipe dynamic

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -370,10 +370,10 @@ class TestIterDataPipe(expecttest.TestCase):
                 str(wa[0].message), r"length of this HeaderIterDataPipe is inferred to be equal to its limit"
             )
 
-        # __len__ Test: returns limit if source doesn't have length, but it has been iterated through once
+        # __len__ Test: returns limit if source doesn't have length, even when it has been iterated through once
         for _ in header_dp:
             pass
-        self.assertEqual(20, len(header_dp))
+        self.assertEqual(30, len(header_dp))
 
     def test_enumerator_iterdatapipe(self) -> None:
         letters = "abcde"

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -201,7 +201,6 @@ class MapKeyZipperIterDataPipe(IterDataPipe[T_co]):
         if merge_fn is not None:
             _check_unpickable_fn(merge_fn)
         self.merge_fn: Optional[Callable] = merge_fn
-        self.length: int = -1
 
     def __iter__(self) -> Iterator:
         for item in self.source_iterdatapipe:
@@ -213,6 +212,4 @@ class MapKeyZipperIterDataPipe(IterDataPipe[T_co]):
             yield self.merge_fn(item, map_item) if self.merge_fn else (item, map_item)
 
     def __len__(self) -> int:
-        if self.length == -1:
-            self.length = len(self.source_iterdatapipe)
-        return self.length
+        return len(self.source_iterdatapipe)

--- a/torchdata/datapipes/iter/util/converter.py
+++ b/torchdata/datapipes/iter/util/converter.py
@@ -116,11 +116,10 @@ class IterToMapConverterMapDataPipe(MapDataPipe):
             self.datapipe,
             dill_key_value_fn,
             self._map,
-            self._length,
         )
 
     def __setstate__(self, state):
-        (self.datapipe, dill_key_value_fn, self._map, self._length) = state
+        (self.datapipe, dill_key_value_fn, self._map) = state
         if DILL_AVAILABLE:
             self.key_value_fn = dill.loads(dill_key_value_fn)  # type: ignore[assignment]
         else:

--- a/torchdata/datapipes/iter/util/converter.py
+++ b/torchdata/datapipes/iter/util/converter.py
@@ -68,7 +68,6 @@ class IterToMapConverterMapDataPipe(MapDataPipe):
             _check_unpickable_fn(key_value_fn)
         self.key_value_fn = key_value_fn  # type: ignore[assignment]
         self._map = None
-        self._length = -1
 
     def _load_map(self):
         self._map = {}
@@ -94,25 +93,19 @@ class IterToMapConverterMapDataPipe(MapDataPipe):
             raise IndexError(f"Index {index} is valid for IterToMapConverter.")
 
     def __len__(self):
-        if self._length > -1:
-            return self._length
         if self._map is not None:
-            self._length = len(self._map)  # type: ignore[arg-type]
-            return self._length
+            return len(self._map)  # type: ignore[arg-type]
         try:
-            self._length = len(self.datapipe)
-            return self._length
+            return len(self.datapipe)
         except (TypeError, NotImplementedError):
-            self._length = -1
-        if self._map is None:
-            warnings.warn(
-                "Data from prior DataPipe are loaded to get length of"
-                "IterToMapConverter before execution of the pipeline."
-                "Please consider removing len()."
-            )
-            self._load_map()
-            self._length = len(self._map)  # type: ignore[arg-type]
-        return self._length
+            pass
+        warnings.warn(
+            "Data from prior DataPipe are loaded to get length of"
+            "IterToMapConverter before execution of the pipeline."
+            "Please consider removing len()."
+        )
+        self._load_map()
+        return len(self._map)  # type: ignore[arg-type]
 
     def __getstate__(self):
         if DILL_AVAILABLE:

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -36,7 +36,6 @@ class HeaderIterDataPipe(IterDataPipe[T_co]):
     def __init__(self, source_datapipe: IterDataPipe[T_co], limit: int = 10) -> None:
         self.source_datapipe: IterDataPipe[T_co] = source_datapipe
         self.limit: int = limit
-        self.length: int = -1
 
     def __iter__(self) -> Iterator[T_co]:
         i: int = 0
@@ -49,12 +48,9 @@ class HeaderIterDataPipe(IterDataPipe[T_co]):
         self.length = min(i, self.limit)  # We know length with certainty when we reach here
 
     def __len__(self) -> int:
-        if self.length != -1:
-            return self.length
         try:
             source_len = len(self.source_datapipe)
-            self.length = min(source_len, self.limit)
-            return self.length
+            return min(source_len, self.limit)
         except TypeError:
             warn(
                 "The length of this HeaderIterDataPipe is inferred to be equal to its limit."

--- a/torchdata/datapipes/iter/util/mux_longest.py
+++ b/torchdata/datapipes/iter/util/mux_longest.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Optional, Set, Sized
+from typing import Set, Sized
 
 from torch.utils.data.datapipes._decorator import functional_datapipe
 from torch.utils.data.datapipes.datapipe import IterDataPipe
@@ -29,7 +29,6 @@ class MultiplexerLongestIterDataPipe(IterDataPipe):
 
     def __init__(self, *datapipes):
         self.datapipes = datapipes
-        self.length: Optional[int] = None
 
     def __iter__(self):
         iterators = [iter(x) for x in self.datapipes]
@@ -44,12 +43,7 @@ class MultiplexerLongestIterDataPipe(IterDataPipe):
                         finished.add(i)
 
     def __len__(self):
-        if self.length is not None:
-            if self.length == -1:
-                raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
-            return self.length
         if all(isinstance(dp, Sized) for dp in self.datapipes):
-            self.length = sum(len(dp) for dp in self.datapipes)
+            return sum(len(dp) for dp in self.datapipes)
         else:
-            self.length = -1
-        return len(self)
+            raise TypeError(f"{type(self).__name__} instance doesn't have valid length")

--- a/torchdata/datapipes/iter/util/samplemultiplexer.py
+++ b/torchdata/datapipes/iter/util/samplemultiplexer.py
@@ -57,7 +57,6 @@ class SampleMultiplexerDataPipe(IterDataPipe[T_co]):
             self.random = random.Random()
         else:
             self.random = random.Random(seed)
-        self.length: Optional[int] = None
 
     def __iter__(self) -> Iterator[T_co]:
         pipes_and_weights = [(iter(k), v) for k, v in self.pipes_and_weights]
@@ -82,12 +81,7 @@ class SampleMultiplexerDataPipe(IterDataPipe[T_co]):
             yield item
 
     def __len__(self) -> int:
-        if self.length is not None:
-            if self.length == -1:
-                raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
-            return self.length
         if all(isinstance(dp, Sized) for dp, _ in self.pipes_and_weights):
-            self.length = sum(len(dp) for dp, _ in self.pipes_and_weights)
+            return sum(len(dp) for dp, _ in self.pipes_and_weights)
         else:
-            self.length = -1
-        return len(self)
+            raise TypeError(f"{type(self).__name__} instance doesn't have valid length")

--- a/torchdata/datapipes/iter/util/zip_longest.py
+++ b/torchdata/datapipes/iter/util/zip_longest.py
@@ -42,7 +42,6 @@ class ZipperLongestIterDataPipe(IterDataPipe):
             raise TypeError("All inputs are required to be `IterDataPipe` " "for `ZipperLongestIterDataPipe`.")
         super().__init__()
         self.datapipes = datapipes  # type: ignore[assignment]
-        self.length = None
         self.fill_value = fill_value
 
     def __iter__(self) -> Iterator[Tuple]:
@@ -63,12 +62,7 @@ class ZipperLongestIterDataPipe(IterDataPipe):
             yield tuple(values)
 
     def __len__(self) -> int:
-        if self.length is not None:
-            if self.length == -1:
-                raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
-            return self.length
         if all(isinstance(dp, Sized) for dp in self.datapipes):
-            self.length = max(len(dp) for dp in self.datapipes)
+            return max(len(dp) for dp in self.datapipes)
         else:
-            self.length = -1
-        return len(self)
+            raise TypeError(f"{type(self).__name__} instance doesn't have valid length")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #873

This PR makes the lengths of DataPipe dynamic, rather than caching the initial calculation as `._length`. Note that this doesn't change manually specified lengths.

TorchData equivalent of https://github.com/pytorch/pytorch/pull/88302

Differential Revision: [D40962187](https://our.internmc.facebook.com/intern/diff/D40962187)