### PR TITLE
update load_state_dict() signature to align with torchsnapshot

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -256,7 +256,7 @@ class DataLoader2(Generic[T_co]):
         data_loader.reading_service_state = reading_service_state
         return data_loader
 
-    def load_state_dict(self, state: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         """
         For the existing ``DataLoader2``, load serialized state to restore ``DataPipe`` graph
         and reset the internal state of ``ReadingService``.
@@ -269,8 +269,8 @@ class DataLoader2(Generic[T_co]):
                 "Please create a new dataloader in order to use load state dict."
             )
 
-        serialized_datapipe = state[SERIALIZED_DATAPIPE_KEY_NAME]
-        reading_service_state = state[READING_SERVICE_STATE_KEY_NAME]
+        serialized_datapipe = state_dict[SERIALIZED_DATAPIPE_KEY_NAME]
+        reading_service_state = state_dict[READING_SERVICE_STATE_KEY_NAME]
 
         # deserialize datapipe
         deserialized_datapipe = deserialize_datapipe(serialized_datapipe)


### PR DESCRIPTION
Summary:
Checkpointing relies on some protocol checking to make sure it takes `Checkpointable` modules.

The canonical protocol currently requires `def load_state_dict(self, state_dict: Dict[str, Any]) -> None:` but DLv2's positional argument is `state` instead.

So even though logically everything works this breaks static type checking, creating confusion to users.

See signature
https://github.com/pytorch/torchsnapshot/blob/28ce508ceb1db0a4f16c269b776fe88216e340f5/torchsnapshot/stateful.py#L14

Reviewed By: Miiira

Differential Revision: D41094635

