### PR TITLE
Fix S3FileLoader local file clobbering

### DIFF
--- a/torchdata/csrc/pybind/S3Handler/S3Handler.cpp
+++ b/torchdata/csrc/pybind/S3Handler/S3Handler.cpp
@@ -202,9 +202,6 @@ class S3FS {
             create_stream_fn);
     downloadHandle->WaitUntilFinished();
 
-    Aws::OFStream storeFile(
-        object_name_.c_str(), Aws::OFStream::out | Aws::OFStream::trunc);
-
     if (downloadHandle->GetStatus() !=
         Aws::Transfer::TransferStatus::COMPLETED) {
       const Aws::Client::AWSError<Aws::S3::S3Errors> error =


### PR DESCRIPTION
Fixes #735; remove unnecessary call to `storeFile()`, a remnant from the `aws-doc-sdk-examples` `transferOnStream.cpp` example, where this function is used to verify the buffer's contents: https://github.com/awsdocs/aws-doc-sdk-examples/blob/main/cpp/example_code/transfer-manager/transferOnStream.cpp#L131

### Changes

- remove unnecessary call to `storeFile()`

### Testing

Verified files are no longer clobbered through local testing