### PR TITLE
Fix: Yield all remaining samples in prefetch_buffer

### DIFF
--- a/torchdata/datapipes/iter/util/prefetcher.py
+++ b/torchdata/datapipes/iter/util/prefetcher.py
@@ -101,6 +101,8 @@ class PrefetcherIterDataPipe(IterDataPipe):
                 if self.thread is not None:
                     self.thread.join()
                     self.thread = None
+                for sample in prefetch_data.prefetch_buffer:
+                    yield sample
 
     def __getstate__(self):
         """


### PR DESCRIPTION
Fixes #899 

Testing this without having a mapping function that adds some delay (sleep) might be hard. Any suggestions?

### Changes

- Yield remaining samples in `finally` block
