### PR TITLE
Fix tests for Azure and DataLoader

### DIFF
--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -227,6 +227,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         res = list(fsspec_loader_dp)
         self.assertEqual(len(res), 18, f"{input} failed")
 
+    @unittest.skipIf(True, "Needs authentications. See: https://github.com/pytorch/data/issues/904")
     @skipIfNoFSSpecAZ
     def test_fsspec_azure_blob(self):
         url = "public/curated/covid-19/ecdc_cases/latest/ecdc_cases.csv"

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -369,7 +369,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
     pin_memory: bool
     timeout: float
     worker_init_fn: Optional[Callable[[int], None]]
-    prefetch_factor: int
+    prefetch_factor: Optional[int]
     persistent_workers: bool
 
     def __init__(
@@ -379,7 +379,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         timeout: float = 0,
         worker_init_fn: Optional[Callable[[int], None]] = None,
         multiprocessing_context=None,
-        prefetch_factor: int = 2,
+        prefetch_factor: Optional[int] = None,
         persistent_workers: bool = False,
     ) -> None:
         self.num_workers = num_workers
@@ -389,6 +389,9 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         self.multiprocessing_context = multiprocessing_context
         self.prefetch_factor = prefetch_factor
         self.persistent_workers = persistent_workers
+        if self.num_workers == 0:
+            self.prefetch_factor = None
+            self.persistent_workers = False
         self.dl_: Optional[DataLoader] = None
 
     # Wrap the DataLoader with IterableWrapper to respect type annotation


### PR DESCRIPTION
### Changes

- For Azure test: Please see https://github.com/pytorch/data/issues/904
- For DataLoader test, https://github.com/pytorch/pytorch/pull/88972 introduces an Error when `prefetch_factor` is specified when `num_workers>0`.