### PR TITLE
Add worker_init_fn and worker_reset_fn to ProtoMPRS

### DIFF
--- a/benchmarks/cloud/aws_s3.py
+++ b/benchmarks/cloud/aws_s3.py
@@ -65,7 +65,7 @@ def check_and_output_speed(prefix: str, create_dp_fn: Callable, n_prefetch: int,
 
     rs_type = "DataLoader2 w/ tar archives"
     new_rs = PrototypeMultiProcessingReadingService(
-        num_workers=n_workers, prefetch_worker=n_prefetch, prefetch_mainloop=n_prefetch
+        num_workers=n_workers, worker_prefetch_cnt=n_prefetch, main_prefetch_cnt=n_prefetch
     )
     dl: DataLoader2 = DataLoader2(dp, reading_service=new_rs)
 

--- a/docs/source/dataloader2.rst
+++ b/docs/source/dataloader2.rst
@@ -18,6 +18,11 @@ Note:
 - :class:`torchdata.datapipes.map.SequenceWrapper`: ``torch.utils.data.Dataset``
 - :class:`torchdata.datapipes.iter.IterableWrapper`: ``torch.utils.data.IterableDataset``
 
+Both custom ``worker_init_fn`` and ``worker_reset_fn`` require the following three arguments:
+- :class:`torchdata.dataloader2.utils.DistInfo`
+- :class:`torchdata.dataloader2.utils.WorkerInfo`
+- ``DataPipe``
+
 ReadingService
 ---------------
 

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -10,6 +10,8 @@ import pickle
 import unittest
 from unittest import TestCase
 
+import torch
+
 from torchdata.dataloader2 import (
     communication,
     DataLoader2,
@@ -140,7 +142,7 @@ class DataLoader2Test(TestCase):
             None,
             TestReadingService(),
             MultiProcessingReadingService(num_workers=4),
-            PrototypeMultiProcessingReadingService(num_workers=4, prefetch_worker=0),
+            PrototypeMultiProcessingReadingService(num_workers=4, worker_prefetch_cnt=0),
         ]
         for reading_service in reading_services:
             data_loader: DataLoader2 = DataLoader2(datapipe=test_data_pipe, reading_service=reading_service)
@@ -346,6 +348,42 @@ class TestDataLoader2EventLoop(TestCase):
         self.assertEqual(input_len, len(local_datapipe))
 
         clean_me(process, req_queue, res_queue)
+
+
+class PrototypeMultiProcessingReadingServiceTest(TestCase):
+    @staticmethod
+    def _worker_init_fn(datapipe, dist_info, worker_info):
+        datapipe = datapipe.sharding_filter()
+        torch.utils.data.graph_settings.apply_sharding(datapipe, worker_info.num_workers, worker_info.worker_id)
+        return datapipe
+
+    @staticmethod
+    def _worker_reset_fn(datapipe, dist_info, worker_info):
+        worker_seed_generator = torch.Generator()
+        worker_seed_generator.manual_seed(123)
+        torch.utils.data.graph_settings.apply_random_seed(
+            datapipe,
+            worker_seed_generator,
+        )
+        return datapipe
+
+    def test_worker_fns(self):
+        dp: IterDataPipe = IterableWrapper(range(100)).batch(2).shuffle()
+        torch.manual_seed(123)
+        exp = list(dp)
+
+        rs = PrototypeMultiProcessingReadingService(
+            num_workers=1, worker_init_fn=self._worker_init_fn, worker_reset_fn=self._worker_reset_fn
+        )
+        dl = DataLoader2(dp, reading_service=rs)
+
+        # Test worker_init_fn to shard the DataPipe graph
+        res1 = list(dl)
+        self.assertEqual(exp, res1)
+
+        # Test worker_reset_fn to set the same random seed across epoches
+        res2 = list(dl)
+        self.assertEqual(exp, res2)
 
 
 if __name__ == "__main__":

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -106,7 +106,7 @@ def EnsureNonBlockingDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, reset_epoch_fn=None):
+def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
     """
     Indefinitely iterates over ``req_queue`` and passing values from source_datapipe to ``res_queue``.
 
@@ -120,7 +120,6 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
         source_datapipe: DataPipe
         protocol: ``IterDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
         blocking_request_get: determines if ``protocol.get_new_request`` will block
-        reset_epoch_fn: function to call when receiving the message ``ResetEpochRequest``
     """
     if not isinstance(protocol, communication.protocol.IterDataPipeQueueProtocolServer):
         raise Exception("Expecting IterDataPipeQueueProtocolServer, got", protocol)
@@ -135,8 +134,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
             continue
 
         if isinstance(request, communication.messages.ResetEpochRequest):
-            if reset_epoch_fn is not None:
-                reset_epoch_fn(source_datapipe, *request.args)
+            source_datapipe = request.reset_fn(source_datapipe)
             protocol.response_reset_epoch()
 
         elif isinstance(request, communication.messages.ResetIteratorRequest):

--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -83,7 +83,7 @@ def EnsureNonBlockingMapDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, reset_epoch_fn=None):
+def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
     """
     Indefinitely iterates over req_queue and passing values from source_datapipe to res_queue.
 
@@ -91,7 +91,6 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
         source_datapipe: DataPipe
         protocol: ``MapDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
         blocking_request_get: determines if ``protocol.get_new_request`` will block
-        reset_epoch_fn: function to call when receiving the message ``ResetEpochRequest``
     """
     if not isinstance(protocol, communication.protocol.MapDataPipeQueueProtocolServer):
         raise Exception("Expecting MapDataPipeQueueProtocolServer, got", protocol)
@@ -106,8 +105,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
             continue
 
         if isinstance(request, communication.messages.ResetEpochRequest):
-            if reset_epoch_fn is not None:
-                reset_epoch_fn(source_datapipe, *request.args)
+            source_datapipe = request.reset_fn(source_datapipe)
             protocol.response_reset_epoch()
 
         elif isinstance(request, communication.messages.TerminateRequest):

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -26,10 +26,10 @@ class ResetIteratorResponse(Response):
 
 
 class ResetEpochRequest(Request):
-    __slots__ = "args"
+    __slots__ = "reset_fn"
 
-    def __init__(self, args):
-        self.args = args
+    def __init__(self, reset_fn):
+        self.reset_fn = reset_fn
 
 
 class ResetEpochResponse(Response):

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -122,10 +122,10 @@ class MapDataPipeQueueProtocolClient(ProtocolClient):
         self.request_queue.put(request)
         self.request_sent(request)
 
-    def request_reset_epoch(self, *args):
+    def request_reset_epoch(self, reset_fn):
         if not self.can_take_request():
             raise Exception("Can not reset while we are still waiting response for previous request")
-        request = communication.messages.ResetEpochRequest(args)
+        request = communication.messages.ResetEpochRequest(reset_fn)
         self.request_queue.put(request)
         self.request_sent(request)
 
@@ -201,10 +201,10 @@ class IterDataPipeQueueProtocolClient(ProtocolClient):
         self.request_queue.put(request)
         self.request_sent(request)
 
-    def request_reset_epoch(self, *args):
+    def request_reset_epoch(self, reset_fn):
         if not self.can_take_request():
             raise Exception("Can not reset while we are still waiting response for previous request")
-        request = communication.messages.ResetEpochRequest(args)
+        request = communication.messages.ResetEpochRequest(reset_fn)
         self.request_queue.put(request)
         self.request_sent(request)
 

--- a/torchdata/dataloader2/graph/settings.py
+++ b/torchdata/dataloader2/graph/settings.py
@@ -7,11 +7,10 @@
 
 import inspect
 
-from typing import Optional
-
 import torch
 
 from torchdata.dataloader2.graph import DataPipe, find_dps, list_dps, traverse_dps
+from torchdata.dataloader2.utils import generate_random_int
 from torchdata.datapipes.iter import ShardingFilter
 
 
@@ -21,12 +20,8 @@ def _is_random_datapipe(datapipe: DataPipe) -> bool:
     return False
 
 
-def _generate_random_seed(rng: Optional[torch.Generator] = None, dtype: torch.dtype = torch.int64) -> int:
-    return int(torch.empty((), dtype=dtype).random_(generator=rng).item())
-
-
 def _seed_datapipe(datapipe: DataPipe, seed_generator: torch.Generator) -> DataPipe:
-    seed = _generate_random_seed(seed_generator)
+    seed = generate_random_int(seed_generator)
     datapipe.set_seed(seed)
     return datapipe
 
@@ -41,7 +36,7 @@ def _set_worker_seed_for_dp_graph(datapipe: DataPipe, seed_generator: torch.Gene
     graph = traverse_dps(datapipe)
     sharding_filter_dps = find_dps(graph, ShardingFilter)
 
-    base_seed = _generate_random_seed(seed_generator)
+    base_seed = generate_random_int(seed_generator)
     worker_seed = base_seed + worker_id
 
     # Set the same seed before sharding_filter

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -5,13 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import functools
 import multiprocessing as mp
-import random
 
 from abc import ABC, abstractmethod
-
 from datetime import timedelta
+from functools import partial
 from typing import Callable, List, Optional
 
 import torch
@@ -22,14 +20,15 @@ from torch.utils.data import DataLoader
 from torchdata._constants import default_dl2_worker_join_timeout_in_s, default_timeout_in_s
 from torchdata.dataloader2 import communication
 from torchdata.dataloader2.graph import DataPipe
+from torchdata.dataloader2.utils import (
+    DistInfo,
+    generate_random_scalar_tensor,
+    process_init_fn,
+    process_reset_fn,
+    WorkerInfo,
+)
+from torchdata.dataloader2.utils.worker import _ExtraInfo
 from torchdata.datapipes.iter import FullSync, IterableWrapper, IterDataPipe
-
-try:
-    import numpy
-
-    HAS_NUMPY = True
-except ModuleNotFoundError:
-    HAS_NUMPY = False
 
 
 class ReadingServiceInterface(ABC):
@@ -115,10 +114,6 @@ def _collate_no_op(batch):
     return batch[0]
 
 
-def _generate_random_seed(rng: Optional[torch.Generator] = None, dtype: torch.dtype = torch.int64) -> torch.Tensor:
-    return torch.empty((), dtype=dtype).random_(generator=rng)
-
-
 class _IterateQueueDataPipes(IterDataPipe):
     r"""
     Takes in ``QueueWrapper``s and iterates through them in a round-robin manner to get batches one-by-one.
@@ -166,11 +161,13 @@ class _IterateQueueDataPipes(IterDataPipe):
         for dp in self.datapipes:
             dp.reset_iterator()
 
-    def reset_epoch(self, *args):
+    def reset_epoch(self, reset_fn: Callable[[WorkerInfo, DataPipe], DataPipe]):
         for dp in self.datapipes:
             dp.protocol.discard_existing_request()
-        for dp in self.datapipes:
-            dp.protocol.request_reset_epoch(*args)
+        num_workers = len(self.datapipes)
+        for worker_id, dp in enumerate(self.datapipes):
+            worker_info = WorkerInfo(num_workers, worker_id)
+            dp.protocol.request_reset_epoch(partial(reset_fn, worker_info=worker_info))
 
 
 class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
@@ -184,67 +181,50 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         multiprocessing_context (str, optional): Multiprocessing starting method.
             If method is None then the default context is returned.
             Otherwise, method should be 'fork', 'spawn'.
+        prefetch_worker: (int, 10 by default):
+        prefetch_mainloop: (int, 10 by default):
+        worker_init_fn: (Callable, optional):
+        worker_reset_fn: (Callable, optional):
     """
     num_workers: int
+    multiprocessing_context: Optional[str]
+    prefetch_worker: int
+    prefetch_mainloop: int
+    worker_init_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]]
+    worker_reset_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]]
     processes: List
     datapipes: List
     end_datapipe: Optional[DataPipe]
     _mp: bool
     _pg: Optional[dist.ProcessGroup]
-    _world_size: int
-    _rank: int
+    _dist_info: DistInfo
 
     def __init__(
         self,
         num_workers: int = 0,
-        multiprocessing_context=None,
+        multiprocessing_context: Optional[str] = None,
         prefetch_worker: int = 10,
         prefetch_mainloop: int = 10,
+        worker_init_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]] = None,
+        worker_reset_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]] = None,
     ) -> None:
         self.num_workers = num_workers
-        # TODO(613): Should be one of 'fork', 'spawn'
+        if multiprocessing_context is not None:
+            _all_start_methods = mp.get_all_start_methods()
+            assert (
+                multiprocessing_context in _all_start_methods
+            ), f"Please choose one available multiprocessing context from {_all_start_methods}"
         self.multiprocessing_context = multiprocessing_context
         self.prefetch_worker = prefetch_worker
         self.prefetch_mainloop = prefetch_mainloop
+        self.worker_init_fn = worker_init_fn
+        self.worker_reset_fn = worker_reset_fn
         self.processes = []
         self.datapipes = []
         self.end_datapipe = None
         self._mp = num_workers > 0
         self._pg = None
-        self._world_size = 1
-        self._rank = 0
-
-    @staticmethod
-    def _process_init_fn(world_size, rank, num_workers, worker_id, datapipe):
-        global_worker_id = worker_id * world_size + rank
-        total_num_workers = num_workers * world_size
-        torch.utils.data.graph_settings.apply_sharding(datapipe, total_num_workers, global_worker_id)
-
-    @staticmethod
-    def _process_reset_fn(world_size, rank, num_workers, worker_id, datapipe, shared_seed):
-        # This function will receive worker local copy of datapipe and args value from ``initialize_iteration``
-        worker_seed_generator = torch.Generator()
-        worker_seed_generator.manual_seed(shared_seed)
-        torch.utils.data.graph_settings.apply_random_seed(
-            datapipe,
-            worker_seed_generator,
-        )
-        # Set different seeds across distributed workers
-        global_worker_id = worker_id * world_size + rank
-        worker_seed_generator.manual_seed(shared_seed + global_worker_id)
-
-        py_seed = _generate_random_seed(worker_seed_generator).item()
-        random.seed(py_seed)
-
-        torch_seed = _generate_random_seed(worker_seed_generator).item()
-        torch.manual_seed(torch_seed)
-
-        if HAS_NUMPY:
-            # Numpy only accepts uint32 as the seed
-            np_seed = _generate_random_seed(worker_seed_generator, torch.int32).item()
-            if np_seed < 0:
-                np_seed = 2 ** 32 + np_seed
-            numpy.random.seed(np_seed)
+        self._dist_info = DistInfo(1, 0)
 
     def initialize(self, datapipe: DataPipe) -> DataPipe:
         r"""
@@ -253,12 +233,14 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         creates subprocesses.
         """
         if dist.is_available() and dist.is_initialized():
-            self._world_size = dist.get_world_size()
-            self._rank = dist.get_rank()
+            _world_size = dist.get_world_size()
+            _rank = dist.get_rank()
+            self._dist_info = DistInfo(_world_size, _rank)
             self._pg = dist.new_group(backend="gloo")
         if not self._mp:
             # TODO(616): Warn and recommend usage of InProcessReadingService
-            self._process_init_fn(self._world_size, self._rank, 1, 0, datapipe)
+            worker_info = WorkerInfo(1, 0)
+            process_init_fn(datapipe, self._dist_info, worker_info, self.worker_init_fn)
             self.end_datapipe = datapipe
             return datapipe
 
@@ -266,11 +248,9 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             datapipe = datapipe.prefetch(self.prefetch_worker)
 
         for worker_id in range(self.num_workers):
-            call_on_process_init = functools.partial(
-                self._process_init_fn, self._world_size, self._rank, self.num_workers, worker_id
-            )
-            call_on_epoch_reset = functools.partial(
-                self._process_reset_fn, self._world_size, self._rank, self.num_workers, worker_id
+            worker_info = WorkerInfo(self.num_workers, worker_id)
+            call_on_process_init = partial(
+                process_init_fn, dist_info=self._dist_info, worker_info=worker_info, custom_init_fn=self.worker_init_fn
             )
             ctx = mp.get_context(self.multiprocessing_context)
             # Process contains a ProtocolServer
@@ -278,7 +258,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                 ctx,
                 datapipe,
                 call_on_process_init,
-                call_on_epoch_reset,
             )
             process.daemon = True
             process.start()
@@ -294,7 +273,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         return self.end_datapipe  # type: ignore[return-value]
 
     def initialize_iteration(self) -> None:
-        shared_seed = _generate_random_seed()
+        shared_seed = generate_random_scalar_tensor()
         if self._pg is not None:
             dist.broadcast(shared_seed, src=0, group=self._pg)
         shared_seed_int: int = shared_seed.item()  # type: ignore[assignment]
@@ -314,7 +293,11 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             else:
                 end_datapipe = self.end_datapipe
             # Send the shared seed to subprocesses
-            end_datapipe.reset_epoch(shared_seed_int)
+            extra_info = _ExtraInfo(shared_seed_int)
+            call_on_epoch_reset = partial(
+                process_reset_fn, dist_info=self._dist_info, extra_info=extra_info, custom_reset_fn=self.worker_reset_fn
+            )
+            end_datapipe.reset_epoch(call_on_epoch_reset)
             end_datapipe.reset()
         # In-process (num_workers == 0)
         else:
@@ -475,7 +458,7 @@ class DistributedReadingService(ReadingServiceInterface):
         )
 
     def _share_seed(self):
-        shared_seed = _generate_random_seed()
+        shared_seed = generate_random_scalar_tensor()
         dist.broadcast(shared_seed, src=0, group=self._pg)
         return shared_seed.item()
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -181,10 +181,17 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         multiprocessing_context (str, optional): Multiprocessing starting method.
             If method is None then the default context is returned.
             Otherwise, method should be 'fork', 'spawn'.
-        prefetch_worker: (int, 10 by default):
-        prefetch_mainloop: (int, 10 by default):
-        worker_init_fn: (Callable, optional):
-        worker_reset_fn: (Callable, optional):
+        prefetch_worker: (int, 10 by default): Number of data will be prefetched at
+            the end of each worker process.
+        prefetch_mainloop: (int, 10 by default): Number of data will be prefetched
+            at the end of the whole pipeline in the main process.
+        worker_init_fn: (Callable, optional): Function to be called when each worker
+            process launches with ``DistInfo``, ``WorkerInfo`` and ``DataPipe``
+            as the expected arguments.
+        worker_reset_fn: (Callable, optional): Function to be called at the beginning
+            of each epoch in each worker process with ``DistInfo``, ``WorkerInfo``
+            and ``DataPipe`` as the expected arguments.
+
     """
     num_workers: int
     multiprocessing_context: Optional[str]

--- a/torchdata/dataloader2/utils/__init__.py
+++ b/torchdata/dataloader2/utils/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from torchdata.dataloader2.utils.random import generate_random_int, generate_random_scalar_tensor
+from torchdata.dataloader2.utils.worker import DistInfo, process_init_fn, process_reset_fn, WorkerInfo
+
+
+__all__ = [
+    "DistInfo",
+    "WorkerInfo",
+    "generate_random_int",
+    "generate_random_scalar_tensor",
+    "process_init_fn",
+    "process_reset_fn",
+]
+
+assert __all__ == sorted(__all__)

--- a/torchdata/dataloader2/utils/random.py
+++ b/torchdata/dataloader2/utils/random.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Optional
+
+import torch
+
+
+def generate_random_scalar_tensor(
+    rng: Optional[torch.Generator] = None, dtype: torch.dtype = torch.int64
+) -> torch.Tensor:
+    return torch.empty((), dtype=dtype).random_(generator=rng)
+
+
+def generate_random_int(rng: Optional[torch.Generator] = None, dtype: torch.dtype = torch.int64) -> int:
+    return int(generate_random_scalar_tensor(rng, dtype).item())

--- a/torchdata/dataloader2/utils/worker.py
+++ b/torchdata/dataloader2/utils/worker.py
@@ -1,0 +1,105 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import random
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import torch
+
+from torchdata.dataloader2.graph import DataPipe
+from torchdata.dataloader2.utils import generate_random_int
+from torchdata.datapipes.iter import IterDataPipe
+from torchdata.datapipes.map import MapDataPipe
+
+try:
+    import numpy
+
+    HAS_NUMPY = True
+except ModuleNotFoundError:
+    HAS_NUMPY = False
+
+
+@dataclass(frozen=True)
+class DistInfo:
+    r"""
+    Message class for keeping track of distributed information.
+    """
+    world_size: int = 1
+    rank: int = 0
+
+
+@dataclass(frozen=True)
+class WorkerInfo:
+    r"""
+    Message class for keeping track of worker information.
+    """
+    num_workers: int
+    worker_id: int
+
+
+@dataclass(frozen=True)
+class _ExtraInfo:
+    r"""
+    Message class for extra arguments.
+    """
+    shared_seed: int
+
+
+def process_init_fn(
+    datapipe: DataPipe,
+    dist_info: DistInfo,
+    worker_info: WorkerInfo,
+    custom_init_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]] = None,
+) -> DataPipe:
+    global_worker_id = worker_info.worker_id * dist_info.world_size + dist_info.rank
+    total_num_workers = worker_info.num_workers * dist_info.world_size
+    torch.utils.data.graph_settings.apply_sharding(datapipe, total_num_workers, global_worker_id)
+
+    if custom_init_fn is not None:
+        datapipe = custom_init_fn(datapipe, dist_info, worker_info)
+        assert isinstance(datapipe, (IterDataPipe, MapDataPipe))
+
+    return datapipe
+
+
+def process_reset_fn(
+    datapipe: DataPipe,
+    dist_info: DistInfo,
+    worker_info: WorkerInfo,
+    extra_info: _ExtraInfo,
+    custom_reset_fn: Optional[Callable[[DataPipe, DistInfo, WorkerInfo], DataPipe]] = None,
+) -> DataPipe:
+    # This function will receive worker local copy of datapipe and reset function from ``initialize_iteration``
+    worker_seed_generator = torch.Generator()
+    worker_seed_generator.manual_seed(extra_info.shared_seed)
+    torch.utils.data.graph_settings.apply_random_seed(
+        datapipe,
+        worker_seed_generator,
+    )
+    # Set different seeds across distributed workers
+    global_worker_id = worker_info.worker_id * dist_info.world_size + dist_info.rank
+    worker_seed_generator.manual_seed(extra_info.shared_seed + global_worker_id)
+
+    py_seed = generate_random_int(worker_seed_generator)
+    random.seed(py_seed)
+
+    torch_seed = generate_random_int(worker_seed_generator)
+    torch.manual_seed(torch_seed)
+
+    if HAS_NUMPY:
+        # Numpy only accepts uint32 as the seed
+        np_seed = generate_random_int(worker_seed_generator, torch.int32)
+        if np_seed < 0:
+            np_seed = 2 ** 32 + np_seed
+        numpy.random.seed(np_seed)
+
+    if custom_reset_fn is not None:
+        datapipe = custom_reset_fn(datapipe, dist_info, worker_info)
+        assert isinstance(datapipe, (IterDataPipe, MapDataPipe))
+
+    return datapipe

--- a/torchdata/datapipes/iter/util/prefetcher.py
+++ b/torchdata/datapipes/iter/util/prefetcher.py
@@ -36,8 +36,8 @@ class PrefetcherIterDataPipe(IterDataPipe):
     from getting the sample ready ahead of time.
 
     This is used by ``PrototypeMultiProcessingReadingService`` when the arguments
-    ``prefetch_worker`` (for prefetching at each worker process) or
-    ``prefetch_mainloop`` (for prefetching at the moain loop) are greater than 0.
+    ``worker_prefetch_cnt`` (for prefetching at each worker process) or
+    ``main_prefetch_cnt`` (for prefetching at the main loop) are greater than 0.
 
     Beyond the built-in use cases, this can be useful to put after I/O DataPipes that have
     expensive I/O operations (e.g. takes a long time to request a file from a remote server).


### PR DESCRIPTION
### Changes

- Add `worker_init_fn` and `worker_reset_fn` to `PrototypeMultiprocessingReadingService`. This should help `SequentialRS` to extend `worker_reset_fn` per epoch (still need to hack by assigning `worker_reset_fn` manually)
- Move `_process_init_fn` and `_process_reset_fn` and move random number/tensor generation to `torchdata.dataloader2.utils`
- Instead of using explicit arguments for `init_fn` or `reset_fn`, add `DistInfo` and `WorkerInfo` to pass relevant information to worker. This should help extensibility to add extra information to those `Info` class
- 