### PR TITLE
Fix CI to use stable numpy and networkx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install -r requirements.txt
+          pip3 install networkx
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
           pip3 install cmake ninja
           echo "/home/runner/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -31,7 +31,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torchvision from nightlies
-        run: pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        run: |
+          pip install numpy networkx
+          pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -79,7 +81,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torchtext from nightlies
-        run: pip install --pre torch torchtext -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        run: |
+          pip install numpy networkx
+          pip install --pre torch torchtext -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -122,7 +126,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torchaudio from nightlies
-        run: pip install --pre torch torchaudio -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        run: |
+          pip install networkx
+          pip install --pre torch torchaudio -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install PyTorch
         run: |
+          pip3 install networkx
           pip3 install --pre torch -f "${{ steps.pytorch_channel.outputs.value }}"
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Fixes torchvision broken CI caused by pre-release `numpy`.

In our CI, we install `torch` using `--pre` flag, which will make `pip` to use pre-release `numpy` and `networkx`. I have reported to TorchVision about the issue so they should be able to start to investigate how to prevent the problem when `numpy` promotes this release version to stable. For TorchData side, to mitigate the problem, the CI should use stable `numpy`.