### PR TITLE
Prevent reset iteration message sent twice to workers

### DIFF
--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -253,10 +253,11 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         if self.worker_prefetch_cnt > 0:
             datapipe = datapipe.prefetch(self.worker_prefetch_cnt)
 
+        ctx = mp.get_context(self.multiprocessing_context)
+
         for worker_id in range(self.num_workers):
             worker_info = WorkerInfo(self.num_workers, worker_id)
             call_on_process_init = partial(process_init_fn, worker_info=worker_info, custom_init_fn=self.worker_init_fn)
-            ctx = mp.get_context(self.multiprocessing_context)
             # Process contains a ProtocolServer
             (process, req_queue, res_queue) = communication.eventloop.SpawnProcessForDataPipeline(
                 ctx,
@@ -300,7 +301,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             dist_info = _DistInfo(shared_seed_int, self._world_size, self._rank)
             call_on_epoch_reset = partial(process_reset_fn, dist_info=dist_info, custom_reset_fn=self.worker_reset_fn)
             end_datapipe.reset_epoch(call_on_epoch_reset)
-            end_datapipe.reset()
         # In-process (num_workers == 0)
         else:
             # Technically speaking, we should call `_process_reset_fn` to reset global RNGs

--- a/torchdata/datapipes/iter/util/header.py
+++ b/torchdata/datapipes/iter/util/header.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterator, TypeVar, Optional
+from typing import Iterator, Optional, TypeVar
 from warnings import warn
 
 from torchdata.datapipes import functional_datapipe


### PR DESCRIPTION
Remove `end_datapipe.reset()` as it's going to be invoked at the beginning of iteration.
nit changes
- move `mp_ctx` creation out of loop
- Fix lint