### PR TITLE
Record elastic worker error

### DIFF
--- a/test/bin/elastic_training.py
+++ b/test/bin/elastic_training.py
@@ -10,6 +10,7 @@ import argparse
 import torch
 import torch.distributed as dist
 
+from torch.distributed.elastic.multiprocessing.errors import record
 from torch.utils.data import DataLoader
 from torchdata.dataloader2 import DataLoader2, DistributedReadingService
 from torchdata.datapipes.iter import IterableWrapper
@@ -33,6 +34,7 @@ def _get_dataloader(data_length: int, dl2: bool, shuffle: bool, rs=None):
     return dl
 
 
+@record
 def main(backend, dl2):
     dist.init_process_group(backend)
     rank = dist.get_rank()

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -245,10 +245,6 @@ class DistributedTest(TestCase):
         world_size = DEFAULT_WORLD_SIZE if backend != "nccl" else torch.cuda.device_count()
         launch_distributed_training(backend, world_size, fn=partial(DistributedTest._test_distributed_training, True))
 
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Torch Elastic is not working properly on Windows. See: https://github.com/pytorch/pytorch/issues/85427",
-    )
     @backend_parametrize
     def test_elastic_training_dl2(self, backend) -> None:
         world_size = DEFAULT_WORLD_SIZE if backend != "nccl" else torch.cuda.device_count()
@@ -271,10 +267,6 @@ class DistributedTest(TestCase):
         world_size = DEFAULT_WORLD_SIZE if backend != "nccl" else torch.cuda.device_count()
         launch_distributed_training(backend, world_size, fn=partial(DistributedTest._test_distributed_training, False))
 
-    @unittest.skipIf(
-        IS_WINDOWS,
-        "Torch Elastic is not working properly on Windows. See: https://github.com/pytorch/pytorch/issues/85427",
-    )
     @unittest.skipIf(sys.version_info < (3, 8), "Torch Elastic requires Python >= 3.8")
     @backend_parametrize
     def test_elastic_training_dl1(self, backend) -> None:


### PR DESCRIPTION
### Changes

- Record worker error to figure out what's wrong with our nightly release pipeline (https://github.com/pytorch/data/actions/workflows/nightly_release.yml)
  - All commits work fine in the PR time. But, after they are anded, the nightly CI becomes broken due to this unknown elastic launch issue
- Add standalone flag as recommended by `torchelastic`
- Remove `skip` windows as the issue has been fixed
