### PR TITLE
Attemp to fix flaky [Connection refused] failure for elastic test

### DIFF
--- a/test/bin/elastic_training.py
+++ b/test/bin/elastic_training.py
@@ -74,6 +74,10 @@ def main(backend, dl2):
     assert len(results[0]) == len(results[2])
     assert results[0] != results[2]
 
+    # Properly shutdown the process group
+    if isinstance(dl, DataLoader2):
+        dl.shutdown()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Elastic Training")


### PR DESCRIPTION
Add `dl.shutdown` to destroy the distributed process group. This potentially fixes the problem that the port is taken up by other process group.

The other failures in our nightly release are caused by PyTorch's dependency issue (`sympy` is missing from conda dependency)