### PR TITLE
Forward fix to enable passing dispatching Queue between processes

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -4,13 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-
+import multiprocessing as mp
 import os
 import pickle
 import unittest
 from unittest import TestCase
 
 import torch
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
 from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
 
@@ -41,6 +42,8 @@ except ImportError:
 
 skipIfNoDill = unittest.skipIf(not HAS_DILL, "no dill")
 TEST_WITH_TSAN = os.getenv("PYTORCH_TEST_WITH_TSAN", "0") == "1"
+
+mp_ctx_parametrize = parametrize("ctx", mp.get_all_start_methods())
 
 
 class _ReadingServiceWrapper:
@@ -375,13 +378,17 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         )
         return datapipe
 
-    def test_worker_fns(self):
+    @mp_ctx_parametrize
+    def test_worker_fns(self, ctx):
         dp: IterDataPipe = IterableWrapper(range(100)).batch(2).shuffle()
         torch.manual_seed(123)
         exp = list(dp)
 
         rs = PrototypeMultiProcessingReadingService(
-            num_workers=1, worker_init_fn=self._worker_init_fn, worker_reset_fn=self._worker_reset_fn
+            num_workers=1,
+            multiprocessing_context=ctx,
+            worker_init_fn=self._worker_init_fn,
+            worker_reset_fn=self._worker_reset_fn,
         )
         dl = DataLoader2(dp, reading_service=rs)
 
@@ -393,7 +400,8 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         res2 = list(dl)
         self.assertEqual(exp, res2)
 
-    def test_single_branch_non_replicable(self):
+    @mp_ctx_parametrize
+    def test_single_branch_non_replicable(self, ctx):
         r"""
         For single branch pipeline with a non-replicable DataPipe, all ``sharding_filters``
         in the pipeline become non-replicable.
@@ -423,7 +431,9 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         graph = traverse_dps(end_dp)
         sf_dp = single_br_dp.sharding_filter()
         replace_dp(graph, single_br_dp, sf_dp)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism and dynamic sharding
         _assert_deterministic_dl_res(dl, [i * 4 for i in range(10)])
 
@@ -435,7 +445,9 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         replace_dp(graph, single_br_dp, round_robin_dispatcher)
         sf_dp = map_dp.sharding_filter()
         replace_dp(graph, map_dp, sf_dp)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism for non-replicable pipeline
         _assert_deterministic_dl_res(dl, [i * 4 for i in range(10)])
 
@@ -447,11 +459,14 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         replace_dp(graph, single_br_dp, sf_dp)
         round_robin_dispatcher = ShardingRoundRobinDispatcher(map_dp, SHARDING_PRIORITIES.MULTIPROCESSING)
         replace_dp(graph, map_dp, round_robin_dispatcher)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism for non-replicable pipeline
         _assert_deterministic_dl_res(dl, [i * 4 for i in range(10)])
 
-    def test_multi_branch_non_replicable(self):
+    @mp_ctx_parametrize
+    def test_multi_branch_non_replicable(self, ctx) -> None:
         r"""
         For multi-branch pipeline with a non-replicable DataPipe on one branch,
         all ``sharding_filter`` on the other branches should remain replicable.
@@ -486,7 +501,9 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         sf2_dp = branch2_dp.sharding_filter()
         replace_dp(graph, branch1_dp, sf1_dp)
         replace_dp(graph, branch2_dp, sf2_dp)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism and dynamic sharding
         _assert_deterministic_dl_res(dl, [i * 2 for i in range(10)], list(range(10)))
 
@@ -499,7 +516,9 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         # The other branch should has a sharding_filter to make data even
         sf_dp = branch2_dp.sharding_filter()
         replace_dp(graph, branch2_dp, sf_dp)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism for non-replicable pipeline
         _assert_deterministic_dl_res(dl, [i * 2 for i in range(10)], list(range(10)))
 
@@ -511,9 +530,14 @@ class PrototypeMultiProcessingReadingServiceTest(TestCase):
         replace_dp(graph, branch1_dp, non_replicable_dp1)
         non_replicable_dp2 = ShardingRoundRobinDispatcher(branch2_dp, SHARDING_PRIORITIES.MULTIPROCESSING)
         replace_dp(graph, branch2_dp, non_replicable_dp2)
-        dl = DataLoader2(end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2))
+        dl = DataLoader2(
+            end_dp, reading_service=PrototypeMultiProcessingReadingService(num_workers=2, multiprocessing_context=ctx)
+        )
         # Determinism for non-replicable pipeline
         _assert_deterministic_dl_res(dl, [i * 2 for i in range(10)], list(range(10)))
+
+
+instantiate_parametrized_tests(PrototypeMultiProcessingReadingServiceTest)
 
 
 if __name__ == "__main__":

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -169,14 +169,18 @@ class DataLoader2(Generic[T_co]):
         r"""
         Shuts down ``ReadingService`` and clean up iterator.
         """
-        if not self._reset_iter:
-            self._reset_iter = True
-            self._datapipe_iter = None
-        if not self._terminated:
-            if self.reading_service is not None:
-                self.reading_service.finalize_iteration()
-                self.reading_service.finalize()
-            self._terminated = True
+        try:
+            if not self._reset_iter:
+                self._reset_iter = True
+                self._datapipe_iter = None
+            if not self._terminated:
+                if self.reading_service is not None:
+                    self.reading_service.finalize_iteration()
+                    self.reading_service.finalize()
+                self._terminated = True
+        # Ignore AttributeError in case any attribute has been removed before `__del__`
+        except AttributeError:
+            pass
 
     def __enter__(self) -> "DataLoader2[T_co]":
         return self

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import multiprocessing as py_mp
+import queue
 
 from abc import ABC, abstractmethod
 from datetime import timedelta
@@ -233,15 +234,23 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                 process.daemon = True
                 process.start()
                 self._dispatch_process = (process, req_queues, res_queues)
+                for req_queue in req_queues:
+                    req_queue.cancel_join_thread()
+                for res_queue in res_queues:
+                    res_queue.cancel_join_thread()
 
         for worker_id in range(self.num_workers):
             worker_info = WorkerInfo(self.num_workers, worker_id)
             # Dispatching process for non-replicable DataPipes exists
-            if self._dispatch_process is not None:
-                # Use the placehold to pass request/response queue to each worker process
-                dummy_dp.req_queue = self._dispatch_process[1][worker_id]
-                dummy_dp.res_queue = self._dispatch_process[2][worker_id]
-            call_on_process_init = partial(process_init_fn, worker_info=worker_info, custom_init_fn=self.worker_init_fn)
+            dispatching_req_queue = self._dispatch_process[1][worker_id] if self._dispatch_process is not None else None
+            dispatching_res_queue = self._dispatch_process[2][worker_id] if self._dispatch_process is not None else None
+            call_on_process_init = partial(
+                process_init_fn,
+                worker_info=worker_info,
+                custom_init_fn=self.worker_init_fn,
+                dispatching_req_queue=dispatching_req_queue,
+                dispatching_res_queue=dispatching_res_queue,
+            )
             (process, req_queue, res_queue) = communication.eventloop.CreateProcessForDataPipeline(
                 ctx,
                 datapipe,
@@ -258,6 +267,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         self.end_datapipe = communication.iter._IterateQueueDataPipes(self.datapipes)  # type: ignore[assignment]
         if self.main_prefetch_cnt > 0:
             self.end_datapipe = self.end_datapipe.prefetch(self.main_prefetch_cnt)  # type: ignore[union-attr]
+
         return self.end_datapipe  # type: ignore[return-value]
 
     def initialize_iteration(self) -> None:
@@ -304,7 +314,10 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             # TODO(619): Can send terminations simultaneously
             # TODO(620): Make termination a function of QueueWrapperDataPipe (similar to reset)
             req_queue.put(communication.messages.TerminateRequest())
-            _ = res_queue.get()
+            try:
+                _ = res_queue.get(timeout=default_dl2_worker_join_timeout_in_s)
+            except queue.Empty:
+                pass
             process.join(default_dl2_worker_join_timeout_in_s)
 
         # Clean up worker processes
@@ -325,7 +338,10 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                 for req_queue in self._dispatch_process[1]:
                     req_queue.put(communication.messages.TerminateRequest())
                 for res_queue in self._dispatch_process[2]:
-                    _ = res_queue.get()
+                    try:
+                        _ = res_queue.get(timeout=default_dl2_worker_join_timeout_in_s)
+                    except queue.Empty:
+                        pass
                 self._dispatch_process[0].join(default_dl2_worker_join_timeout_in_s)
             except AttributeError:
                 # Due to non-deterministic order of destruction, by the time `finalize` is called,

--- a/torchdata/dataloader2/utils/dispatch.py
+++ b/torchdata/dataloader2/utils/dispatch.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from multiprocessing.queues import Queue
+#  from multiprocessing.queues import Queue
 from typing import Dict, List, Optional, Set
 
 from torchdata.dataloader2.graph import DataPipe, DataPipeGraph, list_dps, traverse_dps
@@ -20,8 +20,10 @@ class _DummyIterDataPipe(IterDataPipe):
     This DataPipe is a placeholder to be replaced by the ``QueueWrapper``
     that connects the worker process for non-replicable DataPipe.
     """
-    req_queue: Queue
-    res_queue: Queue
+    # TODO: Revert `_DummyIterDataPipe` as the placeholder when `_SerializationWrapper`
+    #       can handle mp.Queue. See: https://github.com/pytorch/data/issues/934
+    #  req_queue: Queue
+    #  res_queue: Queue
 
 
 def find_lca_non_replicable_dp(graph: DataPipeGraph) -> Optional[DataPipe]:


### PR DESCRIPTION
Due to the issue https://github.com/pytorch/data/issues/934, I can't attach `mp.Queue` to the `_DummyDataPipe` and transfer it to subprocesses when `spawn` or `forkserver` is used.
So, I did the following works

## Changes:
- Extend `process_init_fn` to accept `dispatching_req_queue` and `dispatching_res_queue` without relying on `_DummyDataPipe`
- Add tests to cover all available mp start methods per platform
- A few nit changes in `dataloader2.py` and `reading_service.py` to make sure `Error` is ignored during `__del__`.