### PR TITLE
Execute smoketest for release workflow

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -196,7 +196,7 @@ jobs:
             conda activate wheel_build_env
           fi
           pip3 install dist/torchdata*.whl
-      - name: Run DataPipes Tests with pytest
+      - name: Run Smoke Tests
         shell: bash -l {0}
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
@@ -207,8 +207,7 @@ jobs:
           if ${{ startsWith( matrix.os, 'macos' ) }}; then
             conda activate wheel_build_env
           fi
-          pip3 install -r test/requirements.txt
-          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
+          python test/smoke_test/smoke_test.py
       - name: Upload Wheels to Github
         if: always()
         uses: actions/upload-artifact@v3
@@ -367,15 +366,6 @@ jobs:
             CONDA_CHANNEL=pytorch-${{ needs.get_release_type.outputs.type }}
           fi
           conda install pytorch torchdata cpuonly -c $(pwd)/conda-bld/ -c "$CONDA_CHANNEL"
-      - name: Run DataPipes Tests with pytest
-        shell: bash -l {0}
-        run: |
-          if ${{ ! startsWith( matrix.os, 'windows' ) }}; then
-            source "${MINICONDA_INSTALL_PATH}/etc/profile.d/conda.sh"
-          fi
-          conda activate "${CONDA_ENV_PATH}"
-          conda env update --file test/requirements.yml
-          python -m pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py --ignore=test/test_audio_examples.py
       - name: Upload Conda Package to Github
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -353,19 +353,6 @@ jobs:
           conda install -yq conda-build -c conda-forge
           packaging/build_conda.sh
           conda index ./conda-bld
-      - name: Install TorchData Conda Package
-        shell: bash -l {0}
-        run: |
-          if ${{ ! startsWith( matrix.os, 'windows' ) }}; then
-            source "${MINICONDA_INSTALL_PATH}/etc/profile.d/conda.sh"
-          fi
-          conda activate "${CONDA_ENV_PATH}"
-          if [[ ${{ needs.get_release_type.outputs.type }} == 'official' ]]; then
-            CONDA_CHANNEL=pytorch
-          else
-            CONDA_CHANNEL=pytorch-${{ needs.get_release_type.outputs.type }}
-          fi
-          conda install pytorch torchdata cpuonly -c $(pwd)/conda-bld/ -c "$CONDA_CHANNEL"
       - name: Upload Conda Package to Github
         if: always()
         uses: actions/upload-artifact@v3

--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -36,6 +36,7 @@ build:
 test:
   imports:
     - torchdata
+    - torchdata.dataloader2
     - torchdata.datapipes
   source_files:
     - test


### PR DESCRIPTION
To reduce the time spent for release workflow, disable all TorchData test in the release workflows since each PR/main branch should have been tested. There is no need to run an extra round of tests.
And, use smoketest to make sure the compiled TorchData package having all required modules.