### PR TITLE
Replace easy_install by pip install to fix CI for MacOS

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -481,7 +481,7 @@ jobs:
           fi
 
           pip3 install -r requirements.txt
-          python3 setup.py install
+          pip3 install .
       - name: Check env
         run: echo `which spinx-build`
       - name: Build the docset

--- a/.github/workflows/aistore_ci.yml
+++ b/.github/workflows/aistore_ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: NVIDIA/aistore@master
       - name: Build TorchData
         run: |
-          python setup.py install
+          pip3 install .
       - name: Install test requirements
         run: pip3 install -r test/requirements_aistore.txt
       - name: Run AIStore DataPipe tests with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           echo "/home/runner/.local/bin" >> $GITHUB_PATH
       - name: Build TorchData
         run: |
-          python setup.py install
+          pip3 install .
         env:
           BUILD_S3: 1
       - name: Install test requirements

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install torchdata
         run: |
           pip install -r requirements.txt
-          python setup.py install
+          pip install .
 
       - name: Install test requirements
         run: pip install pytest pytest-mock scipy iopath pycocotools h5py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
           pip3 install mypy==0.960 numpy types-requests
       - name: Build TorchData
         run: |
-          python setup.py develop
+          pip3 install .
       - name: Run mypy
         env:
           MYPY_FORCE_COLOR: 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ conda install pytorch -c pytorch-nightly
 ```bash
 git clone https://github.com/pytorch/data.git
 cd data
-python setup.py develop
+pip install -e .
 pip install flake8 typing mypy pytest expecttest
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can then proceed to run [our examples](https://github.com/pytorch/data/tree/
 ### From source
 
 ```bash
-python setup.py install
+pip install .
 ```
 
 If you'd like to include the S3 IO datapipes and aws-sdk-cpp, you may also follow

--- a/packaging/torchdata/bld.bat
+++ b/packaging/torchdata/bld.bat
@@ -11,5 +11,5 @@ git config --system core.longpaths true
 git submodule update --init --recursive
 if errorlevel 1 exit /b 1
 
-python setup.py install --single-version-externally-managed --record=record.txt
+pip install .
 if errorlevel 1 exit /b 1

--- a/packaging/torchdata/build.sh
+++ b/packaging/torchdata/build.sh
@@ -8,4 +8,4 @@
 set -ex
 
 git submodule update --init --recursive
-python setup.py install --single-version-externally-managed --record=record.txt
+pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ target-version = ["py37"]
 requires = [
     "setuptools",
     "wheel",
+    "ninja",
     "cmake",
     "torch",
 ]

--- a/torchdata/datapipes/iter/load/README.md
+++ b/torchdata/datapipes/iter/load/README.md
@@ -14,7 +14,7 @@ S3 IO datapipes are included when building with flag `BUILD_S3=1`. The following
 source with S3 datapipes.
 
 ```bash
-BUILD_S3=1 python setup.py install
+BUILD_S3=1 pip install .
 ```
 
 We also offer nightly and official (>=0.4.0) TorchData releases integrated with `AWSSDK` on the most of platforms.


### PR DESCRIPTION
Fixes #948

### Changes
- To fix MacOS CI, uses `pip install .` or `pip install -e .` to replace `python setup.py install` or `python setup.py develop`
  - `pip install` would use an isolated environment to prevent the problem in our CI
  - Add `ninja` to [`pyproject.toml`](https://github.com/pytorch/data/blob/main/pyproject.toml) to make sure CMake works properly using `pip install`
  - Easy install is deprecated https://setuptools.pypa.io/en/latest/deprecated/easy_install.html#easy-install
- Change documents to advocate `pip install` rather than `python setup.py`