### PR TITLE
[DataPipe] Fixing fsspec DataPipe to be compatible with new version of fsspec

### DIFF
--- a/torchdata/datapipes/iter/load/fsspec.py
+++ b/torchdata/datapipes/iter/load/fsspec.py
@@ -87,7 +87,7 @@ class FSSpecFileListerIterDataPipe(IterDataPipe[str]):
             if fs.isfile(path):
                 yield root
             else:
-                for file_name in fs.ls(path):
+                for file_name in fs.ls(path, detail=False):  # Ensure it returns List[str], not List[Dict]
                     if not match_masks(file_name, self.masks):
                         continue
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #957

Fixes #956 

Context:

In the old version of `fsspec`, the default argument is `detail=False` for method `ls` for the filesystem `memory`, thus it returned a list of `str`. In the new version, the default is `detail=True`, which returns list of `Dict`.

Source code:
https://github.com/fsspec/filesystem_spec/blob/2023.1.0/fsspec/implementations/memory.py#L34

Differential Revision: [D42646692](https://our.internmc.facebook.com/intern/diff/D42646692)