### PR TITLE
Improve reset epoch sent to all workers before blocking to receive

### DIFF
--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -272,6 +272,7 @@ class _IterateQueueDataPipes(IterDataPipe):
             dp.protocol.request_reset_epoch(
                 partial(reset_fn, worker_info=worker_info, seed_generator=worker_seed_generator)
             )
+        for dp in self.datapipes:
             while True:
                 try:
                     dp.protocol.get_response_reset_epoch()

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -259,8 +259,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         replicable_dp = replicable_dps[0]
 
         if self.worker_prefetch_cnt > 0:
-            worker_prefetch_dp = replicable_dp.prefetch(self.worker_prefetch_cnt)
-            replicable_dp = worker_prefetch_dp
+            replicable_dp = replicable_dp.prefetch(self.worker_prefetch_cnt)
 
         for worker_id in range(self.num_workers):
             worker_info = WorkerInfo(self.num_workers, worker_id)


### PR DESCRIPTION
### Changes

- Send request to workers before requesting response to reduce the latency for each new epoch
- Minor change for resetting `replicable_dp`
