### PR TITLE
Only run wheels/package build step for PRs with changes of the CI workflows

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -2,6 +2,9 @@ name: Build Linux Conda
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/build_wheels_linux.yml
   push:
     branches:
       - nightly

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -2,6 +2,9 @@ name: Build Linux Wheels
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/build_conda_linux.yml
+      - .github/workflows/build_wheels_linux.yml
   push:
     branches:
       - nightly


### PR DESCRIPTION
Reduce the waiting time on CI for PRs.