### PR TITLE
Pin sphinx to 5 to render table correctly

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==5.0.0
 # torch
 # PyTorch Theme
 -e git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme


### PR DESCRIPTION
Fixes #959

Pin sphinx to 5 as pytorch is doing to help render tables correctly in pytorch.org/data

PyTorch: https://github.com/pytorch/pytorch/blob/207399cf5f68a6370cbacc28fce3fc5d9132c87f/docs/requirements.txt#LL1