### PR TITLE
Fix lint for SequentialReadingService and unify the API for process_reset_fn

### DIFF
--- a/docs/source/dataloader2.rst
+++ b/docs/source/dataloader2.rst
@@ -33,6 +33,7 @@ ReadingService
     DistributedReadingService
     MultiProcessingReadingService
     PrototypeMultiProcessingReadingService
+    SequentialReadingService
 
 Each ``ReadingServices`` would take the ``DataPipe`` graph and rewrite it to achieve a few features like dynamic sharding, sharing random seeds and snapshoting for multi-/distributed processes. For more detail about those features, please refer to `the documentation <reading_service.html>`_.
 

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -13,7 +13,7 @@ from torchdata.dataloader2.reading_service import (
     MultiProcessingReadingService,
     PrototypeMultiProcessingReadingService,
     ReadingServiceInterface,
-    SequentialReadingService
+    SequentialReadingService,
 )
 from torchdata.dataloader2.shuffle_spec import ShuffleSpec
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -328,7 +328,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                 self._main_prefetch_datapipe.reset()  # type: ignore[union-attr]
             # Send the shared seed to subprocesses
             call_on_epoch_reset = partial(
-                process_reset_fn, custom_reset_fn=self.worker_reset_fn, custom_dispatch_process_reset_fn=iter_reset_fn
+                process_reset_fn, iter_reset_fn=iter_reset_fn, custom_reset_fn=self.worker_reset_fn
             )
             assert self._worker_consumer_datapipe is not None
             self._worker_consumer_datapipe.reset_epoch(call_on_epoch_reset, seed_generator)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -64,7 +64,9 @@ class ReadingServiceInterface(ABC):
         """
         pass
 
-    def initialize_iteration(self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None) -> Optional[Callable[[DataPipe], DataPipe]]:
+    def initialize_iteration(
+        self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         r"""
         ``ReadingService`` spins up service for an epoch. Called at the beginning
         of every time getting ``DataLoader2`` iterator.
@@ -303,7 +305,9 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
 
         return self._end_datapipe  # type: ignore[return-value]
 
-    def initialize_iteration(self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None) -> Optional[Callable[[DataPipe], DataPipe]]:
+    def initialize_iteration(
+        self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         if self._pg is not None:
             shared_seed_int = dist_share_seed(seed_generator.generate_shared_seed(), self._pg)
             seed_generator.seed(shared_seed_int)
@@ -318,7 +322,9 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                 # Stop prefetching first
                 self._main_prefetch_datapipe.reset()  # type: ignore[union-attr]
             # Send the shared seed to subprocesses
-            call_on_epoch_reset = partial(process_reset_fn, custom_reset_fn=self.worker_reset_fn, custom_dispatch_process_reset_fn=iter_reset_fn)
+            call_on_epoch_reset = partial(
+                process_reset_fn, custom_reset_fn=self.worker_reset_fn, custom_dispatch_process_reset_fn=iter_reset_fn
+            )
             assert self._worker_consumer_datapipe is not None
             self._worker_consumer_datapipe.reset_epoch(call_on_epoch_reset, seed_generator)
         # In-process (num_workers == 0)
@@ -328,6 +334,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             # (random, torch and numpy), if users have already seeded them in the main process
             # TODO(ejguan): This should be fixed by adding a method to isolate global RNGs
             pass
+        return None
 
     def __del__(self):
         self.finalize()
@@ -485,7 +492,9 @@ class DistributedReadingService(ReadingServiceInterface):
         self._datapipe = datapipe
         return datapipe
 
-    def initialize_iteration(self, seed_generator: SeedGenerator) -> None:
+    def initialize_iteration(
+        self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         r"""
         Shares the same seed from rank 0 to other ranks across the distributed processes
         and apply the random seed to the ``DataPipe`` graph.
@@ -496,6 +505,7 @@ class DistributedReadingService(ReadingServiceInterface):
         seed_generator.seed(shared_seed)
         seed_generator = seed_generator.spawn(self._rank, inplace=True)
         set_graph_random_seed(self._datapipe, seed_generator)
+        return None
 
     def __del__(self):
         self.finalize()
@@ -509,7 +519,7 @@ class DistributedReadingService(ReadingServiceInterface):
             self._pg = None
 
 
-class SequentialReadingService(ReadingServiceInterface):
+class SequentialReadingService(CheckpointableReadingServiceInterface):
     def __init__(self, *reading_services):
         self.reading_services = reading_services
 
@@ -525,10 +535,15 @@ class SequentialReadingService(ReadingServiceInterface):
             rs.finalize()
 
     # Sequential Order
-    def initialize_iteration(self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None) -> Optional[Callable[[DataPipe], DataPipe]]:
+    def initialize_iteration(
+        self, seed_generator: SeedGenerator, iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         chained_iter_reset_fn = iter_reset_fn
         for rs in self.reading_services:
-            chained_iter_reset_fn = rs.initialize_iteration(seed_generator=seed_generator, iter_reset_fn=chained_iter_reset_fn)
+            chained_iter_reset_fn = rs.initialize_iteration(
+                seed_generator=seed_generator, iter_reset_fn=chained_iter_reset_fn
+            )
+        return None
 
     # Reversed Order
     def finalize_iteration(self) -> None:
@@ -540,9 +555,12 @@ class SequentialReadingService(ReadingServiceInterface):
         states = []
         for rs in self.reading_services:
             states.append(rs.checkpoint())
+        return b"\n".join(states)
 
     # Sequential Order, to align with initialize
-    def restore(self, datapipe, serialized_state) -> DataPipe:
-        for rs, state in zip(self.reading_service, serialized_state):
+    def restore(self, datapipe, serialized_state: bytes) -> DataPipe:
+        states = serialized_state.split(b"\n")
+        assert len(states) == len(self.reading_services)
+        for rs, state in zip(self.reading_services, states):
             datapipe = rs.restore(datapipe, state)
         return datapipe

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -75,6 +75,11 @@ class ReadingServiceInterface(ABC):
             seed_generator: SeedGenerator object created and managed by DataLoader2. As the single
                 source of randomness, it will governs the determinism for all of random operations
                 with the graph of DataPipes.
+            iter_reset_fn: Optional reset function from the prior ``ReadingServcie``
+                when ``SequentialReadingService`` chains multiple ``ReadingServices``
+
+        Returns:
+            A new ``iter_reset_fn`` to be used by subseqeuent ``ReadingService``
 
         Example:
             MultiProcessingReadingService starts setting worker seeds per process and prefetching

--- a/torchdata/dataloader2/utils/worker.py
+++ b/torchdata/dataloader2/utils/worker.py
@@ -142,7 +142,7 @@ def process_reset_fn(
     datapipe: DataPipe,
     worker_info: WorkerInfo,
     seed_generator: SeedGenerator,
-    custom_reset_fn: Optional[Callable[[DataPipe, WorkerInfo], DataPipe]] = None,
+    custom_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
     custom_dispatch_process_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None,
 ) -> DataPipe:
     r"""
@@ -160,7 +160,9 @@ def process_reset_fn(
         # Only send the reset epoch message once
         if worker_info.worker_id == 0:
             # Use WorkerInfo(1, 0)
-            dispatch_reset_fn = partial(dispatch_process_reset_fn, custom_dispatch_process_reset_fn=custom_dispatch_process_reset_fn)
+            dispatch_reset_fn = partial(
+                dispatch_process_reset_fn, custom_dispatch_process_reset_fn=custom_dispatch_process_reset_fn
+            )
             dispatch_process_consumer_dp.reset_epoch(dispatch_reset_fn, seed_generator)
 
     # Set global random states


### PR DESCRIPTION
This is the follow up for 807db8f8c7282b2f48b48b1e07439c119a2ba12f

### Changes

- Fix lint
- Fix checkpoint result
- Add inline doc
- Unify the API for process_reset_fn and dispatch_process_reset_fn

After this PR, I will land a test case and tutorial for SequentialRS
