### PR TITLE
Refactor `ShardingFilterIterDataPipe` into a seperate file (#94095)

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -20,7 +20,7 @@ import torch
 import torch.distributed as dist
 from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata.dataloader2 import (
     communication,

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -14,7 +14,7 @@ import expecttest
 from _utils._common_utils_for_test import IS_WINDOWS
 
 from torch.utils.data import IterDataPipe
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService, ReadingServiceInterface
 from torchdata.dataloader2.graph import find_dps, list_dps, remove_dp, replace_dp, traverse_dps

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -18,7 +18,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from torch.utils.data import DataLoader
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata._constants import default_dl2_worker_join_timeout_in_s, default_timeout_in_s
 from torchdata.dataloader2 import communication

--- a/torchdata/dataloader2/utils/worker.py
+++ b/torchdata/dataloader2/utils/worker.py
@@ -13,7 +13,7 @@ from typing import Callable, Optional
 
 import torch
 
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata.dataloader2 import communication
 from torchdata.dataloader2.graph import (

--- a/torchdata/datapipes/iter/__init__.pyi.in
+++ b/torchdata/datapipes/iter/__init__.pyi.in
@@ -12,7 +12,7 @@ from torchdata._constants import default_timeout_in_s
 from torchdata.datapipes.map import MapDataPipe
 from torch.utils.data import DataChunk, IterableDataset, default_collate
 from torch.utils.data.datapipes._typing import _DataPipeMeta
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union, Hashable
 

--- a/torchdata/datapipes/iter/util/sharding.py
+++ b/torchdata/datapipes/iter/util/sharding.py
@@ -6,7 +6,7 @@
 
 from typing import Iterator, Optional, TypeVar
 
-from torch.utils.data.datapipes.iter.grouping import SHARDING_PRIORITIES
+from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterDataPipe
 


### PR DESCRIPTION
Summary:
Move `ShardingFilterIterDataPipe` into a dedicated file.

Also, propose to have a dedicated parent class (`_ShardingIterDataPipe`) for sharding data pipe, as this seems more like a "system/engine-level" datapipe that gives strong hints to RS on how to execute, and needs first-class citizen treatment in RS (compared with other "user-level" datapipe that are mostly composable `Callable[[Iterable], Iterable]`.  But open to other discussions.

Open question: Should
[ShardingRoundRobinDispatcherIterDataPipe](https://github.com/pytorch/data/blob/01fc76200354501b057bb439b43a1f05f609dd0a/torchdata/datapipes/iter/util/sharding.py#L16-L17) also be considered as a `_ShardingIterDataPipe`? (e.g. this sharding is executed by replicating (the metadata), while `ShardingRoundRobinDispatcherIterDataPipe` hints too expensive to replicate so requires round robin data exchange/dispatch).

Differential Revision:
D43014692

X-link: https://github.com/pytorch/pytorch/pull/94095

D43014692

