### PR TITLE
Experiment with Python3.11 Linux Wheels Build

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -113,11 +113,7 @@ jobs:
         run: |
           conda init bash
           PYTHON_VERSION=${{ matrix.python-version }}
-          if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
-            conda create -y --name wheel_build_env -c conda-forge python=${{ matrix.python-version }}
-          else
-            conda create -y --name wheel_build_env python=${{ matrix.python-version }}
-          fi
+          conda create -y --name wheel_build_env python=${{ matrix.python-version }}
       - name: Setup msbuild on Windows
         if: startsWith( matrix.os, 'windows' )
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -114,7 +114,7 @@ jobs:
           conda init bash
           PYTHON_VERSION=${{ matrix.python-version }}
           if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
-            conda create -y --name wheel_build_end -c conda-forge python=${{ matrix.python-version }}
+            conda create -y --name wheel_build_env -c conda-forge python=${{ matrix.python-version }}
           else
             conda create -y --name wheel_build_env python=${{ matrix.python-version }}
           fi

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -69,6 +69,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
+          - "3.11"
           - pure
         exclude:
           - os: macos-latest
@@ -111,7 +112,12 @@ jobs:
         shell: bash -l {0}
         run: |
           conda init bash
-          conda create -y --name wheel_build_env python=${{ matrix.python-version }}
+          PYTHON_VERSION=${{ matrix.python-version }}
+          if [[ "${PYTHON_VERSION}" = "3.11" ]]; then
+            conda create -y --name wheel_build_end -c conda-forge python=${{ matrix.python-version }}
+          else
+            conda create -y --name wheel_build_env python=${{ matrix.python-version }}
+          fi
       - name: Setup msbuild on Windows
         if: startsWith( matrix.os, 'windows' )
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -112,7 +112,6 @@ jobs:
         shell: bash -l {0}
         run: |
           conda init bash
-          PYTHON_VERSION=${{ matrix.python-version }}
           conda create -y --name wheel_build_env python=${{ matrix.python-version }}
       - name: Setup msbuild on Windows
         if: startsWith( matrix.os, 'windows' )


### PR DESCRIPTION
Python3.11 support for Wheels builds. Seems to work on:
* Linux: https://github.com/pytorch/data/actions/runs/4109256531/jobs/7090889894
* MacOS x86: https://github.com/pytorch/data/actions/runs/4109256531/jobs/7090889410
* MacOS M1: https://github.com/pytorch/data/actions/runs/4109256531/jobs/7090890738