### PR TITLE
Guarantee datapipe being reset iterator when all loops have received reset request in the dispatching process

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import torch
 import torch.distributed as dist
-from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
 
 from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
@@ -764,6 +764,7 @@ def _dist_training_fn(rank, world_size, q, dp_fn, rs_fn, num_workers, ctx):
 
 
 @skipIfNoDistributed
+@unittest.skipIf(IS_WINDOWS, "Remove when https://github.com/pytorch/data/issues/857 is fixed")
 class SequentialReadingServiceTest(TestCase):
     @staticmethod
     def _make_dp(data_length):

--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -20,7 +20,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
+from torch.testing._internal.common_utils import instantiate_parametrized_tests, parametrize
 from torch.utils.data import DataLoader
 
 from torchdata.dataloader2 import DataLoader2, DistributedReadingService, PrototypeMultiProcessingReadingService

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -50,8 +50,6 @@ class _ResetCounter:
         assert self.cnt <= self.exp_cnt
 
     def is_reached(self) -> bool:
-        if self._reached:
-            return self._reached
         if self.cnt == self.exp_cnt:
             self._reached = True
         return self._reached

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -35,24 +35,59 @@ __all__ = [
 ]
 
 
+class _ResetCounter:
+    exp_cnt: int
+    cnt: int
+    _reached: bool
+
+    def __init__(self, exp_cnt: int):
+        self.exp_cnt = exp_cnt
+        self.cnt = 0
+        self._reached = False
+
+    def increment(self) -> None:
+        self.cnt += 1
+        assert self.cnt <= self.exp_cnt
+
+    def is_reached(self) -> bool:
+        if self._reached:
+            return self._reached
+        if self.cnt == self.exp_cnt:
+            self._reached = True
+        return self._reached
+
+    def reset(self) -> None:
+        if self._reached:
+            self._reached = False
+            self.cnt = 0
+
+
 def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, call_on_process_init=None):
     r"""
     Set the appropriate pipes and protocol server type, and create a loop over multiple datapipes
     with the protocol server in a non-blocking manner.
     """
     assert call_on_process_init is None, "``MultipleDataPipesToQueuesLoop`` does not support call_on_process_init"
-    assert len(source_datapipes) == len(req_queues) and len(req_queues) == len(
+    num_loops = len(source_datapipes)
+    assert num_loops == len(req_queues) and num_loops == len(
         res_queues
     ), "``MultipleDataPipesToQueuesLoop`` requires the same number of datapipes, request queues and response queues"
 
     torch.set_num_threads(1)
 
     loops = []
+    reset_iterator_counter = _ResetCounter(num_loops)
 
     for source_datapipe, req_queue, res_queue in zip(source_datapipes, req_queues, res_queues):
         loops.append(
-            _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, blocking_request_get=False)
-        )  # Non-blocking request
+            _create_datapipe_queue_loop(
+                source_datapipe,
+                req_queue,
+                res_queue,
+                blocking_request_get=False,
+                reset_iterator_counter=reset_iterator_counter,
+            )
+        )  # Non-blocking request with reset counters
 
     # Using `zip_longest` to guarantee the process is terminated only when
     # all loops have received `TerminateRequest`
@@ -79,7 +114,9 @@ def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_on_process_
         pass
 
 
-def _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, blocking_request_get=True):
+def _create_datapipe_queue_loop(
+    source_datapipe, req_queue, res_queue, blocking_request_get=True, reset_iterator_counter=None
+):
     if isinstance(source_datapipe, IterDataPipe):
         pipe_type = communication.iter
         protocol_type = communication.protocol.IterDataPipeQueueProtocolServer
@@ -93,6 +130,7 @@ def _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, blocking_
         source_datapipe,
         protocol_type(req_queue, res_queue),
         blocking_request_get=blocking_request_get,
+        reset_iterator_counter=reset_iterator_counter,
     )
 
 

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -127,6 +127,9 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
         source_datapipe: DataPipe
         protocol: ``IterDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
         blocking_request_get: determines if ``protocol.get_new_request`` will block
+        reset_iterator_counter: Optional counter to synchronize all loops that have received
+            `ResetIteratorRequest` within the dispatching process. It would guarantee that
+            all loops starts to reset iterator and get next element at the same time.
     """
     if not isinstance(protocol, communication.protocol.IterDataPipeQueueProtocolServer):
         raise Exception("Expecting IterDataPipeQueueProtocolServer, got", protocol)

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -113,7 +113,7 @@ def EnsureNonBlockingDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
+def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, reset_iterator_counter=None):
     """
     Indefinitely iterates over ``req_queue`` and passing values from source_datapipe to ``res_queue``.
 
@@ -145,6 +145,15 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
             protocol.response_reset_epoch()
 
         elif isinstance(request, communication.messages.ResetIteratorRequest):
+            # Ensure only reset iterator once for the dispatching process
+            if reset_iterator_counter is not None:
+                reset_iterator_counter.increment()
+                while not reset_iterator_counter.is_reached():
+                    yield True
+                # Sync between loops within the dispatching process
+                source_datapipe.reset_iterator()
+                yield True
+                reset_iterator_counter.reset()
             source_datapipe.reset_iterator()
             protocol.response_reset_iterator()
 

--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -83,7 +83,7 @@ def EnsureNonBlockingMapDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
+def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, reset_iterator_counter=None):
     """
     Indefinitely iterates over req_queue and passing values from source_datapipe to res_queue.
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -95,6 +95,8 @@ class ReadingServiceInterface(ABC):
         pass
 
     def __del__(self):
+        # Due to non-deterministic order of destruction, by the time `finalize` is called,
+        # some objects may already be `None`.
         try:
             self.finalize()
         except AttributeError:
@@ -348,10 +350,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         for process, req_queue, res_queue in self._worker_processes:
             try:
                 clean_me(process, req_queue, res_queue)
-            except AttributeError:
-                # Due to non-deterministic order of destruction, by the time `finalize` is called,
-                # some objects may already be `None`.
-                pass
             except TimeoutError:
                 pass
 
@@ -367,10 +365,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
                     except queue.Empty:
                         pass
                 self._dispatch_process[0].join(default_dl2_worker_join_timeout_in_s)
-            except AttributeError:
-                # Due to non-deterministic order of destruction, by the time `finalize` is called,
-                # some objects may already be `None`.
-                pass
             except TimeoutError:
                 pass
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -94,6 +94,12 @@ class ReadingServiceInterface(ABC):
         """
         pass
 
+    def __del__(self):
+        try:
+            self.finalize()
+        except AttributeError:
+            pass
+
 
 class CheckpointableReadingServiceInterface(ReadingServiceInterface):
     r"""
@@ -323,9 +329,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             pass
         return None
 
-    def __del__(self):
-        self.finalize()
-
     def finalize(self) -> None:
         r"""
         ``PrototypeMultiProcessingReadingService`` invalidate states & properly exits all subprocesses.
@@ -489,9 +492,6 @@ class DistributedReadingService(ReadingServiceInterface):
         seed_generator = seed_generator.spawn(self._rank, inplace=True)
         set_graph_random_seed(self._datapipe, seed_generator)
         return None
-
-    def __del__(self):
-        self.finalize()
 
     def finalize(self) -> None:
         r"""

--- a/torchdata/datapipes/iter/util/prefetcher.py
+++ b/torchdata/datapipes/iter/util/prefetcher.py
@@ -87,9 +87,10 @@ class PrefetcherIterDataPipe(IterDataPipe):
             try:
                 prefetch_data = _PrefetchData(self.source_datapipe, self.buffer_size)
                 self.prefetch_data = prefetch_data
-                self.thread = threading.Thread(
+                thread = threading.Thread(
                     target=PrefetcherIterDataPipe.thread_worker, args=(prefetch_data,), daemon=True
                 )
+                self.thread = thread
                 self.thread.start()
                 while prefetch_data.run_prefetcher:
                     if len(prefetch_data.prefetch_buffer) > 0:
@@ -99,9 +100,7 @@ class PrefetcherIterDataPipe(IterDataPipe):
                         time.sleep(CONSUMER_SLEEP_INTERVAL)
             finally:
                 prefetch_data.run_prefetcher = False
-                if self.thread is not None:
-                    self.thread.join()
-                    self.thread = None
+                thread.join()
 
     def __getstate__(self):
         """
@@ -124,3 +123,4 @@ class PrefetcherIterDataPipe(IterDataPipe):
         if self.thread is not None:
             self.prefetch_data.run_prefetcher = False
             self.thread.join()
+            self.thread = None


### PR DESCRIPTION
### Changes

- ~Fix S3 Tests~ in #997
- Ignore AttributeError for ReadingService when `gc` gets involved
- Add a reset_iterator_counter to dispatching process to guarantee that the datapipe is reset when all loops have received the request. Otherwise, datapipe can be reset in the middle of iteration of the other loops.
- Remove reference of the `thread` from `Prefetcher`. This would prevent racing condition when both `finally` in generator and `reset` function are accessing the same `thread`.
