### PR TITLE
Fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,11 @@ Please read the [full documentation here](https://pytorch.org/data/main/dataload
 
 ## Tutorial
 
-A tutorial of this library is [available here on the documentation site](https://pytorch.org/data/main/tutorial.html).
-It covers three topics: [using DataPipes](https://pytorch.org/data/main/tutorial.html#using-datapipes),
-[working with DataLoader](https://pytorch.org/data/main/tutorial.html#working-with-dataloader), and
-[implementing DataPipes](https://pytorch.org/data/main/tutorial.html#implementing-a-custom-datapipe).
+A tutorial of this library is
+[available here on the documentation site](https://pytorch.org/data/main/dp_tutorial.html). It covers three topics:
+[using DataPipes](https://pytorch.org/data/main/dp_tutorial.html#using-datapipes),
+[working with DataLoader](https://pytorch.org/data/main/dp_tutorial.html#working-with-dataloader), and
+[implementing DataPipes](https://pytorch.org/data/main/dp_tutorial.html#implementing-a-custom-datapipe).
 
 ## Usage Examples
 
@@ -194,8 +195,8 @@ What should I do if the existing set of DataPipes does not do what I need?
 </summary>
 
 You can
-[implement your own custom DataPipe](https://pytorch.org/data/main/tutorial.html#implementing-a-custom-datapipe). If you
-believe your use case is common enough such that the community can benefit from having your custom DataPipe added to
+[implement your own custom DataPipe](https://pytorch.org/data/main/dp_tutorial.html#implementing-a-custom-datapipe). If
+you believe your use case is common enough such that the community can benefit from having your custom DataPipe added to
 this library, feel free to open a GitHub issue. We will be happy to discuss!
 
 </details>
@@ -240,7 +241,7 @@ Multi-process data loading is still handled by the `DataLoader`, see the
 [DataLoader documentation for more details](https://pytorch.org/docs/stable/data.html#single-and-multi-process-data-loading).
 As of PyTorch version >= 1.12.0 (TorchData version >= 0.4.0), data sharding is automatically done for DataPipes within
 the `DataLoader` as long as a `ShardingFilter` DataPipe exists in your pipeline. Please see the
-[tutorial](https://pytorch.org/data/main/tutorial.html#working-with-dataloader) for an example.
+[tutorial](https://pytorch.org/data/main/dp_tutorial.html#working-with-dataloader) for an example.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,14 @@ Please read the [full documentation here](https://pytorch.org/data/main/dataload
 ## Tutorial
 
 A tutorial of this library is
-[available here on the documentation site](https://pytorch.org/data/main/dp_tutorial.html). It covers three topics:
+[available here on the documentation site](https://pytorch.org/data/main/dp_tutorial.html). It covers four topics:
 [using DataPipes](https://pytorch.org/data/main/dp_tutorial.html#using-datapipes),
-[working with DataLoader](https://pytorch.org/data/main/dp_tutorial.html#working-with-dataloader), and
-[implementing DataPipes](https://pytorch.org/data/main/dp_tutorial.html#implementing-a-custom-datapipe).
+[working with DataLoader](https://pytorch.org/data/main/dp_tutorial.html#working-with-dataloader),
+[implementing DataPipes](https://pytorch.org/data/main/dp_tutorial.html#implementing-a-custom-datapipe), and
+[working with Cloud Storage Providers](https://pytorch.org/data/main/dp_tutorial.html#working-with-cloud-storage-providers).
+
+There is also a tutorial available on
+[how to work with the new DataLoader2](https://pytorch.org/data/main/dlv2_tutorial.html).
 
 ## Usage Examples
 

--- a/docs/source/dlv2_tutorial.rst
+++ b/docs/source/dlv2_tutorial.rst
@@ -1,7 +1,7 @@
 DataLoader2 Tutorial
 =====================
 
-This is the tutorial for users to create ``DataPipe`` graph and load data via ``DataLoader2`` with different backend systems (``ReadingService``). An usage example can found in `this colab notebook <https://colab.research.google.com/drive/1eSvp-eUDYPj0Sd0X_Mv9s9VkE8RNDg1u>`_.
+This is the tutorial for users to create a ``DataPipe`` graph and load data via ``DataLoader2`` with different backend systems (``ReadingService``). An usage example can be found in `this colab notebook <https://colab.research.google.com/drive/1eSvp-eUDYPj0Sd0X_Mv9s9VkE8RNDg1u>`_.
 
 DataPipe
 ---------
@@ -12,7 +12,7 @@ to make sure the data pipeline has different order per epoch and data shards are
 - Place ``sharding_filter`` or ``sharding_round_robin_dispatch`` as early as possible in the pipeline to avoid repeating expensive operations in worker/distributed processes.
 - Add a ``shuffle`` DataPipe before sharding to achieve inter-shard shuffling. ``ReadingService`` will handle synchronization of those ``shuffle`` operations to ensure the order of data are the same before sharding so that all shards are mutually exclusive and collectively exhaustive.
 
-Here is an example of ``DataPipe`` graph:
+Here is an example of a ``DataPipe`` graph:
 
 .. code:: python
 
@@ -24,7 +24,7 @@ Here is an example of ``DataPipe`` graph:
 Multiprocessing
 ----------------
 
-``PrototypeMultiProcessingReadingService`` handles multiprocessing sharding at the point of ``sharding_filter`` and synchronize the seeds across worker processes.
+``PrototypeMultiProcessingReadingService`` handles multiprocessing sharding at the point of ``sharding_filter`` and synchronizes the seeds across worker processes.
 
 .. code:: python
 
@@ -39,7 +39,7 @@ Multiprocessing
 Distributed
 ------------
 
-``DistributedReadingService`` handles distributed sharding at the point of ``sharding_filter`` and synchronize the seeds across distributed processes. And, in order to balance the data shards across distributed nodes, a ``fullsync`` ``DataPipe`` will be attached to the ``DataPipe`` graph to align the number of batches across distributed ranks. This would prevent hanging issue caused by uneven shards in distributed training.
+``DistributedReadingService`` handles distributed sharding at the point of ``sharding_filter`` and synchronizes the seeds across distributed processes. And, in order to balance the data shards across distributed nodes, a ``fullsync`` ``DataPipe`` will be attached to the ``DataPipe`` graph to align the number of batches across distributed ranks. This would prevent hanging issue caused by uneven shards in distributed training.
 
 .. code:: python
 
@@ -54,7 +54,7 @@ Distributed
 Multiprocessing + Distributed
 ------------------------------
 
-``SequentialReadingService`` can be used to combine both ``ReadingServices`` together to achive multiprocessing and distributed training at the same time.
+``SequentialReadingService`` can be used to combine both ``ReadingServices`` together to achieve multiprocessing and distributed training at the same time.
 
 .. code:: python
 

--- a/torchdata/datapipes/iter/transform/callable.py
+++ b/torchdata/datapipes/iter/transform/callable.py
@@ -266,8 +266,8 @@ class SliceIterDataPipe(IterDataPipe[T_co]):
         if isinstance(index, list):
             if stop or step:
                 warnings.warn(
-                    "A list of indices was passed as well as a stop or step for the slice,"
-                    "these arguments can't be used together so onlyu the indices list will be used."
+                    "A list of indices was passed as well as a stop or step for the slice, "
+                    "these arguments can't be used together so only the indices list will be used."
                 )
 
     def __iter__(self) -> Iterator[T_co]:


### PR DESCRIPTION
Fixes #993

### Changes

- Fix links to tutorial in README
- Fix typo in warning in Slicer
