### PR TITLE
Fix test_remote_io.py due to mutating public s3 bucket

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,3 +13,4 @@ protobuf >= 3.9.2, < 3.20
 datasets
 graphviz
 adlfs
+awscli

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -13,4 +13,4 @@ protobuf >= 3.9.2, < 3.20
 datasets
 graphviz
 adlfs
-awscli
+awscli>=1.27.66

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -5,11 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import io
+import json
 import os
+import subprocess
 import unittest
 import warnings
-import subprocess
-import json
 from unittest.mock import patch
 
 import expecttest
@@ -231,7 +231,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         for p in s3_pths:
             pth_parts = p.split("s3://")[1].split("/", 1)
             if len(pth_parts) == 1:
-                bkt_name, prefix = pth_parts[0], ''
+                bkt_name, prefix = pth_parts[0], ""
             else:
                 bkt_name, prefix = pth_parts
 
@@ -239,13 +239,12 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
                 aws_cmd = f"aws --output json s3api list-objects  --bucket {bkt_name} --prefix {prefix} --no-sign-request --query Contents[*].Key"
             else:
                 aws_cmd = f"aws --output json s3api list-objects  --bucket {bkt_name} --no-sign-request --query Contents[*].Key"
-                
+
             res = subprocess.run(aws_cmd, shell=True, check=True, capture_output=True)
             objs = json.loads(res.stdout)
-            tot_objs |= set(objs)  
+            tot_objs |= set(objs)
 
         return len(tot_objs)
-
 
     @skipIfNoFSSpecS3
     def test_fsspec_io_iterdatapipe(self):

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -235,13 +235,9 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
             else:
                 bkt_name, prefix = pth_parts
 
+            aws_cmd = f"aws --output json s3api list-objects  --bucket {bkt_name} --no-sign-request"
             if prefix.strip():
-                aws_cmd = (
-                    f"aws --output json s3api list-objects  --bucket {bkt_name} --prefix {prefix} --no-sign-request"
-                )
-            else:
-                aws_cmd = f"aws --output json s3api list-objects  --bucket {bkt_name} --no-sign-request"
-
+                aws_cmd += f" --prefix {prefix}"
             if not recursive:
                 aws_cmd += " --delimiter /"
 

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -295,9 +295,6 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
     @skipIfNoAWS
     @unittest.skipIf(IS_M1, "PyTorch M1 CI Machine doesn't allow accessing")
     def test_s3_io_iterdatapipe(self):
-        res = subprocess.run("aws --output json s3api list-objects  --bucket ai2-public-datasets --no-sign-request --query Contents[*].Key", \
-            shell=True, check=True, capture_output=True)
-        num_items =  len(res.stdout.decode("utf-8").split("\n")) - 1
         # S3FileLister: different inputs
         input_list = [
             ["s3://ai2-public-datasets"],  # bucket without '/'

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -8,6 +8,7 @@ import io
 import os
 import unittest
 import warnings
+import subprocess
 from unittest.mock import patch
 
 import expecttest
@@ -274,6 +275,9 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
     @skipIfNoAWS
     @unittest.skipIf(IS_M1, "PyTorch M1 CI Machine doesn't allow accessing")
     def test_s3_io_iterdatapipe(self):
+        res = subprocess.run("aws --output json s3api list-objects  --bucket ai2-public-datasets --no-sign-request --query Contents[*].Key", \
+            shell=True, check=True, capture_output=True)
+        num_items =  len(res.stdout.decode("utf-8").split("\n")) - 1
         # S3FileLister: different inputs
         input_list = [
             [["s3://ai2-public-datasets"], 81],  # bucket without '/'

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -243,7 +243,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
                 aws_cmd = f"aws --output json s3api list-objects  --bucket {bkt_name} --no-sign-request"
 
             if not recursive:
-                aws_cmd += f" --delimiter /"
+                aws_cmd += " --delimiter /"
 
             res = subprocess.run(aws_cmd, shell=True, check=True, capture_output=True)
             json_res = json.loads(res.stdout)

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -345,14 +345,6 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
                 for _ in s3_lister_dp:
                     pass
 
-        # S3FileLoader: loader
-        input = [
-            "s3://charades-tar-shards/charades-video-0.tar",
-            "s3://charades-tar-shards/charades-video-1.tar",
-        ]  # multiple files
-        s3_loader_dp = S3FileLoader(input, region="us-west-2")
-        self.assertEqual(sum(1 for _ in s3_loader_dp), 2, f"{input} failed")
-
         input = [["s3://aft-vbi-pds/bin-images/100730.jpg"], 1]
         s3_loader_dp = S3FileLoader(input[0], region="us-east-1")
         self.assertEqual(sum(1 for _ in s3_loader_dp), input[1], f"{input[0]} failed")

--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -250,21 +250,18 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
     @skipIfNoFSSpecS3
     def test_fsspec_io_iterdatapipe(self):
         input_list = [
-            (["s3://ai2-public-datasets"], 41),  # bucket without '/'
-            (["s3://ai2-public-datasets/charades/"], 18),  # bucket with '/'
-            (
-                [
-                    "s3://ai2-public-datasets/charades/Charades_v1.zip",
-                    "s3://ai2-public-datasets/charades/Charades_v1_flow.tar",
-                    "s3://ai2-public-datasets/charades/Charades_v1_rgb.tar",
-                    "s3://ai2-public-datasets/charades/Charades_v1_480.zip",
-                ],
-                4,
-            ),  # multiple files
+            ["s3://ai2-public-datasets"],  # bucket without '/'
+            ["s3://ai2-public-datasets/charades/"],  # bucket with '/'
+            [
+                "s3://ai2-public-datasets/charades/Charades_v1.zip",
+                "s3://ai2-public-datasets/charades/Charades_v1_flow.tar",
+                "s3://ai2-public-datasets/charades/Charades_v1_rgb.tar",
+                "s3://ai2-public-datasets/charades/Charades_v1_480.zip",
+            ],  # multiple files
         ]
-        for urls, num in input_list:
+        for urls in input_list:
             fsspec_lister_dp = FSSpecFileLister(IterableWrapper(urls), anon=True)
-            self.assertEqual(sum(1 for _ in fsspec_lister_dp), num, f"{urls} failed")
+            self.assertEqual(sum(1 for _ in fsspec_lister_dp), self.__get_s3_cnt(urls), f"{urls} failed")
 
         url = "s3://ai2-public-datasets/charades/"
         fsspec_loader_dp = FSSpecFileOpener(FSSpecFileLister(IterableWrapper([url]), anon=True), anon=True)


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #984

### Changes
- Add a private function to TestDataPipeRemoteIO in test_remote_io.py to get s3 objects count label through aws cli
- add awscli in requirements
