### PR TITLE
Forward worker exceptions and exit with it

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -27,7 +27,6 @@ from torchdata.dataloader2 import (
     DataLoader2,
     DistributedReadingService,
     MultiProcessingReadingService,
-    PrototypeMultiProcessingReadingService,
     ReadingServiceInterface,
     SequentialReadingService,
 )
@@ -119,7 +118,7 @@ class DataLoader2Test(TestCase):
         dp = MakeMistakeDataPipe(dp)
         for worker_prefetch_cnt in [0, 5, 10]:
             for num_workers in [1, 4]:
-                rs = PrototypeMultiProcessingReadingService(
+                rs = MultiProcessingReadingService(
                     num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt
                 )
                 dl = DataLoader2(dp, reading_service=rs)

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -122,9 +122,9 @@ class DataLoader2Test(TestCase):
                 dl = DataLoader2(dp, reading_service=rs)
                 it = iter(dl)
                 for i in range(EXCEPTION_ITERATION_NUM*num_workers):
-                    item = next(it)
+                    next(it)
                 with self.assertRaises(communication.iter.WorkerException):
-                    item = next(it)
+                    next(it)
 
     def test_dataloader2_state_dict(self) -> None:
         test_data_pipe = IterableWrapper(range(3))

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -754,9 +754,9 @@ def _random_fn(data):
     r"""
     Used to validate the randomness of subprocess-local RNGs are set deterministically.
     """
-    py_random_num = random.randint(0, 2**32)
-    np_random_num = np.random.randint(0, 2**32)
-    torch_random_num = torch.randint(0, 2**32, size=[]).item()
+    py_random_num = random.randint(0, 2 ** 32)
+    np_random_num = np.random.randint(0, 2 ** 32)
+    torch_random_num = torch.randint(0, 2 ** 32, size=[]).item()
     return (data, py_random_num, np_random_num, torch_random_num)
 
 

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -81,6 +81,7 @@ class _ReadingServiceWrapper:
     def return_one():
         return 1
 
+
 class MakeMistakeDataPipe(IterDataPipe):
     def __init__(self, source_datapipe, exc_iteration=EXCEPTION_ITERATION_NUM):
         self.source_datapipe = source_datapipe
@@ -118,10 +119,12 @@ class DataLoader2Test(TestCase):
         dp = MakeMistakeDataPipe(dp)
         for worker_prefetch_cnt in [0, 5, 10]:
             for num_workers in [1, 4]:
-                rs = PrototypeMultiProcessingReadingService(num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt)
+                rs = PrototypeMultiProcessingReadingService(
+                    num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt
+                )
                 dl = DataLoader2(dp, reading_service=rs)
                 it = iter(dl)
-                for i in range(EXCEPTION_ITERATION_NUM*num_workers):
+                for i in range(EXCEPTION_ITERATION_NUM * num_workers):
                     next(it)
                 with self.assertRaises(communication.iter.WorkerException):
                     next(it)
@@ -208,7 +211,6 @@ class DataLoader2Test(TestCase):
             self.assertEqual(list(range(10)), actual)
 
     def test_dataloader2_reset(self) -> None:
-
         test_data_pipe = IterableWrapper(range(10))
         reading_services = [None, TestReadingService(), MultiProcessingReadingService(num_workers=1)]
 
@@ -338,7 +340,6 @@ class DataLoader2IntegrationTest(TestCase):
     "fork is not supported. Dying (set die_after_fork=0 to override)",
 )
 class TestDataLoader2EventLoop(TestCase):
-
     # TODO: This needs fixing, see issue 624
     # @skipIfNoDill
     # def test_basic_threading(self):
@@ -753,9 +754,9 @@ def _random_fn(data):
     r"""
     Used to validate the randomness of subprocess-local RNGs are set deterministically.
     """
-    py_random_num = random.randint(0, 2 ** 32)
-    np_random_num = np.random.randint(0, 2 ** 32)
-    torch_random_num = torch.randint(0, 2 ** 32, size=[]).item()
+    py_random_num = random.randint(0, 2**32)
+    np_random_num = np.random.randint(0, 2**32)
+    torch_random_num = torch.randint(0, 2**32, size=[]).item()
     return (data, py_random_num, np_random_num, torch_random_num)
 
 

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -118,9 +118,7 @@ class DataLoader2Test(TestCase):
         dp = MakeMistakeDataPipe(dp)
         for worker_prefetch_cnt in [0, 5, 10]:
             for num_workers in [1, 4]:
-                rs = MultiProcessingReadingService(
-                    num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt
-                )
+                rs = MultiProcessingReadingService(num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt)
                 dl = DataLoader2(dp, reading_service=rs)
                 it = iter(dl)
                 for i in range(EXCEPTION_ITERATION_NUM * num_workers):

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -178,7 +178,6 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False):
                     yield True
                     break
                 except Exception as e:
-                    # print("==== setting resp")
                     protocol.response_worker_exception(str(e))
                     return
                 protocol.response_next(value)
@@ -266,7 +265,6 @@ class _IterateQueueDataPipes(IterDataPipe):
                     if isinstance(response, communication.messages.TerminateResponse):
                         raise communication.iter.TerminateRequired
                     if isinstance(response, communication.messages.WorkerExceptionResponse):
-                        # print("====raising", idx, total_pipes)
                         raise communication.iter.WorkerException(f"Exception from worker {idx}: {response.exception}")
                     self.datapipes[idx].protocol.request_next()
                     yield response.value

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -58,14 +58,11 @@ class TerminateRequired(Exception):
 
 
 class WorkerException(Exception):
-    def __init__(self, exception):
-        self.exception = exception
+    """
+    Returned by DataPipe when there is a failure/exception from a worker process
+    """
 
-    def __str__(self):
-        return self.exception
-
-    def __traceback__(self):
-        return self.exception.__traceback__
+    pass
 
 
 class NonBlocking(IterDataPipe):
@@ -191,7 +188,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
                     yield True
                     break
                 except Exception as e:
-                    protocol.response_worker_exception(str(e))
+                    protocol.response_worker_exception(e)
                     return
                 protocol.response_next(value)
                 yield True  # Returns control
@@ -278,7 +275,7 @@ class _IterateQueueDataPipes(IterDataPipe):
                     if isinstance(response, communication.messages.TerminateResponse):
                         raise communication.iter.TerminateRequired
                     if isinstance(response, communication.messages.WorkerExceptionResponse):
-                        raise communication.iter.WorkerException(f"Exception from worker {idx}: {response.exception}")
+                        raise communication.iter.WorkerException(f"Exception from worker {idx}") from response.exception
                     self.datapipes[idx].protocol.request_next()
                     yield response.value
 

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -239,6 +239,7 @@ class QueueWrapper(NonBlocking):
             raise NotAvailable
         return response.value
 
+
 class _IterateQueueDataPipes(IterDataPipe):
     r"""
     Takes in ``QueueWrapper``s and iterates through them in a round-robin manner to get batches one-by-one.

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -62,8 +62,6 @@ class WorkerException(Exception):
     Returned by DataPipe when there is a failure/exception from a worker process
     """
 
-    pass
-
 
 class NonBlocking(IterDataPipe):
     not_available_hook = default_not_available_hook

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -92,3 +92,8 @@ class InvalidStateResponse(Response):
     """
 
     pass
+
+
+class WorkerExceptionResponse(Response):
+    def __init__(self, exception):
+        self.exception = exception

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -192,6 +192,12 @@ class IterDataPipeQueueProtocolServer(ProtocolServer):
         self.response_queue.put(communication.messages.InvalidStateResponse())
         self._req_received = None
 
+    def response_worker_exception(self, exception):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.WorkerExceptionResponse(exception))
+        self._req_received = None
+
 
 class IterDataPipeQueueProtocolClient(ProtocolClient):
     def request_reset_iterator(self):

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -264,8 +264,11 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         for worker_id in range(self.num_workers):
             worker_info = WorkerInfo(self.num_workers, worker_id)
             # Dispatching process for non-replicable DataPipes exists
+            print("=====in initialize PMPRS disp req queue for ", worker_id)
             dispatching_req_queue = self._dispatch_process[1][worker_id] if self._dispatch_process is not None else None
+            print("=====in initialize PMPRS disp req queue for ", worker_id)
             dispatching_res_queue = self._dispatch_process[2][worker_id] if self._dispatch_process is not None else None
+            print("=====in initialize PMPRS disp req queue for ", worker_id)
             call_on_process_init = partial(
                 process_init_fn,
                 worker_info=worker_info,
@@ -280,6 +283,7 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             )
             process.daemon = True
             process.start()
+            print("=====in initialize PMPRS proc started ", process)
             self._worker_processes.append((process, req_queue, res_queue))  # These queues are independent
             local_datapipe = communication.iter.QueueWrapper(
                 communication.protocol.IterDataPipeQueueProtocolClient(req_queue, res_queue)

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -264,11 +264,8 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
         for worker_id in range(self.num_workers):
             worker_info = WorkerInfo(self.num_workers, worker_id)
             # Dispatching process for non-replicable DataPipes exists
-            print("=====in initialize PMPRS disp req queue for ", worker_id)
             dispatching_req_queue = self._dispatch_process[1][worker_id] if self._dispatch_process is not None else None
-            print("=====in initialize PMPRS disp req queue for ", worker_id)
             dispatching_res_queue = self._dispatch_process[2][worker_id] if self._dispatch_process is not None else None
-            print("=====in initialize PMPRS disp req queue for ", worker_id)
             call_on_process_init = partial(
                 process_init_fn,
                 worker_info=worker_info,
@@ -283,7 +280,6 @@ class PrototypeMultiProcessingReadingService(ReadingServiceInterface):
             )
             process.daemon = True
             process.start()
-            print("=====in initialize PMPRS proc started ", process)
             self._worker_processes.append((process, req_queue, res_queue))  # These queues are independent
             local_datapipe = communication.iter.QueueWrapper(
                 communication.protocol.IterDataPipeQueueProtocolClient(req_queue, res_queue)

--- a/torchdata/datapipes/iter/util/prefetcher.py
+++ b/torchdata/datapipes/iter/util/prefetcher.py
@@ -76,6 +76,7 @@ class PrefetcherIterDataPipe(IterDataPipe):
                     prefetch_data.run_prefetcher = False
                 except Exception as e:
                     prefetch_data.prefetch_buffer.append(e)
+                    break
             elif stop_iteration and len(prefetch_data.prefetch_buffer) == 0:
                 prefetch_data.run_prefetcher = False
             else:  # Buffer is full, waiting for main thread to consume items


### PR DESCRIPTION
When a worker thread fails in PrototypeMultiProcessingReadingService, exception was silently neglected and the thread hanged. This PR fixes that by catching and propagating exception to response queue, showing that to user and exiting the process instead of hanging. 