### PR TITLE
[DataLoader2] Safeguarding DL2Iterator's `__getattr__`

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -77,7 +77,7 @@ class DataLoader2Iterator(Iterator[T_co]):
         """
         To delegate operations to ``dataloader._datapipe_iter``.
         """
-        if self.dataloader._datapipe_iter is None:
+        if "dataloader" not in self.__dict__ or self.dataloader._datapipe_iter is None:
             raise AttributeError
         return getattr(self.dataloader._datapipe_iter, name)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1004

Fixes #1000

As reported in the issue, in some uncommon cases, it is possible for the attribute to be missing, leading to infinite recursion. This should prevent it.

Differential Revision: [D43197744](https://our.internmc.facebook.com/intern/diff/D43197744)