### PR TITLE
Remove fsspec from conda build test for Python 3.11

### DIFF
--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -43,7 +43,8 @@ test:
     - cpuonly
     - pytest
     - expecttest
-    - fsspec
+    # fsspec doesn't support Python 3.11
+    # - fsspec
     # The following packages are not on the default conda channel
     # - iopath
     # - rarfile


### PR DESCRIPTION
`fsspec` doesn't support python 3.11 for now. In order to enable TorchData conda release for python 3.11, I have to remove `fsspec` from `meta.yml` to prevent installation during building process.
See: https://anaconda.org/anaconda/fsspec/files

You can find failing release workflow in https://github.com/pytorch/data/actions/runs/4183212525