### PR TITLE
[DataLoader2] Forward fix of 'limit' delegation

### DIFF
--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -121,7 +121,7 @@ class DataLoader2Iterator(Iterator[T_co]):
         self.limit_counter = 0
         self.limit_threshold = num_batches
         if self.dataloader._datapipe_iter and hasattr(self.dataloader._datapipe_iter, "limit"):
-            self.dataloader._datapipe_iter.limit()  # type: ignore[attr-defined]
+            self.dataloader._datapipe_iter.limit(num_batches)  # type: ignore[attr-defined]
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #915
* #998
* #1011
* __->__ #1019

The internal revert didn't work so I'm forward fixing. I ran a local test and it passed.
