### PR TITLE
Attach traceback to Exception & Test disatpching process

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -297,7 +297,8 @@ class TestDataLoader2EventLoop(TestCase):
         it = list(range(input_len))
         numbers_dp = SequenceWrapper(it)
         (process, req_queue, res_queue, _thread_local_datapipe) = communication.eventloop.CreateThreadForDataPipeline(
-            numbers_dp
+            numbers_dp,
+            name="worker thread",
         )
 
         process.start()

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -81,18 +81,6 @@ class _ReadingServiceWrapper:
         return 1
 
 
-class MakeMistakeDataPipe(IterDataPipe):
-    def __init__(self, source_datapipe, exc_iteration=EXCEPTION_ITERATION_NUM):
-        self.source_datapipe = source_datapipe
-        self.exc_iteration = exc_iteration
-
-    def __iter__(self):
-        for i, x in enumerate(self.source_datapipe):
-            if i == self.exc_iteration:
-                raise Exception("oops")
-            yield x
-
-
 class TestReadingService(ReadingServiceInterface):
     def initialize(self, dp: DataPipe) -> DataPipe:
         return _ReadingServiceWrapper(dp)  # type: ignore[return-value]
@@ -112,19 +100,6 @@ class DataLoader2Test(TestCase):
         test_data_pipe = IterableWrapper(range(3))
         data_loader: DataLoader2 = DataLoader2(datapipe=test_data_pipe)
         data_loader.shutdown()
-
-    def test_worker_exception_raised(self):
-        dp = IterableWrapper(range(100)).sharding_filter()
-        dp = MakeMistakeDataPipe(dp)
-        for worker_prefetch_cnt in [0, 5, 10]:
-            for num_workers in [1, 4]:
-                rs = MultiProcessingReadingService(num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt)
-                dl = DataLoader2(dp, reading_service=rs)
-                it = iter(dl)
-                for i in range(EXCEPTION_ITERATION_NUM * num_workers):
-                    next(it)
-                with self.assertRaises(communication.iter.WorkerException):
-                    next(it)
 
     def test_dataloader2_state_dict(self) -> None:
         test_data_pipe = IterableWrapper(range(3))
@@ -363,6 +338,22 @@ class NonReplicableDataPipe(IterDataPipe):
 
     def is_replicable(self):
         return False
+
+
+class _CustomException(Exception):
+    pass
+
+
+class MakeMistakeDataPipe(IterDataPipe):
+    def __init__(self, source_datapipe, exc_iteration=EXCEPTION_ITERATION_NUM):
+        self.source_datapipe = source_datapipe
+        self.exc_iteration = exc_iteration
+
+    def __iter__(self):
+        for i, x in enumerate(self.source_datapipe):
+            if i == self.exc_iteration:
+                raise _CustomException("oops")
+            yield x
 
 
 class MultiProcessingReadingServiceTest(TestCase):
@@ -627,6 +618,42 @@ class MultiProcessingReadingServiceTest(TestCase):
 
         torch.manual_seed(321)
         self.assertNotEqual(res, list(dl) + list(dl))
+
+    @parametrize("num_workers", [1, 3])
+    @parametrize("worker_prefetch_cnt", [0, 5, 10])
+    def test_worker_exception_raised(self, num_workers, worker_prefetch_cnt):
+        dp = IterableWrapper(range(100)).sharding_filter()
+        dp = MakeMistakeDataPipe(dp)
+        rs = MultiProcessingReadingService(num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt)
+        dl = DataLoader2(dp, reading_service=rs)
+        it = iter(dl)
+        for _ in range(EXCEPTION_ITERATION_NUM * num_workers):
+            next(it)
+        with self.assertRaises(_CustomException) as cm:
+            next(it)
+        exc_msg = str(cm.exception)
+        self.assertTrue("Caught _CustomException in worker process 0" in exc_msg)
+        self.assertTrue("Original Traceback" in exc_msg)
+        self.assertTrue("_CustomException: oops" in exc_msg)
+
+    @parametrize("num_workers", [1, 3])
+    @parametrize("worker_prefetch_cnt", [0, 5, 10])
+    def test_dispatching_exception_raised(self, num_workers, worker_prefetch_cnt):
+        dp = IterableWrapper(range(100))
+        dp = MakeMistakeDataPipe(dp)
+        dp = dp.sharding_round_robin_dispatch(SHARDING_PRIORITIES.MULTIPROCESSING)
+        dp = dp.map(_x_mult_2)
+        rs = MultiProcessingReadingService(num_workers=num_workers, worker_prefetch_cnt=worker_prefetch_cnt)
+        dl = DataLoader2(dp, reading_service=rs)
+        it = iter(dl)
+        for _ in range(EXCEPTION_ITERATION_NUM):
+            next(it)
+        with self.assertRaises(_CustomException) as cm:
+            next(it)
+        exc_msg = str(cm.exception)
+        self.assertTrue("Caught _CustomException in dispatching process" in exc_msg)
+        self.assertTrue("Original Traceback" in exc_msg)
+        self.assertTrue("_CustomException: oops" in exc_msg)
 
 
 TEST_MASTER_ADDR = "127.0.0.1"

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -298,7 +298,7 @@ class TestDataLoader2EventLoop(TestCase):
         numbers_dp = SequenceWrapper(it)
         (process, req_queue, res_queue, _thread_local_datapipe) = communication.eventloop.CreateThreadForDataPipeline(
             numbers_dp,
-            name="worker thread",
+            thread_name="worker thread",
         )
 
         process.start()

--- a/torchdata/_utils.py
+++ b/torchdata/_utils.py
@@ -8,6 +8,13 @@ import sys
 import traceback
 
 
+class KeyErrorMessage(str):
+    r"""str subclass that returns itself in repr"""
+
+    def __repr__(self):
+        return self
+
+
 class ExceptionWrapper:
     r"""
     Wraps an exception with traceback to communicate across threads/processes

--- a/torchdata/_utils.py
+++ b/torchdata/_utils.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import traceback
+
+
+class ExceptionWrapper:
+    r"""
+    Wraps an exception with traceback to communicate across threads/processes
+    """
+
+    def __init__(self, exc_info=None, where: str = "in background"):
+        if exc_info is None:
+            exc_info = sys.exc_info()
+        self.exc_type = exc_info[0]
+        self.exc_msg = "".join(traceback.format_exception(*exc_info))
+        self.where = where
+
+    def reraise(self):
+        r"""
+        Reraises the wrapped exception in the current thread/process
+        """
+        # Format a message such as: "Caught ValueError in DataLoader worker
+        # process 2. Original Traceback:", followed by the traceback.
+        msg = f"Caught {self.exc_type.__name__} {self.where}.\nOriginal {self.exc_msg}"
+        if self.exc_type == KeyError:
+            # KeyError calls repr() on its argument (usually a dict key). This
+            # makes stack traces unreadable. It will not be changed in Python
+            # (https://bugs.python.org/issue2651), so we work around it.
+            msg = KeyErrorMessage(msg)
+        elif getattr(self.exc_type, "message", None):
+            # Some exceptions have first argument as non-str but explicitly
+            # have message field
+            raise self.exc_type(message=msg)
+        try:
+            exception = self.exc_type(msg)
+        except TypeError:
+            # If the exception takes multiple arguments, don't try to
+            # instantiate since we don't know how to
+            raise RuntimeError(msg) from None
+        raise exception

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -61,7 +61,7 @@ class _ResetCounter:
             self.cnt = 0
 
 
-def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, name, call_on_process_init=None):
+def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, process_name, call_on_process_init=None):
     r"""
     Set the appropriate pipes and protocol server type, and create a loop over multiple datapipes
     with the protocol server in a non-blocking manner.
@@ -85,7 +85,7 @@ def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, name
                 source_datapipe,
                 req_queue,
                 res_queue,
-                name,
+                process_name,
                 blocking_request_get=False,
                 reset_iterator_counter=reset_iterator_counter,
             )
@@ -100,7 +100,7 @@ def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, name
         time.sleep(0)
 
 
-def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, name, call_on_process_init=None):
+def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, process_name, call_on_process_init=None):
     r"""
     Initialize with the given init function, set the appropriate pipe and protocol server type, and
     create a loop with the protocol server.
@@ -113,7 +113,7 @@ def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, name, call_on_pr
 
     torch.set_num_threads(1)
 
-    loop = _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, name, blocking_request_get=True)
+    loop = _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, process_name, blocking_request_get=True)
 
     for _ in loop:
         pass
@@ -123,7 +123,7 @@ def _create_datapipe_queue_loop(
     source_datapipe,
     req_queue,
     res_queue,
-    name,
+    process_name,
     blocking_request_get=True,
     reset_iterator_counter=None,
 ):
@@ -139,13 +139,13 @@ def _create_datapipe_queue_loop(
     return pipe_type.DataPipeBehindQueues(
         source_datapipe,
         protocol_type(req_queue, res_queue),
-        name=name,
+        process_name=process_name,
         blocking_request_get=blocking_request_get,
         reset_iterator_counter=reset_iterator_counter,
     )
 
 
-def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, name, call_on_process_init=None):
+def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, process_name, call_on_process_init=None):
     r"""
     Given a DataPipe, creates a new process with ``DataPipeToQueuesLoop`` as target,
     and returns ``(process, req_queue, res_queue)``.
@@ -153,12 +153,12 @@ def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, name, call_on_pr
     req_queue = multiprocessing_ctx.Queue()
     res_queue = multiprocessing_ctx.Queue()
     process = multiprocessing_ctx.Process(
-        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, name, call_on_process_init)
+        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, process_name, call_on_process_init)
     )
     return process, req_queue, res_queue
 
 
-def CreateThreadForDataPipeline(datapipe, name):
+def CreateThreadForDataPipeline(datapipe, thread_name):
     r"""
     Given a DataPipe, creates a copy of the DataPipe, starts a new Thread with ``DataPipeToQueuesLoop`` as target,
     and returns ``(process, req_queue, res_queue, new_copied_datapipe)``.
@@ -179,12 +179,12 @@ def CreateThreadForDataPipeline(datapipe, name):
             raise Exception("Unable to pickle DataPipe to make thread local copy (consider installing `dill`)", pe)
 
     process = threading.Thread(
-        target=DataPipeToQueuesLoop, args=(new_datapipe, req_queue, res_queue, name), daemon=True
+        target=DataPipeToQueuesLoop, args=(new_datapipe, req_queue, res_queue, thread_name), daemon=True
     )
     return process, req_queue, res_queue, new_datapipe
 
 
-def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes, name):
+def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes, process_name):
     r"""
     Given a DataPipe, creates a new process with ``MultipleDataPipesToQueuesLoop`` as target,
     and returns ``(process, [req_queue_0, ...], [res_queue_0, ...])``.
@@ -196,6 +196,6 @@ def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes, name):
         res_queues.append(multiprocessing_ctx.Queue())
 
     process = multiprocessing_ctx.Process(
-        target=MultipleDataPipesToQueuesLoop, args=(datapipes, req_queues, res_queues, name)
+        target=MultipleDataPipesToQueuesLoop, args=(datapipes, req_queues, res_queues, process_name)
     )
     return process, req_queues, res_queues

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -116,7 +116,9 @@ def EnsureNonBlockingDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=False, reset_iterator_counter=None):
+def DataPipeBehindQueues(
+    source_datapipe, protocol, process_name, blocking_request_get=False, reset_iterator_counter=None
+):
     """
     Indefinitely iterates over ``req_queue`` and passing values from source_datapipe to ``res_queue``.
 
@@ -129,7 +131,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=F
     Args:
         source_datapipe: DataPipe
         protocol: ``IterDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
-        name: Process name
+        process_name: Process name
         blocking_request_get: determines if ``protocol.get_new_request`` will block
         reset_iterator_counter: Optional counter to synchronize all loops that have received
             `ResetIteratorRequest` within the dispatching process. It would guarantee that
@@ -215,7 +217,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=F
                     yield True
                     break
                 except Exception:
-                    exc = ExceptionWrapper(where=f"in {name}")
+                    exc = ExceptionWrapper(where=f"in {process_name}")
                     protocol.response_worker_exception(exc)
                     return
                 protocol.response_next(value)

--- a/torchdata/dataloader2/communication/iter.py
+++ b/torchdata/dataloader2/communication/iter.py
@@ -13,6 +13,7 @@ from functools import partial
 from typing import Callable, Deque, List
 
 from torch.utils.data import IterDataPipe
+from torchdata._utils import ExceptionWrapper
 from torchdata.dataloader2 import communication
 from torchdata.dataloader2.graph import DataPipe, list_dps, traverse_dps
 from torchdata.dataloader2.random import SeedGenerator
@@ -57,12 +58,6 @@ class TerminateRequired(Exception):
     """
 
     pass
-
-
-class WorkerException(Exception):
-    """
-    Returned by DataPipe when there is a failure/exception from a worker process
-    """
 
 
 class NonBlocking(IterDataPipe):
@@ -121,7 +116,7 @@ def EnsureNonBlockingDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, reset_iterator_counter=None):
+def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=False, reset_iterator_counter=None):
     """
     Indefinitely iterates over ``req_queue`` and passing values from source_datapipe to ``res_queue``.
 
@@ -134,6 +129,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
     Args:
         source_datapipe: DataPipe
         protocol: ``IterDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
+        name: Process name
         blocking_request_get: determines if ``protocol.get_new_request`` will block
         reset_iterator_counter: Optional counter to synchronize all loops that have received
             `ResetIteratorRequest` within the dispatching process. It would guarantee that
@@ -218,8 +214,9 @@ def DataPipeBehindQueues(source_datapipe, protocol, blocking_request_get=False, 
                     protocol.response_invalid_state()
                     yield True
                     break
-                except Exception as e:
-                    protocol.response_worker_exception(e)
+                except Exception:
+                    exc = ExceptionWrapper(where=f"in {name}")
+                    protocol.response_worker_exception(exc)
                     return
                 protocol.response_next(value)
                 yield True  # Returns control
@@ -332,7 +329,7 @@ class _IterateQueueDataPipes(IterDataPipe):
                     if isinstance(response, communication.messages.TerminateResponse):
                         raise communication.iter.TerminateRequired
                     if isinstance(response, communication.messages.WorkerExceptionResponse):
-                        raise communication.iter.WorkerException(f"Exception from worker {idx}") from response.exception
+                        response.exc.reraise()
                     if len(self.res_buffers[idx]) == 0:  # Only request if buffer is empty
                         self.datapipes[idx].protocol.request_next()
                     yield response.value

--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -84,14 +84,16 @@ def EnsureNonBlockingMapDataPipe(validated_datapipe):
     return validated_datapipe
 
 
-def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=False, reset_iterator_counter=None):
+def DataPipeBehindQueues(
+    source_datapipe, protocol, process_name, blocking_request_get=False, reset_iterator_counter=None
+):
     """
     Indefinitely iterates over req_queue and passing values from source_datapipe to res_queue.
 
     Args:
         source_datapipe: DataPipe
         protocol: ``MapDataPipeQueueProtocolServer`` that contains ``req_queue`` and ``res_queue``
-        name: Process name
+        process_name: Process name
         blocking_request_get: determines if ``protocol.get_new_request`` will block
     """
     if not isinstance(protocol, communication.protocol.MapDataPipeQueueProtocolServer):
@@ -131,7 +133,7 @@ def DataPipeBehindQueues(source_datapipe, protocol, name, blocking_request_get=F
                     yield True
                     break
                 except Exception:
-                    exc = ExceptionWrapper(where=f"in {name}")
+                    exc = ExceptionWrapper(where=f"in {process_name}")
                     protocol.response_worker_exception(exc)
                     break
                 protocol.response_item(request.key, value)

--- a/torchdata/dataloader2/communication/map.py
+++ b/torchdata/dataloader2/communication/map.py
@@ -8,6 +8,7 @@ import time
 import types
 
 from torch.utils.data import MapDataPipe
+from torchdata._utils import ExceptionWrapper
 from torchdata.dataloader2 import communication
 
 DEFAULT_NON_BLOCKING_SLEEP = 0.001

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchdata._utils import ExceptionWrapper
+
 
 class DataLoaderQueueMessage:
     pass
@@ -111,5 +113,7 @@ class InvalidStateResponse(Response):
 
 
 class WorkerExceptionResponse(Response):
-    def __init__(self, exception):
-        self.exception = exception
+    __slots__ = "exc"
+
+    def __init__(self, exc: ExceptionWrapper):
+        self.exc: ExceptionWrapper = exc

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -152,6 +152,12 @@ class MapDataPipeQueueProtocolServer(ProtocolServer):
         self.response_queue.put(communication.messages.LenResponse(size))
         self._req_received = None
 
+    def response_index_out_of_bound(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.StopIterationResponse())
+        self._req_received = None
+
 
 class MapDataPipeQueueProtocolClient(ProtocolClient):
     def request_len(self):

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -132,6 +132,12 @@ class ProtocolServer(Protocol):
         self.response_queue.put(communication.messages.ResumeResponse())
         self._req_received = None
 
+    def response_worker_exception(self, exception):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.WorkerExceptionResponse(exception))
+        self._req_received = None
+
 
 class MapDataPipeQueueProtocolServer(ProtocolServer):
     def response_item(self, key, value):
@@ -144,12 +150,6 @@ class MapDataPipeQueueProtocolServer(ProtocolServer):
         if not self.have_pending_request():
             raise Exception("Attempting to reply with pending request")
         self.response_queue.put(communication.messages.LenResponse(size))
-        self._req_received = None
-
-    def response_index_out_of_bound(self):
-        if not self.have_pending_request():
-            raise Exception("Attempting to reply with pending request")
-        self.response_queue.put(communication.messages.StopIterationResponse())
         self._req_received = None
 
 
@@ -229,12 +229,6 @@ class IterDataPipeQueueProtocolServer(ProtocolServer):
         if not self.have_pending_request():
             raise Exception("Attempting to reply with pending request")
         self.response_queue.put(communication.messages.InvalidStateResponse())
-        self._req_received = None
-
-    def response_worker_exception(self, exception):
-        if not self.have_pending_request():
-            raise Exception("Attempting to reply with pending request")
-        self.response_queue.put(communication.messages.WorkerExceptionResponse(exception))
         self._req_received = None
 
 

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -234,6 +234,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         # Launch dispatching process for the lowest common ancestor of non-replicable DataPipes
         graph = traverse_dps(datapipe)
         dispatching_dp = find_lca_round_robin_sharding_dp(graph)
+        # TODO(ejguan): When the last DataPipe is round_robin_sharding, use InPrcoessReadingService
         if dispatching_dp is not None:
             dummy_dp = _DummyIterDataPipe()
             graph = replace_dp(graph, dispatching_dp, dummy_dp)  # type: ignore[arg-type]
@@ -243,8 +244,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             round_robin_dps = dispatching_dp.round_robin_demux(num_instances=self.num_workers)
             # TODO(ejguan): Benchmark if we need to prefetch in dispatching process
             process, req_queues, res_queues = communication.eventloop.CreateProcessForMultipleDataPipelines(
-                ctx,
-                round_robin_dps,
+                ctx, round_robin_dps, name="dispatching process"
             )
             assert len(req_queues) == self.num_workers and len(res_queues) == self.num_workers
             process.daemon = True
@@ -282,7 +282,8 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             (process, req_queue, res_queue) = communication.eventloop.CreateProcessForDataPipeline(
                 ctx,
                 replicable_dp,
-                call_on_process_init,
+                name=f"worker process {worker_id}",
+                call_on_process_init=call_on_process_init,
             )
             process.daemon = True
             process.start()

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -244,7 +244,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             round_robin_dps = dispatching_dp.round_robin_demux(num_instances=self.num_workers)
             # TODO(ejguan): Benchmark if we need to prefetch in dispatching process
             process, req_queues, res_queues = communication.eventloop.CreateProcessForMultipleDataPipelines(
-                ctx, round_robin_dps, name="dispatching process"
+                ctx, round_robin_dps, process_name="dispatching process"
             )
             assert len(req_queues) == self.num_workers and len(res_queues) == self.num_workers
             process.daemon = True
@@ -282,7 +282,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             (process, req_queue, res_queue) = communication.eventloop.CreateProcessForDataPipeline(
                 ctx,
                 replicable_dp,
-                name=f"worker process {worker_id}",
+                process_name=f"worker process {worker_id}",
                 call_on_process_init=call_on_process_init,
             )
             process.daemon = True

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -257,9 +257,9 @@ class RoundRobinDemultiplexerIterDataPipe(IterDataPipe):
             raise ValueError(f"Expected `num_instaces` larger than 0, but {num_instances} is found")
         if num_instances == 1:
             warnings.warn(
-                "The operation of `round_robin_demux` with `num_instances=1` is an no-op and returns the provided `datapipe` directly"
+                "The operation of `round_robin_demux` with `num_instances=1` is an no-op and returns the provided `datapipe` in a list directly"
             )
-            return datapipe
+            return [datapipe]
 
         datapipe = datapipe.enumerate()
         container = _RoundRobinDemultiplexerIterDataPipe(datapipe, num_instances, buffer_size=buffer_size)


### PR DESCRIPTION
Partially fixes #969

### Changes

- Add `ExceptionWrapper` to attach traceback to the Exception
  - Reason: traceback is unserializable. So, it has to be passed by string
  - In order to provide informative Error message, pass name for each process like `dispatching process` and `worker process <id>`.
- Add tests to validate Error propagation from the dispatching process
  - parametrize the tests
- Fix a bug for `round_robin_demux` to return a list of DataPipe rather than a single DataPipe when `num_of_instances` is 1.