### PR TITLE
Attach traceback to Exception & Test disatpching process (#1036)

### DIFF
--- a/torchdata/_utils.py
+++ b/torchdata/_utils.py
@@ -1,0 +1,52 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+import traceback
+
+
+class KeyErrorMessage(str):
+    r"""str subclass that returns itself in repr"""
+
+    def __repr__(self):
+        return self
+
+
+class ExceptionWrapper:
+    r"""
+    Wraps an exception with traceback to communicate across threads/processes
+    """
+
+    def __init__(self, exc_info=None, where: str = "in background"):
+        if exc_info is None:
+            exc_info = sys.exc_info()
+        self.exc_type = exc_info[0]
+        self.exc_msg = "".join(traceback.format_exception(*exc_info))
+        self.where = where
+
+    def reraise(self):
+        r"""
+        Reraises the wrapped exception in the current thread/process
+        """
+        # Format a message such as: "Caught ValueError in DataLoader worker
+        # process 2. Original Traceback:", followed by the traceback.
+        msg = f"Caught {self.exc_type.__name__} {self.where}.\nOriginal {self.exc_msg}"
+        if self.exc_type == KeyError:
+            # KeyError calls repr() on its argument (usually a dict key). This
+            # makes stack traces unreadable. It will not be changed in Python
+            # (https://bugs.python.org/issue2651), so we work around it.
+            msg = KeyErrorMessage(msg)
+        elif getattr(self.exc_type, "message", None):
+            # Some exceptions have first argument as non-str but explicitly
+            # have message field
+            raise self.exc_type(message=msg)
+        try:
+            exception = self.exc_type(msg)
+        except TypeError:
+            # If the exception takes multiple arguments, don't try to
+            # instantiate since we don't know how to
+            raise RuntimeError(msg) from None
+        raise exception

--- a/torchdata/dataloader2/communication/eventloop.py
+++ b/torchdata/dataloader2/communication/eventloop.py
@@ -61,7 +61,7 @@ class _ResetCounter:
             self.cnt = 0
 
 
-def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, call_on_process_init=None):
+def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, process_name, call_on_process_init=None):
     r"""
     Set the appropriate pipes and protocol server type, and create a loop over multiple datapipes
     with the protocol server in a non-blocking manner.
@@ -85,6 +85,7 @@ def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, call
                 source_datapipe,
                 req_queue,
                 res_queue,
+                process_name,
                 blocking_request_get=False,
                 reset_iterator_counter=reset_iterator_counter,
             )
@@ -99,7 +100,7 @@ def MultipleDataPipesToQueuesLoop(source_datapipes, req_queues, res_queues, call
         time.sleep(0)
 
 
-def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_on_process_init=None):
+def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, process_name, call_on_process_init=None):
     r"""
     Initialize with the given init function, set the appropriate pipe and protocol server type, and
     create a loop with the protocol server.
@@ -112,14 +113,19 @@ def DataPipeToQueuesLoop(source_datapipe, req_queue, res_queue, call_on_process_
 
     torch.set_num_threads(1)
 
-    loop = _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, blocking_request_get=True)
+    loop = _create_datapipe_queue_loop(source_datapipe, req_queue, res_queue, process_name, blocking_request_get=True)
 
     for _ in loop:
         pass
 
 
 def _create_datapipe_queue_loop(
-    source_datapipe, req_queue, res_queue, blocking_request_get=True, reset_iterator_counter=None
+    source_datapipe,
+    req_queue,
+    res_queue,
+    process_name,
+    blocking_request_get=True,
+    reset_iterator_counter=None,
 ):
     if isinstance(source_datapipe, IterDataPipe):
         pipe_type = communication.iter
@@ -133,12 +139,13 @@ def _create_datapipe_queue_loop(
     return pipe_type.DataPipeBehindQueues(
         source_datapipe,
         protocol_type(req_queue, res_queue),
+        process_name=process_name,
         blocking_request_get=blocking_request_get,
         reset_iterator_counter=reset_iterator_counter,
     )
 
 
-def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, call_on_process_init=None):
+def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, process_name, call_on_process_init=None):
     r"""
     Given a DataPipe, creates a new process with ``DataPipeToQueuesLoop`` as target,
     and returns ``(process, req_queue, res_queue)``.
@@ -146,12 +153,12 @@ def CreateProcessForDataPipeline(multiprocessing_ctx, datapipe, call_on_process_
     req_queue = multiprocessing_ctx.Queue()
     res_queue = multiprocessing_ctx.Queue()
     process = multiprocessing_ctx.Process(
-        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, call_on_process_init)
+        target=DataPipeToQueuesLoop, args=(datapipe, req_queue, res_queue, process_name, call_on_process_init)
     )
     return process, req_queue, res_queue
 
 
-def CreateThreadForDataPipeline(datapipe):
+def CreateThreadForDataPipeline(datapipe, thread_name):
     r"""
     Given a DataPipe, creates a copy of the DataPipe, starts a new Thread with ``DataPipeToQueuesLoop`` as target,
     and returns ``(process, req_queue, res_queue, new_copied_datapipe)``.
@@ -171,11 +178,13 @@ def CreateThreadForDataPipeline(datapipe):
         else:
             raise Exception("Unable to pickle DataPipe to make thread local copy (consider installing `dill`)", pe)
 
-    process = threading.Thread(target=DataPipeToQueuesLoop, args=(new_datapipe, req_queue, res_queue), daemon=True)
+    process = threading.Thread(
+        target=DataPipeToQueuesLoop, args=(new_datapipe, req_queue, res_queue, thread_name), daemon=True
+    )
     return process, req_queue, res_queue, new_datapipe
 
 
-def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes):
+def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes, process_name):
     r"""
     Given a DataPipe, creates a new process with ``MultipleDataPipesToQueuesLoop`` as target,
     and returns ``(process, [req_queue_0, ...], [res_queue_0, ...])``.
@@ -187,6 +196,6 @@ def CreateProcessForMultipleDataPipelines(multiprocessing_ctx, datapipes):
         res_queues.append(multiprocessing_ctx.Queue())
 
     process = multiprocessing_ctx.Process(
-        target=MultipleDataPipesToQueuesLoop, args=(datapipes, req_queues, res_queues)
+        target=MultipleDataPipesToQueuesLoop, args=(datapipes, req_queues, res_queues, process_name)
     )
     return process, req_queues, res_queues

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -4,6 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from torchdata._utils import ExceptionWrapper
+
 
 class DataLoaderQueueMessage:
     pass
@@ -111,5 +113,7 @@ class InvalidStateResponse(Response):
 
 
 class WorkerExceptionResponse(Response):
-    def __init__(self, exception):
-        self.exception = exception
+    __slots__ = "exc"
+
+    def __init__(self, exc: ExceptionWrapper):
+        self.exc: ExceptionWrapper = exc

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -132,6 +132,12 @@ class ProtocolServer(Protocol):
         self.response_queue.put(communication.messages.ResumeResponse())
         self._req_received = None
 
+    def response_worker_exception(self, exception):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        self.response_queue.put(communication.messages.WorkerExceptionResponse(exception))
+        self._req_received = None
+
 
 class MapDataPipeQueueProtocolServer(ProtocolServer):
     def response_item(self, key, value):
@@ -229,12 +235,6 @@ class IterDataPipeQueueProtocolServer(ProtocolServer):
         if not self.have_pending_request():
             raise Exception("Attempting to reply with pending request")
         self.response_queue.put(communication.messages.InvalidStateResponse())
-        self._req_received = None
-
-    def response_worker_exception(self, exception):
-        if not self.have_pending_request():
-            raise Exception("Attempting to reply with pending request")
-        self.response_queue.put(communication.messages.WorkerExceptionResponse(exception))
         self._req_received = None
 
 

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -257,9 +257,9 @@ class RoundRobinDemultiplexerIterDataPipe(IterDataPipe):
             raise ValueError(f"Expected `num_instaces` larger than 0, but {num_instances} is found")
         if num_instances == 1:
             warnings.warn(
-                "The operation of `round_robin_demux` with `num_instances=1` is an no-op and returns the provided `datapipe` directly"
+                "The operation of `round_robin_demux` with `num_instances=1` is an no-op and returns the provided `datapipe` in a list directly"
             )
-            return datapipe
+            return [datapipe]
 
         datapipe = datapipe.enumerate()
         container = _RoundRobinDemultiplexerIterDataPipe(datapipe, num_instances, buffer_size=buffer_size)


### PR DESCRIPTION
Cherry-pick: #1036

Summary:
Partially fixes https://github.com/pytorch/data/issues/969

### Changes

- Add `ExceptionWrapper` to attach traceback to the Exception
  - Reason: traceback is unserializable. So, it has to be passed by string
  - In order to provide informative Error message, pass name for each process like `dispatching process` and `worker process <id>`.
- Add tests to validate Error propagation from the dispatching process
  - parametrize the tests
- Fix a bug for `round_robin_demux` to return a list of DataPipe rather than a single DataPipe when `num_of_instances` is 1.

Pull Request resolved: https://github.com/pytorch/data/pull/1036

Reviewed By: NivekT

Differential Revision: D43472709

Pulled By: ejguan

fbshipit-source-id: e5c9e581ca881f523fb568b6f46bf16ecfc243d2
