### PR TITLE
keep_key in MapKeyZipper

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -261,6 +261,11 @@ class TestIterDataPipe(expecttest.TestCase):
         with self.assertRaisesRegex(KeyError, "is not a valid key in the given MapDataPipe"):
             next(it)
 
+        # Functional test: ensure that keep_key option works
+        result_dp = source_dp.zip_with_map(map_dp, odd_even, keep_key=True)
+        expected_res_keep_key = [(key, (i, odd_even_string(i))) for i, key in zip(range(10), [0, 1] * 5)]
+        self.assertEqual(expected_res_keep_key, list(result_dp))
+
         # Reset Test:
         n_elements_before_reset = 4
         result_dp = source_dp.zip_with_map(map_dp, odd_even)

--- a/torchdata/datapipes/iter/util/combining.py
+++ b/torchdata/datapipes/iter/util/combining.py
@@ -180,16 +180,27 @@ class MapKeyZipperIterDataPipe(IterDataPipe[T_co]):
             from ``map_datapipe``, by default a tuple is created
 
     Example:
-        >>> from torchdata.datapipes.iter import IterableWrapper
-        >>> from torchdata.datapipes.map import SequenceWrapper
-        >>> from operator import itemgetter
-        >>> def merge_fn(tuple_from_iter, value_from_map):
-        >>>     return tuple_from_iter[0], tuple_from_iter[1] + value_from_map
-        >>> dp1 = IterableWrapper([('a', 1), ('b', 2), ('c', 3)])
-        >>> mapdp = SequenceWrapper({'a': 100, 'b': 200, 'c': 300, 'd': 400})
-        >>> res_dp = dp1.zip_with_map(map_datapipe=mapdp, key_fn=itemgetter(0), merge_fn=merge_fn)
-        >>> list(res_dp)
+
+    .. testsetup::
+
+        from operator import itemgetter
+
+    .. testcode::
+
+        from torchdata.datapipes.iter import IterableWrapper
+        from torchdata.datapipes.map import SequenceWrapper
+
+        def merge_fn(tuple_from_iter, value_from_map):
+            return tuple_from_iter[0], tuple_from_iter[1] + value_from_map
+        dp1 = IterableWrapper([('a', 1), ('b', 2), ('c', 3)])
+        mapdp = SequenceWrapper({'a': 100, 'b': 200, 'c': 300, 'd': 400})
+        res_dp = dp1.zip_with_map(map_datapipe=mapdp, key_fn=itemgetter(0), merge_fn=merge_fn)
+        print(list(res_dp))
+
+    .. testoutput::
+
         [('a', 101), ('b', 202), ('c', 303)]
+
     """
 
     def __init__(


### PR DESCRIPTION
As mentioned in #256 it would be useful to have this in all dp that use a `key_fn`.

### Changes

- Add keep_key option to `MapKeyZipper`
- Test for the new option
- Improve example in documentation by using sphinx doctest
