### PR TITLE
Create new eventloop to run coroutines

### DIFF
--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -1601,6 +1601,15 @@ class TestIterDataPipe(expecttest.TestCase):
             output_col=1,
         )
 
+        # Test multiple asyncio eventloops
+        dp1 = IterableWrapper(range(50))
+        dp1 = dp1.async_map_batches(_async_mul_ten, 16)
+        dp2 = IterableWrapper(range(50))
+        dp2 = dp2.async_map_batches(_async_mul_ten, 16)
+        for v1, v2, exp in zip(dp1, dp2, [i * 10 for i in range(50)]):
+            self.assertEqual(v1, exp)
+            self.assertEqual(v2, exp)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Prevent calling `asyncio.run` within `__iter__` function. New event loop would be created rather than reusing the global event loop.
Using policy for the case of custom policy is used as suggested in https://docs.python.org/3.8/library/asyncio-eventloop.html#event-loop

Address the [comment](https://docs.python.org/3/library/asyncio-runner.html#:~:text=It%20should%20be%20used%20as,ideally%20only%20be%20called%20once.&text=New%20in%20version%203.7.)
