### PR TITLE
ci: Do not install conda-build from conda-forge

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -381,7 +381,7 @@ jobs:
             conda install -yq conda-build -c malfet -c conda-forge
             export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c malfet"
           else
-            conda install -yq conda-build -c conda-forge
+            conda install -yq conda-build
           fi
           packaging/build_conda.sh
           conda index ./conda-bld


### PR DESCRIPTION
This create a bad dependency chain, do not do that please

Tested on my local mac