### PR TITLE
ci: Do not install conda-build from conda-forge (#1064)

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -381,7 +381,7 @@ jobs:
             conda install -yq conda-build -c malfet -c conda-forge
             export CONDA_CHANNEL_FLAGS="${CONDA_CHANNEL_FLAGS} -c malfet"
           else
-            conda install -yq conda-build -c conda-forge
+            conda install -yq conda-build
           fi
           packaging/build_conda.sh
           conda index ./conda-bld


### PR DESCRIPTION
Summary:
This create a bad dependency chain, do not do that please

Tested on my local mac

Pull Request resolved: https://github.com/pytorch/data/pull/1064

Reviewed By: seemethere, NivekT

Differential Revision: D43780624

Pulled By: atalman

fbshipit-source-id: c61b1887881a91c41702ba2efbd1246b753ec99f