### PR TITLE
HuggingFaceHubReader better align with default values of datasets.load_dataset()

### DIFF
--- a/test/test_huggingface_datasets.py
+++ b/test/test_huggingface_datasets.py
@@ -40,7 +40,7 @@ class TestHuggingFaceHubReader(expecttest.TestCase):
         assert elem["id"] == "7bd227d9-afc9-11e6-aba1-c4b301cdf627"
         assert elem["package_name"] == "com.mantz_it.rfanalyzer"
         mock_load_dataset.assert_called_with(
-            path="lhoestq/demo1", streaming=False, split="train", revision="branch", use_auth_token=True
+            path="lhoestq/demo1", streaming=False, revision="branch", use_auth_token=True
         )
         with self.assertRaises(StopIteration):
             next(iterator)

--- a/torchdata/datapipes/iter/load/huggingface.py
+++ b/torchdata/datapipes/iter/load/huggingface.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 
-import warnings
 from typing import Any, Iterator, Tuple
 
 from torchdata.datapipes.iter import IterDataPipe
@@ -19,14 +18,10 @@ except ImportError:
 
 def _get_response_from_huggingface_hub(
     dataset: str,
-    split: str = "train",
-    revision: str = "main",
     streaming: bool = True,
     **config_kwargs,
 ) -> Iterator[Any]:
-    hf_dataset = datasets.load_dataset(
-        path=dataset, streaming=streaming, split=split, revision=revision, **config_kwargs
-    )
+    hf_dataset = datasets.load_dataset(path=dataset, streaming=streaming, **config_kwargs)
     return iter(hf_dataset)
 
 
@@ -34,14 +29,14 @@ class HuggingFaceHubReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
     r"""
     Takes in dataset names and returns an Iterable HuggingFace dataset.
     Please refer to https://huggingface.co/docs/datasets/loading for the meaning and type of each argument.
-    Contrary to their implementation, default behavior differs in the following (this will be changed in version 0.7):
+    Contrary to their implementation, default behavior differs in the following:
 
-    * ``split`` is set to ``"train"``
-    * ``revision`` is set to ``"main"``
     * ``streaming`` is set to ``True``
 
     Args:
-        source_datapipe: a DataPipe that contains dataset names which will be accepted by the HuggingFace datasets library
+        dataset: path or name of the dataset
+        **config_kwargs: additional arguments for ``datasets.load_dataset()``
+
     Example:
 
     .. testsetup::
@@ -62,8 +57,6 @@ class HuggingFaceHubReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
     """
 
-    source_datapipe: IterDataPipe[str]
-
     def __init__(
         self,
         dataset: str,
@@ -78,10 +71,6 @@ class HuggingFaceHubReaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
 
         self.dataset = dataset
         self.config_kwargs = config_kwargs
-        if "split" not in self.config_kwargs:
-            warnings.warn("Default value of `split` will be changed to None in version 0.7", FutureWarning)
-        if "revision" not in self.config_kwargs:
-            warnings.warn("Default value of `revision` will be changed to None in version 0.7", FutureWarning)
 
     def __iter__(self) -> Iterator[Any]:
         return _get_response_from_huggingface_hub(dataset=self.dataset, **self.config_kwargs)


### PR DESCRIPTION
### Changes

- Change default value of HuggingFaceHubReader parameters
- Remove legacy `source_datapipe` attribute

A quick search on Github reveals no usage of this dp outside torchdata.

### BC-breaking note

**0.6.0**: Previously `HuggingFaceHubReader("lhoestq/demo1")` called 
`datasets.load_dataset(path="lhoestq/demo1", streaming=True, split="train", revision="main")`

**PR**: This PR changes default arguments of `split` and `revision` to the default values of `datasets.load_dataset()`:  
Now `HuggingFaceHubReader("lhoestq/demo1")` calls 
`datasets.load_dataset(path="lhoestq/demo1", streaming=True)`

As the default value of `split` and `train` are both `None` this is equivalent to:
`datasets.load_dataset(path="lhoestq/demo1", streaming=True, split=None, revision=None)`

In some cases (depending on the dataset) this **will change the data retrieved from HuggingFace**.

`streaming` is still set to `True`.


