### PR TITLE
Use 'index-url' instead of 'find-links' to install domain libraries during CI testing

### DIFF
--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -166,7 +166,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torcharrow from nightlies
-        run: pip install --pre torch torcharrow --index-url https://download.pytorch.org/whl/nightly/cpu
+        run: pip install --pre torch torcharrow -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -166,7 +166,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torcharrow from nightlies
-        run: pip install --pre torch torcharrow -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        run:
+          pip install --pre torch torcharrow --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install torch and torchvision from nightlies
         run: |
           pip install numpy networkx
-          pip install --pre torch torchvision -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
       - name: Install torch and torchtext from nightlies
         run: |
           pip install numpy networkx
-          pip install --pre torch torchtext -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchtext --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
       - name: Install torch and torchaudio from nightlies
         run: |
           pip install networkx
-          pip install --pre torch torchaudio -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install torch and torchvision from nightlies
         run: |
           pip install numpy networkx
-          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
       - name: Install torch and torchtext from nightlies
         run: |
           pip install numpy networkx
-          pip install --pre torch torchtext --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchtext --index-url https://download.pytorch.org/whl/nightly/cpu
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
       - name: Install torch and torchaudio from nightlies
         run: |
           pip install networkx
-          pip install --pre torch torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+          pip install --pre torch torchaudio --index-url https://download.pytorch.org/whl/nightly/cpu
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3
@@ -166,8 +166,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install torch and torcharrow from nightlies
-        run:
-          pip install --pre torch torcharrow --index-url https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+        run: pip install --pre torch torcharrow --index-url https://download.pytorch.org/whl/nightly/cpu
 
       - name: Check out torchdata repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1091
* #1090

Differential Revision: [D44111515](https://our.internmc.facebook.com/intern/diff/D44111515)