### PR TITLE
Properly cleanup processes and queues for MPRS and Fix `pause` for prefetch (#1075)

### DIFF
--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -64,6 +64,16 @@ class ProtocolClient(Protocol):
         self.request_queue.put(request)
         self.request_sent(request)
 
+    def request_terminate(self):
+        r"""
+        Drop the existing request and send TerminateRequest directly
+        """
+        if not self.can_take_request():
+            self._req_sent = None
+        request = communication.messages.TerminateRequest()
+        self.request_queue.put(request)
+        self.request_sent(request)
+
 
 class ProtocolServer(Protocol):
     """

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -247,14 +247,14 @@ class DataLoader2(Generic[T_co]):
         Shuts down ``ReadingService`` and clean up iterator.
         """
         try:
-            if not self._reset_iter:
-                self._reset_iter = True
-                self._datapipe_iter = None
             if not self._terminated:
+                self._terminated = True
                 if self.reading_service is not None:
                     self.reading_service.finalize_iteration()
                     self.reading_service.finalize()
-                self._terminated = True
+            if not self._reset_iter:
+                self._reset_iter = True
+                self._datapipe_iter = None
         # Ignore AttributeError in case any attribute has been removed before `__del__`
         except AttributeError:
             pass

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import multiprocessing as py_mp
-import queue
 import warnings
 
 from abc import ABC, abstractmethod
@@ -22,7 +21,7 @@ from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata._constants import default_dl2_worker_join_timeout_in_s, default_timeout_in_s
 from torchdata.dataloader2 import communication
-from torchdata.dataloader2.graph import DataPipe, replace_dp, set_graph_random_seed, traverse_dps
+from torchdata.dataloader2.graph import DataPipe, list_dps, replace_dp, set_graph_random_seed, traverse_dps
 from torchdata.dataloader2.graph._serialization import attach_wrapper
 from torchdata.dataloader2.graph.utils import _find_replicable_branches
 from torchdata.dataloader2.random import dist_share_seed, SeedGenerator
@@ -185,6 +184,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
     _main_prefetch_datapipe: Optional[DataPipe]
     _end_datapipe: Optional[DataPipe]
     _mp: bool
+    _finalized: bool = False
 
     def __init__(
         self,
@@ -247,13 +247,13 @@ class MultiProcessingReadingService(ReadingServiceInterface):
                 ctx, round_robin_dps, process_name="dispatching process"
             )
             assert len(req_queues) == self.num_workers and len(res_queues) == self.num_workers
-            process.daemon = True
-            process.start()
-            self._dispatch_process = (process, req_queues, res_queues)
             for req_queue in req_queues:
                 req_queue.cancel_join_thread()
             for res_queue in res_queues:
                 res_queue.cancel_join_thread()
+            process.daemon = True
+            process.start()
+            self._dispatch_process = (process, req_queues, res_queues)
 
         # Find replicable branches for worker processes
         # The rest of non-replicable DataPipes will remain in the main process
@@ -285,6 +285,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
                 process_name=f"worker process {worker_id}",
                 call_on_process_init=call_on_process_init,
             )
+            req_queue.cancel_join_thread()
             process.daemon = True
             process.start()
             self._worker_processes.append((process, req_queue, res_queue))  # These queues are independent
@@ -340,54 +341,53 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         r"""
         ``MultiProcessingReadingService`` invalidate states & properly exits all subprocesses.
         """
-        # TODO(618): Check if anyone stuck with messages
-        def clean_me(process, req_queue, res_queue):
-            # TODO(619): Can send terminations simultaneously
-            # TODO(620): Make termination a function of QueueWrapperDataPipe (similar to reset)
-            req_queue.put(communication.messages.TerminateRequest())
-            try:
-                _ = res_queue.get(timeout=default_dl2_worker_join_timeout_in_s)
-            except queue.Empty:
-                pass
-            process.join(default_dl2_worker_join_timeout_in_s)
+        if self._finalized:
+            return
+        self._finalized = True
 
+        # TODO(618): Check if anyone stuck with messages
         # Clean up worker processes
-        for process, req_queue, res_queue in self._worker_processes:
+        if self.num_workers > 0:
+            self._worker_consumer_datapipe.request_terminate()  # type: ignore[union-attr]
+        for process, req_queue, _ in self._worker_processes:
             try:
-                clean_me(process, req_queue, res_queue)
+                process.join(default_dl2_worker_join_timeout_in_s)
             except TimeoutError:
                 pass
+            req_queue.close()
 
         # Clean up dispatching process
         if self._dispatch_process:
             try:
-                # Send TerminateRequest to all loops to make sure `zip_longest` exits
-                for req_queue in self._dispatch_process[1]:
-                    req_queue.put(communication.messages.TerminateRequest())
-                for res_queue in self._dispatch_process[2]:
-                    try:
-                        _ = res_queue.get(timeout=default_dl2_worker_join_timeout_in_s)
-                    except queue.Empty:
-                        pass
                 self._dispatch_process[0].join(default_dl2_worker_join_timeout_in_s)
             except TimeoutError:
                 pass
+            for req_queue in self._dispatch_process[1]:
+                req_queue.close()
 
         self._worker_processes = []
         self._dispatch_process = None
 
     def _pause(self):
         """
-        Pauses DataPipes' activities such as prefetching, in order to collect state.
+        Pauses DataPipes' activities such as prefetching within main/worker/dispatching processes,
+        in order to collect state.
         """
-        if self.main_prefetch_cnt > 0 and self.num_workers > 0:
-            # Stop prefetching of main loop first
-            self._main_prefetch_datapipe.pause()  # type: ignore[union-attr]
+        assert self._end_datapipe is not None
+        dp_list = list_dps(traverse_dps(self._end_datapipe))
+        for dp in dp_list:
+            # TODO: Combine QueueWrapper and _IterateQueueDataPipes,
+            #       and attach pause method. Then, no need to call
+            #       self._worker_consumer_datapipe.request_pause()
+            if isinstance(dp, communication.iter.QueueWrapper):
+                continue
+            if hasattr(dp, "pause") and callable(dp.pause):
+                dp.pause()
         if self.num_workers > 0:
             self._worker_consumer_datapipe.request_pause()  # type: ignore[union-attr]
         else:
             raise RuntimeError(
-                "If you would like to use `pause` with `PrototypeMultiProcessingReadingService`, "
+                "If you would like to use `pause` with `MultiProcessingReadingService`, "
                 "please use more than 0 worker."
             )
 
@@ -400,7 +400,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
             self._worker_consumer_datapipe.request_resume()  # type: ignore[union-attr]
         else:
             raise RuntimeError(
-                "If you would like to use `resume` with `PrototypeMultiProcessingReadingService`, "
+                "If you would like to use `resume` with `MultiProcessingReadingService`, "
                 "please use more than 0 worker."
             )
         if self.main_prefetch_cnt > 0 and self.num_workers > 0:

--- a/torchdata/dataloader2/utils/worker.py
+++ b/torchdata/dataloader2/utils/worker.py
@@ -78,6 +78,7 @@ def process_init_fn(
     else:
         assert len(non_replicable_dp) == 1
         assert not (dispatching_req_queue is None and dispatching_res_queue is None)
+        dispatching_req_queue.cancel_join_thread()  # type: ignore[union-attr]
         non_dispatching_branches = find_non_dispatching_branches(graph)
         for dp in non_dispatching_branches:
             torch.utils.data.graph_settings.apply_sharding(


### PR DESCRIPTION
Summary:
Fixes issue about `MPRS.finalize` when `dataloader2.shutdown()` is called

### Changes

- DataLoader2 should always clean up `datapipe_iter` at shutdown
- Guard `MPRS` to finalize once
- Fix the problem of `ConnectionError` when DataLoader early exits
  - This is caused by `queue` is joined when main/worker/dispatching process exits. No more request/response can be passed across processes.
    - Consumer process shouldn't join the `req_queue` at exit to make sure producer process can still access the remaining request. And, consumer will close `req_queue` after clean up to prevent any further request sent to queue.
    - Produce process shouldn't join the `res_queue` at exit to make sure consumer process can still access response. And, producer will close `res_queue` after clean up to prevent any further response sent to queue.
       - Main (Consumer) <-> Worker (Producer)
       - Worker (Consumer) -> Dispatching (Producer)
- Fix `pause` API for DataLoader2
    - ~Invoke `pause` lazily until the `limit+1` iteration is reached to align with python's iterator behavior.~ (**Breaking internal tests**)
    - Make `prefetch.pause` blocking unless there might be potential racing issue. Main thread is paused but prefetch worker is still trying to fetch data from `iter`.
- Add tests to validate

Pull Request resolved: https://github.com/pytorch/data/pull/1075

Differential Revision: D44168655

Pulled By: ejguan

