### PR TITLE
[DataPipe] Fix/add __len__ implementation of Prefetcher and WebDataset

### DIFF
--- a/test/test_huggingface_datasets.py
+++ b/test/test_huggingface_datasets.py
@@ -45,6 +45,8 @@ class TestHuggingFaceHubReader(expecttest.TestCase):
         with self.assertRaises(StopIteration):
             next(iterator)
             next(iterator)
+        with self.assertRaises(TypeError):
+            len(datapipe)
 
 
 if __name__ == "__main__":

--- a/test/test_iterdatapipe.py
+++ b/test/test_iterdatapipe.py
@@ -305,6 +305,9 @@ class TestIterDataPipe(expecttest.TestCase):
         actual = list(prefetched_dp)
         self.assertEqual(expected, actual)
 
+        # __len__ Test: returns the same length as source
+        self.assertEqual(len(source_dp), len(prefetched_dp))
+
     def test_repeater_iterdatapipe(self) -> None:
         import itertools
 

--- a/torchdata/datapipes/iter/util/prefetcher.py
+++ b/torchdata/datapipes/iter/util/prefetcher.py
@@ -8,7 +8,7 @@ import threading
 import time
 
 from collections import deque
-from typing import Deque, final, Optional
+from typing import Deque, final, Optional, Sized
 
 import torch
 
@@ -151,6 +151,11 @@ class PrefetcherIterDataPipe(IterDataPipe):
             assert self.prefetch_data is not None
             self.prefetch_data.run_prefetcher = True
             self.prefetch_data.paused = False
+
+    def __len__(self) -> int:
+        if isinstance(self.source_datapipe, Sized):
+            return len(self.source_datapipe)
+        raise TypeError(f"{type(self).__name__} instance doesn't have valid length")
 
 
 @functional_datapipe("pin_memory")

--- a/torchdata/datapipes/iter/util/webdataset.py
+++ b/torchdata/datapipes/iter/util/webdataset.py
@@ -99,6 +99,3 @@ class WebDatasetIterDataPipe(IterDataPipe[Dict]):
             sample[suffix] = data
         if sample != {}:
             yield sample
-
-    def __len__(self) -> int:
-        return len(self.source_datapipe)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #1121
* __->__ #1120

- Fixes #1114
    - `Prefetcher` will use the length from source if it is available.
- Remove `__len__` from `WebDataset` as it cannot be know with certainty in advance

Differential Revision: [D44717406](https://our.internmc.facebook.com/intern/diff/D44717406)