### PR TITLE
[NovaX] M1 Builds on Nova GHA

### DIFF
--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -23,19 +23,20 @@ jobs:
       test-infra-ref: main
   build:
     needs: generate-matrix
-    name: pytorch/vision
+    name: pytorch/data
     uses: pytorch/test-infra/.github/workflows/build_conda_macos.yml@main
     with:
-      conda-package-directory: packaging/torchvision
-      repository: pytorch/vision
+      conda-package-directory: packaging/torchdata
+      repository: pytorch/data
       ref: ""
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: ""
       post-script: ""
-      package-name: torchvision
-      smoke-test-script: test/smoke_test.py
+      package-name: torchdata
+      env-var-script: packaging/env-var-script.txt
+      smoke-test-script: test/smoke_test/smoke_test.py
       runner-type: macos-m1-12
       trigger-event: dev
     secrets:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -8,9 +8,9 @@ on:
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
-        # Release candidate tags look like: v1.11.0-rc1
-        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -1,0 +1,42 @@
+name: Build M1 Conda
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: conda
+      os: macos-arm64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+  build:
+    needs: generate-matrix
+    name: pytorch/vision
+    uses: pytorch/test-infra/.github/workflows/build_conda_macos.yml@main
+    with:
+      conda-package-directory: packaging/torchvision
+      repository: pytorch/vision
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ""
+      post-script: ""
+      package-name: torchvision
+      smoke-test-script: test/smoke_test.py
+      runner-type: macos-m1-12
+      trigger-event: dev
+    secrets:
+      CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -1,0 +1,42 @@
+name: Build M1 Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+      - main
+      - release/*
+    tags:
+        # NOTE: Binary build pipelines should only get triggered on release candidate builds
+        # Release candidate tags look like: v1.11.0-rc1
+        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: macos-arm64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+  build:
+    needs: generate-matrix
+    name: pytorch/data
+    uses: pytorch/test-infra/.github/workflows/build_wheels_macos.yml@main
+    with:
+      repository: pytorch/data
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: "" 
+      post-script: packaging/post_build_script_linux.sh
+      package-name: torchdata
+      runner-type: macos-m1-12
+      smoke-test-script: test/smoke_test.py
+      trigger-event: dev
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -34,8 +34,9 @@ jobs:
       pre-script: "" 
       post-script: ""
       package-name: torchdata
+      env-var-script: packaging/env-var-script.txt
       runner-type: macos-m1-12
-      smoke-test-script: test/smoke_test.py
+      smoke-test-script: test/smoke_test/smoke_test.py
       trigger-event: dev
     secrets:
       AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -8,9 +8,9 @@ on:
       - main
       - release/*
     tags:
-        # NOTE: Binary build pipelines should only get triggered on release candidate builds
-        # Release candidate tags look like: v1.11.0-rc1
-        - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+      # NOTE: Binary build pipelines should only get triggered on release candidate builds
+      # Release candidate tags look like: v1.11.0-rc1
+      - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
   workflow_dispatch:
 
 jobs:
@@ -31,7 +31,7 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
-      pre-script: "" 
+      pre-script: ""
       post-script: ""
       package-name: torchdata
       env-var-script: packaging/env-var-script.txt

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -32,7 +32,7 @@ jobs:
       test-infra-ref: main
       build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
       pre-script: "" 
-      post-script: packaging/post_build_script_linux.sh
+      post-script: ""
       package-name: torchdata
       runner-type: macos-m1-12
       smoke-test-script: test/smoke_test.py

--- a/packaging/env-var-script.txt
+++ b/packaging/env-var-script.txt
@@ -1,1 +1,2 @@
 export BUILD_S3="1"
+export MACOSX_DEPLOYMENT_TARGET="10.13"


### PR DESCRIPTION
As part of the move to Nova, this PR adds Wheels/Conda builds for M1 Macs for torchdata. It includes smoke-test support and the logic for uploading nightlies/release builds in the reusable workflows. If these builds run smoothly over the next 1-2 weeks, we can start deprecating the old release workflows. Until then, these Nova workflows do not upload any binaries to anaconda/pypi indices - they just run the build and verify with smoke tests. Would love any feedback from the data team about missing functionality/concerns/etc. regarding this move.