### PR TITLE
Implement InProcessReadingService

### DIFF
--- a/docs/source/dataloader2.rst
+++ b/docs/source/dataloader2.rst
@@ -31,6 +31,7 @@ ReadingService
     :template: class_method_template.rst
 
     DistributedReadingService
+    InProcessReadingService
     MultiProcessingReadingService
     SequentialReadingService
 

--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -25,6 +25,7 @@ from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 from torchdata.dataloader2 import (
     DataLoader2,
     DistributedReadingService,
+    InProcessReadingService,
     MultiProcessingReadingService,
     ReadingServiceInterface,
     SequentialReadingService,
@@ -221,8 +222,8 @@ class DataLoader2ConsistencyTest(TestCase):
         return MultiProcessingReadingService(num_workers=2)
 
     @staticmethod
-    def _get_mp_reading_service_zero_workers():
-        return MultiProcessingReadingService(num_workers=0)
+    def _get_in_process_reading_service():
+        return InProcessReadingService()
 
     def _collect_data(self, datapipe, reading_service_gen):
         dl: DataLoader2 = DataLoader2(datapipe, reading_service=reading_service_gen())
@@ -245,7 +246,7 @@ class DataLoader2ConsistencyTest(TestCase):
 
         reading_service_generators = (
             self._get_mp_reading_service,
-            self._get_mp_reading_service_zero_workers,
+            self._get_in_process_reading_service,
         )
         for reading_service_gen in reading_service_generators:
             actual = self._collect_data(dp, reading_service_gen=reading_service_gen)

--- a/test/dataloader2/test_mprs.py
+++ b/test/dataloader2/test_mprs.py
@@ -226,12 +226,6 @@ class TestMultiProcessingReadingService(TestCase):
     `pause`, `resume`, `snapshot`.
     """
 
-    def test_zero_worker(self) -> None:
-        rs = MultiProcessingReadingService(
-            num_workers=0,
-        )
-        self.assertTrue(isinstance(rs, InProcessReadingService))
-
     @mp_ctx_parametrize
     @parametrize("dp_fn", [subtest(_non_dispatching_dp, "non_dispatch"), subtest(_dispatching_dp, "dispatch")])
     @parametrize("main_prefetch", [0, 10])

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -26,7 +26,7 @@ def _random_fn(data):
     Used to validate the randomness of subprocess-local RNGs are set deterministically.
     """
     py_random_num = random.randint(0, 2 ** 32)
-    np_random_num = np.random.randint(0, 2 ** 32)
+    np_random_num = np.random.randint(0, 2 ** 32 - 1)
     torch_random_num = torch.randint(0, 2 ** 32, size=[]).item()
     return (data, py_random_num, np_random_num, torch_random_num)
 

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 
 from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
-from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService
+from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService, SingleProcessingReadingService
 from torchdata.dataloader2.graph.settings import set_graph_random_seed
 from torchdata.dataloader2.random import SeedGenerator
 from torchdata.datapipes.iter import IterableWrapper
@@ -33,8 +33,8 @@ def _random_fn(data):
 
 class DeterminismTest(TestCase):
     @unittest.skipIf(IS_WINDOWS, "Remove when https://github.com/pytorch/data/issues/857 is fixed")
-    @parametrize("num_workers", [0, 8])
-    def test_proto_rs_determinism(self, num_workers):
+    @parametrize("num_workers", [1, 8])
+    def test_mprs_determinism(self, num_workers):
         data_length = 64
         exp = list(range(data_length))
 
@@ -109,6 +109,52 @@ class DeterminismTest(TestCase):
         ss_0_321, ds_0_321 = _get_dp_seeds_after_setting(worker_id=0, seed=321)
         self.assertNotEqual(ss_0_123, ss_0_321)
         self.assertNotEqual(ds_0_123, ds_0_321)
+
+    def test_sprs_determinism(self):
+        data_length = 64
+        exp = list(range(data_length))
+
+        data_source = IterableWrapper(exp)
+        dp = data_source.shuffle().sharding_filter().map(_random_fn)
+        rs = SingleProcessingReadingService()
+        dl = DataLoader2(dp, reading_service=rs)
+
+        # No seed
+        res = []
+        for d, *_ in dl:
+            res.append(d)
+        self.assertEqual(sorted(res), exp)
+
+        # Shuffle with seed
+        results = []
+        for _ in range(2):
+            res = []
+            ran_res = []
+            torch.manual_seed(123)
+            random.seed(123)
+            np.random.seed(123)
+            for d, *ran_nums in dl:
+                res.append(d)
+                ran_res.append(ran_nums)
+            self.assertEqual(sorted(res), exp)
+            results.append((res, ran_res))
+        # Same seed generate the same order of data and the same random state
+        self.assertEqual(results[0], results[1])
+
+        # Different seed
+        res = []
+        ran_res = []
+        torch.manual_seed(321)
+        random.seed(321)
+        np.random.seed(321)
+        for d, *ran_nums in dl:
+            res.append(d)
+            ran_res.append(ran_nums)
+        self.assertEqual(sorted(res), exp)
+        # Different shuffle order
+        self.assertNotEqual(results[0][0], res)
+        # Different subprocess-local random state
+        self.assertNotEqual(results[0][1], ran_res)
 
 
 instantiate_parametrized_tests(DeterminismTest)

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -26,7 +26,7 @@ def _random_fn(data):
     Used to validate the randomness of subprocess-local RNGs are set deterministically.
     """
     py_random_num = random.randint(0, 2 ** 32)
-    np_random_num = np.random.randint(0, 2 ** 32 - 1)
+    np_random_num = np.random.randint(0, 2 ** 32, dtype=np.uint32)
     torch_random_num = torch.randint(0, 2 ** 32, size=[]).item()
     return (data, py_random_num, np_random_num, torch_random_num)
 

--- a/test/dataloader2/test_random.py
+++ b/test/dataloader2/test_random.py
@@ -15,7 +15,7 @@ import numpy as np
 import torch
 
 from torch.testing._internal.common_utils import instantiate_parametrized_tests, IS_WINDOWS, parametrize
-from torchdata.dataloader2 import DataLoader2, MultiProcessingReadingService, SingleProcessingReadingService
+from torchdata.dataloader2 import DataLoader2, InProcessReadingService, MultiProcessingReadingService
 from torchdata.dataloader2.graph.settings import set_graph_random_seed
 from torchdata.dataloader2.random import SeedGenerator
 from torchdata.datapipes.iter import IterableWrapper
@@ -116,7 +116,7 @@ class DeterminismTest(TestCase):
 
         data_source = IterableWrapper(exp)
         dp = data_source.shuffle().sharding_filter().map(_random_fn)
-        rs = SingleProcessingReadingService()
+        rs = InProcessReadingService()
         dl = DataLoader2(dp, reading_service=rs)
 
         # No seed

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -10,11 +10,11 @@ from torchdata.dataloader2.error import PauseIteration
 from torchdata.dataloader2.reading_service import (
     CheckpointableReadingServiceInterface,
     DistributedReadingService,
+    InProcessReadingService,
     MultiProcessingReadingService,
     PrototypeMultiProcessingReadingService,
     ReadingServiceInterface,
     SequentialReadingService,
-    SingleProcessingReadingService,
 )
 from torchdata.dataloader2.shuffle_spec import ShuffleSpec
 
@@ -23,13 +23,13 @@ __all__ = [
     "DataLoader2",
     "DataLoader2Iterator",
     "DistributedReadingService",
+    "InProcessReadingService",
     "MultiProcessingReadingService",
     "PauseIteration",
     "PrototypeMultiProcessingReadingService",
     "ReadingServiceInterface",
     "SequentialReadingService",
     "ShuffleSpec",
-    "SingleProcessingReadingService",
 ]
 
 assert __all__ == sorted(__all__)

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -14,6 +14,7 @@ from torchdata.dataloader2.reading_service import (
     PrototypeMultiProcessingReadingService,
     ReadingServiceInterface,
     SequentialReadingService,
+    SingleProcessingReadingService,
 )
 from torchdata.dataloader2.shuffle_spec import ShuffleSpec
 
@@ -28,6 +29,7 @@ __all__ = [
     "ReadingServiceInterface",
     "SequentialReadingService",
     "ShuffleSpec",
+    "SingleProcessingReadingService",
 ]
 
 assert __all__ == sorted(__all__)

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -22,8 +22,8 @@ from torchdata.dataloader2.random import SeedGenerator
 from torchdata.dataloader2.random.seed_generator import _UINT64_UPPER_BOUND
 from torchdata.dataloader2.reading_service import (
     CheckpointableReadingServiceInterface,
+    InProcessReadingService,
     ReadingServiceInterface,
-    SingleProcessingReadingService,
 )
 
 T_co = TypeVar("T_co", covariant=True)
@@ -150,7 +150,7 @@ class DataLoader2(Generic[T_co]):
             right after the creation of the DataLoader.
         datapipe_adapter_fn (``Iterable[Adapter]`` or ``Adapter``, optional): ``Adapter`` function(s) that
             will be applied to the DataPipe (default: ``None``).
-        reading_service (ReadingServiceInterface): defines how ``DataLoader2`` should execute operations over
+        reading_service (ReadingServiceInterface, optional): defines how ``DataLoader2`` should execute operations over
             the ``DataPipe``, e.g. multiprocessing/distributed (default: ``None``). A deepcopy of this will be
             created during initialization, allowing the ReadingService to be re-used in a different
             ``DataLoader2`` without sharing states.

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -20,11 +20,7 @@ from torchdata.dataloader2.graph._serialization import (
 )
 from torchdata.dataloader2.random import SeedGenerator
 from torchdata.dataloader2.random.seed_generator import _UINT64_UPPER_BOUND
-from torchdata.dataloader2.reading_service import (
-    CheckpointableReadingServiceInterface,
-    InProcessReadingService,
-    ReadingServiceInterface,
-)
+from torchdata.dataloader2.reading_service import CheckpointableReadingServiceInterface, ReadingServiceInterface
 
 T_co = TypeVar("T_co", covariant=True)
 SERIALIZED_DATAPIPE_KEY_NAME = "serialized_datapipe"
@@ -182,7 +178,6 @@ class DataLoader2(Generic[T_co]):
             self.datapipe_adapter_fns = datapipe_adapter_fn
         else:
             self.datapipe_adapter_fns = [datapipe_adapter_fn]
-
         self.reading_service = clone(reading_service)
         self.reading_service_state: Optional[bytes] = None  # is not `None` when `load_state_dict` is called
         self._terminated: bool = False

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -20,7 +20,11 @@ from torchdata.dataloader2.graph._serialization import (
 )
 from torchdata.dataloader2.random import SeedGenerator
 from torchdata.dataloader2.random.seed_generator import _UINT64_UPPER_BOUND
-from torchdata.dataloader2.reading_service import CheckpointableReadingServiceInterface, ReadingServiceInterface
+from torchdata.dataloader2.reading_service import (
+    CheckpointableReadingServiceInterface,
+    ReadingServiceInterface,
+    SingleProcessingReadingService,
+)
 
 T_co = TypeVar("T_co", covariant=True)
 SERIALIZED_DATAPIPE_KEY_NAME = "serialized_datapipe"
@@ -146,7 +150,7 @@ class DataLoader2(Generic[T_co]):
             right after the creation of the DataLoader.
         datapipe_adapter_fn (``Iterable[Adapter]`` or ``Adapter``, optional): ``Adapter`` function(s) that
             will be applied to the DataPipe (default: ``None``).
-        reading_service (ReadingServiceInterface, optional): defines how ``DataLoader2`` should execute operations over
+        reading_service (ReadingServiceInterface): defines how ``DataLoader2`` should execute operations over
             the ``DataPipe``, e.g. multiprocessing/distributed (default: ``None``). A deepcopy of this will be
             created during initialization, allowing the ReadingService to be re-used in a different
             ``DataLoader2`` without sharing states.
@@ -178,6 +182,7 @@ class DataLoader2(Generic[T_co]):
             self.datapipe_adapter_fns = datapipe_adapter_fn
         else:
             self.datapipe_adapter_fns = [datapipe_adapter_fn]
+
         self.reading_service = clone(reading_service)
         self.reading_service_state: Optional[bytes] = None  # is not `None` when `load_state_dict` is called
         self._terminated: bool = False

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -204,6 +204,8 @@ class SingleProcessingReadingService(ReadingServiceInterface):
         Resumes DataPipes' activities. This is required to be called after `_pause` before
         the DataLoader can keep yielding elements.
         """
+        assert self._end_datapipe is not None
+
         dp_list = list_dps(traverse_dps(self._end_datapipe))
         # Reversed order
         for dp in dp_list[::-1]:

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -192,7 +192,9 @@ class InProcessReadingService(ReadingServiceInterface):
 
         return None
 
-    def _pause(self):
+    def _pause(
+        self, pause_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         """
         Pauses DataPipes' activities in the main process in order to collect state.
         """
@@ -202,8 +204,11 @@ class InProcessReadingService(ReadingServiceInterface):
         for dp in dp_list:
             if hasattr(dp, "pause") and callable(dp.pause):
                 dp.pause()
+        return None
 
-    def _resume(self):
+    def _resume(
+        self, resume_fn: Optional[Callable[[DataPipe], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe], DataPipe]]:
         """
         Resumes DataPipes' activities. This is required to be called after `_pause` before
         the DataLoader can keep yielding elements.
@@ -215,6 +220,18 @@ class InProcessReadingService(ReadingServiceInterface):
         for dp in dp_list[::-1]:
             if hasattr(dp, "resume") and callable(dp.resume):
                 dp.resume()
+        return None
+
+    def _limit(
+        self, num_batches: Optional[int], limit_fn: Optional[Callable[[DataPipe, Optional[int]], DataPipe]] = None
+    ) -> Optional[Callable[[DataPipe, Optional[int]], DataPipe]]:
+        r"""
+        Apply limit_fn to the DataPipe graph.
+        """
+        if limit_fn is not None:
+            # TODO: Remove when flexible checkpoint is supported
+            limit_fn(self._end_datapipe, num_batches)  # type: ignore[arg-type]
+        return None
 
 
 class MultiProcessingReadingService(ReadingServiceInterface):

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -227,7 +227,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
     process and eventually return the result to the main process.
 
     Args:
-        num_workers (int, optional): How many subprocesses to use for data loading.
+        num_workers (int): How many subprocesses to use for data loading.
         multiprocessing_context (str, optional): Multiprocessing starting method.
             If method is None then the default context is returned.
             Otherwise, method should be 'fork', 'spawn'.
@@ -256,30 +256,16 @@ class MultiProcessingReadingService(ReadingServiceInterface):
     _mp: bool
     _finalized: bool = False
 
-    def __new__(
-        cls,
-        num_workers: int = 0,
-        multiprocessing_context: Optional[str] = None,
-        worker_prefetch_cnt: int = 10,
-        main_prefetch_cnt: int = 10,
-        worker_init_fn: Optional[Callable[[DataPipe, WorkerInfo], DataPipe]] = None,
-        worker_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
-    ):
-        if num_workers == 0:
-            warnings.warn(f"`InProcessReadingService` is used when {num_workers=}")
-            return InProcessReadingService(worker_init_fn, worker_reset_fn)
-        return super().__new__(cls)
-
     def __init__(
         self,
-        num_workers: int = 0,
+        num_workers: int,
         multiprocessing_context: Optional[str] = None,
         worker_prefetch_cnt: int = 10,
         main_prefetch_cnt: int = 10,
         worker_init_fn: Optional[Callable[[DataPipe, WorkerInfo], DataPipe]] = None,
         worker_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
     ) -> None:
-        assert num_workers > 0
+        assert num_workers > 0, "Please use `InProcessReadingService` for num_workers=0"
         self.num_workers = num_workers
         if multiprocessing_context is not None:
             _all_start_methods = mp.get_all_start_methods()

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -275,7 +275,7 @@ class MultiProcessingReadingService(ReadingServiceInterface):
 
     def __init__(
         self,
-        num_workers: int,
+        num_workers: int = 0,
         multiprocessing_context: Optional[str] = None,
         worker_prefetch_cnt: int = 10,
         main_prefetch_cnt: int = 10,

--- a/torchdata/dataloader2/reading_service.py
+++ b/torchdata/dataloader2/reading_service.py
@@ -265,8 +265,11 @@ class MultiProcessingReadingService(ReadingServiceInterface):
         worker_init_fn: Optional[Callable[[DataPipe, WorkerInfo], DataPipe]] = None,
         worker_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
     ) -> None:
-        assert num_workers > 0, "Please use `InProcessReadingService` for num_workers=0"
+        if num_workers == 0:
+            raise ValueError("Please use `InProcessReadingService` for num_workers=0")
+        assert num_workers > 0
         self.num_workers = num_workers
+
         if multiprocessing_context is not None:
             _all_start_methods = mp.get_all_start_methods()
             assert (


### PR DESCRIPTION
Fixes #1107 
Fixes #720
Fixes #616

### Changes

- Implement `InProcessReadingService` (Willing to take any suggestion on naming)
  - Control shuffle and sharding (noop)
  - Add support to pause/resume/limit
- ~Make `InProcessReadingService` as the default `reading_service` to `DataLoader2`.~
  - ~Then, `reading_service` always has a value, and remove the logic of `reading_service` is None.~
- Modify `MultiProcessingReadingService`
  - When `num_workers=0`, raise a warning