### PR TITLE
Enable miniepoch for MultiProcessingReadingService

### DIFF
--- a/test/dataloader2/test_mprs.py
+++ b/test/dataloader2/test_mprs.py
@@ -40,6 +40,7 @@ def _non_dispatching_dp(n_elements=1000):
 
 def _dispatching_dp(n_elements=1000):
     dp = IterableWrapper(list(range(n_elements))).shuffle()
+    dp = dp.prefetch()
     dp = dp.sharding_round_robin_dispatch(SHARDING_PRIORITIES.MULTIPROCESSING)
     dp = dp.map(_add_one).batch(16)
     return dp

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -38,8 +38,22 @@ class ResetEpochResponse(Response):
     pass
 
 
-class PauseRequest(Request):
+class LimitRequest(Request):
+    __slots__ = "limit_fn"
+
+    def __init__(self, limit_fn):
+        self.limit_fn = limit_fn
+
+
+class LimitResponse(Response):
     pass
+
+
+class PauseRequest(Request):
+    __slots__ = "pause_fn"
+
+    def __init__(self, pause_fn):
+        self.pause_fn = pause_fn
 
 
 class PauseResponse(Response):
@@ -47,7 +61,10 @@ class PauseResponse(Response):
 
 
 class ResumeRequest(Request):
-    pass
+    __slots__ = "resume_fn"
+
+    def __init__(self, resume_fn):
+        self.resume_fn = resume_fn
 
 
 class ResumeResponse(Response):

--- a/torchdata/dataloader2/dataloader2.py
+++ b/torchdata/dataloader2/dataloader2.py
@@ -377,25 +377,31 @@ class DataLoader2(Generic[T_co]):
         """
         self._seed_generator = self._initial_seed_generator
 
-    def _pause(self):
+    def _pause(self) -> None:
         if hasattr(self.reading_service, "_pause"):
             self._is_paused = True
-            self.reading_service._pause()
+            pause_fn = self.reading_service._pause()
+            if pause_fn is not None:
+                self.datapipe = pause_fn(self.datapipe)
         else:
             warnings.warn("ReadingService doesn't support `pause`.")
 
-    def _resume(self):
+    def _resume(self) -> None:
         if hasattr(self.reading_service, "_resume"):
             if not self._is_paused:
                 warnings.warn("Resume is called when `DataLoader2` is not paused. No operation is performed.")
             else:
-                self.reading_service._resume()
+                resume_fn = self.reading_service._resume()
+                if resume_fn is not None:
+                    self.datapipe = resume_fn(self.datapipe)
                 self._is_paused = False
         else:
             warnings.warn("ReadingService doesn't support `resume`.")
 
     def _limit(self, num_batches: Optional[int]) -> None:
         if hasattr(self.reading_service, "_limit"):
-            self.reading_service._limit(num_batches)
+            limit_fn = self.reading_service._limit(num_batches)
+            if limit_fn is not None:
+                self.datapipe = limit_fn(self.datapipe)
         else:
             warnings.warn("ReadingService doesn't support `limit`.")


### PR DESCRIPTION
Summary:
Add `pause`, `resume`, `limit` API to `MultiProcessingReadingService` to support miniepoch API.
- Adding a function as the input to make sure it working with internal ReadingService to control miniepoch within the worker/dispatching process

All tests should be passing in `test/dataloader2/test_mrps.py`

Differential Revision: D45289736

