### PR TITLE
[DataPipe] Fix FullSync shutdown hanging issue while paused

### DIFF
--- a/test/test_distributed.py
+++ b/test/test_distributed.py
@@ -149,6 +149,14 @@ class DistributedTest(TestCase):
         except Exception as e:
             assert isinstance(e, PrefetchTimeoutError)
 
+        # Test that reset/shutdown does not hang while paused
+        dp3 = dp.fullsync()
+        it = iter(dp3)
+        next(it)
+        dp3.pause()
+        it2 = iter(dp3)  # Reset
+        next(it2)
+
         _finalize_distributed_queue(rank, q)
 
     @world_size_parametrize

--- a/torchdata/datapipes/iter/util/distributed.py
+++ b/torchdata/datapipes/iter/util/distributed.py
@@ -114,6 +114,7 @@ class _PrefetchExecutor:
         return data
 
     def shutdown(self):
+        self._paused = False
         self._executor.shutdown(wait=True)
 
     def pause(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1153

Before this PR, the executor within FullSync fails to shutdown if it were currently paused. This PR allows shutdown without submitting additional jobs.

Differential Revision: [D45610885](https://our.internmc.facebook.com/intern/diff/D45610885)