### PR TITLE
[DataPipe] Fix a word in WebDS DataPipe

### DIFF
--- a/torchdata/datapipes/iter/util/webdataset.py
+++ b/torchdata/datapipes/iter/util/webdataset.py
@@ -16,7 +16,7 @@ def pathsplit(p):
 
     The prefix is used for grouping files into samples,
     the suffix is used as key in the output dictionary.
-    The suffix consists of all components after the last
+    The suffix consists of all components after the first
     "." in the filename.
 
     In torchdata, the prefix consists of the .tar file


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1156

Fixes #1144 

Note that the description is already correct in the [docstring of the DataPipe](https://github.com/pytorch/data/blob/483274f17a3244d14de886652ce8b35512fb7763/torchdata/datapipes/iter/util/webdataset.py#L52). This merely fixes the docstring of the helper function.

Differential Revision: [D45754064](https://our.internmc.facebook.com/intern/diff/D45754064)