### PR TITLE
Prevent `in_memory_cache` from yielding from `source_dp` when it's fully cached

### DIFF
--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -97,11 +97,12 @@ class InMemoryCacheHolderIterDataPipe(IterDataPipe[T_co]):
 
     def __iter__(self) -> Iterator[T_co]:
         if self.cache:
-            for idx, data in enumerate(self.source_dp):
-                if idx < self.idx:
-                    yield data
-                else:
-                    break
+            if self.idx > 0:
+                for idx, data in enumerate(self.source_dp):
+                    if idx < self.idx:
+                        yield data
+                    else:
+                        break
             yield from self.cache
         else:
             # Local cache


### PR DESCRIPTION
Fixes #1159.
