### PR TITLE
Enable miniepoch for MultiProcessingReadingService

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -23,7 +23,6 @@ from torch.testing._internal.common_utils import instantiate_parametrized_tests,
 from torch.utils.data.datapipes.iter.sharding import SHARDING_PRIORITIES
 
 from torchdata.dataloader2 import (
-    communication,
     DataLoader2,
     DistributedReadingService,
     MultiProcessingReadingService,
@@ -35,7 +34,6 @@ from torchdata.dataloader2.dataloader2 import READING_SERVICE_STATE_KEY_NAME, SE
 from torchdata.dataloader2.graph import DataPipe, list_dps, replace_dp, set_datapipes_seed, traverse_dps
 from torchdata.dataloader2.random import SeedGenerator
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe, ShardingRoundRobinDispatcher
-from torchdata.datapipes.map import SequenceWrapper
 
 try:
     import dill
@@ -257,73 +255,6 @@ class DataLoader2ConsistencyTest(TestCase):
     def test_dataloader2_shuffle(self) -> None:
         # TODO(589): Add shuffle test
         pass
-
-
-@unittest.skipIf(
-    TEST_WITH_TSAN,
-    "Fails with TSAN with the following error: starting new threads after multi-threaded "
-    "fork is not supported. Dying (set die_after_fork=0 to override)",
-)
-class TestDataLoader2EventLoop(TestCase):
-    # TODO: This needs fixing, see issue 624
-    # @skipIfNoDill
-    # def test_basic_threading(self):
-    #     def clean_me(process, req_queue, res_queue):
-    #         req_queue.put(communication.messages.TerminateRequest())
-    #         _ = res_queue.get()
-    #         process.join()
-    #
-    #     it = list(range(100))
-    #     numbers_dp = IterableWrapper(it)
-    #     (process, req_queue, res_queue, _thread_local_datapipe) = communication.eventloop.CreateThreadForDataPipeline(numbers_dp)
-    #
-    #     process.start()
-    #     local_datapipe = communication.iter.QueueWrapper(
-    #         communication.protocol.IterDataPipeQueueProtocolClient(req_queue, res_queue))
-    #
-    #     actual = list(local_datapipe)
-    #     clean_me(process, req_queue, res_queue)
-    #
-    #     self.assertEqual(list(range(100)), actual)
-
-    @skipIfNoDill
-    def test_basic_mapdatapipe_threading(self):
-        def clean_me(process, req_queue, res_queue):
-            req_queue.put(communication.messages.TerminateRequest())
-            _ = res_queue.get()
-            process.join()
-
-        input_len = 100
-        it = list(range(input_len))
-        numbers_dp = SequenceWrapper(it)
-        (process, req_queue, res_queue, _thread_local_datapipe) = communication.eventloop.CreateThreadForDataPipeline(
-            numbers_dp,
-            thread_name="worker thread",
-        )
-
-        process.start()
-
-        # Functional Test: Ensure that you can retrieve every element from the Queue and DataPipe
-        local_datapipe = communication.map.QueueWrapperForMap(
-            communication.protocol.MapDataPipeQueueProtocolClient(req_queue, res_queue)
-        )
-        actual = list(local_datapipe)
-        self.assertEqual([(x, x) for x in range(100)], actual)
-
-        # Functional Test: raise Error when input
-        local_datapipe = communication.map.QueueWrapperForMap(
-            communication.protocol.MapDataPipeQueueProtocolClient(req_queue, res_queue)
-        )
-        with self.assertRaisesRegex(IndexError, "out of bound"):
-            local_datapipe[1000]
-
-        # __len__ Test: Ensure that the correct length is returned
-        local_datapipe = communication.map.QueueWrapperForMap(
-            communication.protocol.MapDataPipeQueueProtocolClient(req_queue, res_queue)
-        )
-        self.assertEqual(input_len, len(local_datapipe))
-
-        clean_me(process, req_queue, res_queue)
 
 
 def _x_mult_2(d):

--- a/test/dataloader2/test_mprs.py
+++ b/test/dataloader2/test_mprs.py
@@ -40,6 +40,7 @@ def _non_dispatching_dp(n_elements=1000):
 
 def _dispatching_dp(n_elements=1000):
     dp = IterableWrapper(list(range(n_elements))).shuffle()
+    dp = dp.prefetch(20)
     dp = dp.sharding_round_robin_dispatch(SHARDING_PRIORITIES.MULTIPROCESSING)
     dp = dp.map(_add_one).batch(16)
     return dp

--- a/torchdata/dataloader2/communication/messages.py
+++ b/torchdata/dataloader2/communication/messages.py
@@ -19,27 +19,36 @@ class Response(DataLoaderQueueMessage):
     pass
 
 
-class ResetIteratorRequest(Request):
-    pass
-
-
-class ResetIteratorResponse(Response):
-    pass
-
-
 class ResetEpochRequest(Request):
-    __slots__ = "reset_fn"
+    __slots__ = ("seed_generator", "iter_reset_fn")
 
-    def __init__(self, reset_fn):
-        self.reset_fn = reset_fn
+    def __init__(self, seed_generator, iter_reset_fn):
+        self.seed_generator = seed_generator
+        self.iter_reset_fn = iter_reset_fn
 
 
 class ResetEpochResponse(Response):
     pass
 
 
-class PauseRequest(Request):
+class LimitRequest(Request):
+    __slots__ = ("num_batches", "limit_fn", "worker_num_batches")
+
+    def __init__(self, num_batches, limit_fn, worker_num_batches=None):
+        self.num_batches = num_batches
+        self.limit_fn = limit_fn
+        self.worker_num_batches = worker_num_batches
+
+
+class LimitResponse(Response):
     pass
+
+
+class PauseRequest(Request):
+    __slots__ = "pause_fn"
+
+    def __init__(self, pause_fn):
+        self.pause_fn = pause_fn
 
 
 class PauseResponse(Response):
@@ -47,7 +56,10 @@ class PauseResponse(Response):
 
 
 class ResumeRequest(Request):
-    pass
+    __slots__ = "resume_fn"
+
+    def __init__(self, resume_fn):
+        self.resume_fn = resume_fn
 
 
 class ResumeResponse(Response):

--- a/torchdata/dataloader2/communication/protocol.py
+++ b/torchdata/dataloader2/communication/protocol.py
@@ -50,17 +50,24 @@ class ProtocolClient(Protocol):
             response = self.response_queue.get(block=True)
             self.request_served(response)
 
-    def request_pause(self):
+    def request_limit(self, num_batches, limit_fn=None, worker_num_batches=None):
         if not self.can_take_request():
-            raise Exception("Can not `pause` while we are still waiting response for previous request")
-        request = communication.messages.PauseRequest()
+            raise Exception("Can not `limit` while we are still waiting response for previous request")
+        request = communication.messages.LimitRequest(num_batches, limit_fn, worker_num_batches)
         self.request_queue.put(request)
         self.request_sent(request)
 
-    def request_resume(self):
+    def request_pause(self, pause_fn=None):
+        if not self.can_take_request():
+            raise Exception("Can not `pause` while we are still waiting response for previous request")
+        request = communication.messages.PauseRequest(pause_fn)
+        self.request_queue.put(request)
+        self.request_sent(request)
+
+    def request_resume(self, resume_fn=None):
         if not self.can_take_request():
             raise Exception("Can not `resume` while we are still waiting response for previous request")
-        request = communication.messages.ResumeRequest()
+        request = communication.messages.ResumeRequest(resume_fn)
         self.request_queue.put(request)
         self.request_sent(request)
 
@@ -124,6 +131,14 @@ class ProtocolServer(Protocol):
         self.response_queue.put(communication.messages.ResetEpochResponse())
         self._req_received = None
 
+    def response_limit(self):
+        if not self.have_pending_request():
+            raise Exception("Attempting to reply with pending request")
+        if not isinstance(self._req_received, communication.messages.LimitRequest):
+            raise Exception("Replaying with `limit` status to other type of message")
+        self.response_queue.put(communication.messages.LimitResponse())
+        self._req_received = None
+
     def response_pause(self):
         if not self.have_pending_request():
             raise Exception("Attempting to reply with pending request")
@@ -177,10 +192,10 @@ class MapDataPipeQueueProtocolClient(ProtocolClient):
         self.request_queue.put(request)
         self.request_sent(request)
 
-    def request_reset_epoch(self, reset_fn):
+    def request_reset_epoch(self, seed_generator, iter_reset_fn):
         if not self.can_take_request():
             raise Exception("Can not reset while we are still waiting response for previous request")
-        request = communication.messages.ResetEpochRequest(reset_fn)
+        request = communication.messages.ResetEpochRequest(seed_generator, iter_reset_fn)
         self.request_queue.put(request)
         self.request_sent(request)
 
@@ -221,14 +236,6 @@ class EmptyQueue(Exception):
 
 
 class IterDataPipeQueueProtocolServer(ProtocolServer):
-    def response_reset_iterator(self):
-        if not self.have_pending_request():
-            raise Exception("Attempting to reply with pending request")
-        if not isinstance(self._req_received, communication.messages.ResetIteratorRequest):
-            raise Exception("Replaying with reset status to other type of message")
-        self.response_queue.put(communication.messages.ResetIteratorResponse())
-        self._req_received = None
-
     def response_next(self, value):
         if not self.have_pending_request():
             raise Exception("Attempting to reply with pending request")
@@ -249,17 +256,10 @@ class IterDataPipeQueueProtocolServer(ProtocolServer):
 
 
 class IterDataPipeQueueProtocolClient(ProtocolClient):
-    def request_reset_iterator(self):
+    def request_reset_epoch(self, seed_generator, iter_reset_fn):
         if not self.can_take_request():
             raise Exception("Can not reset while we are still waiting response for previous request")
-        request = communication.messages.ResetIteratorRequest()
-        self.request_queue.put(request)
-        self.request_sent(request)
-
-    def request_reset_epoch(self, reset_fn):
-        if not self.can_take_request():
-            raise Exception("Can not reset while we are still waiting response for previous request")
-        request = communication.messages.ResetEpochRequest(reset_fn)
+        request = communication.messages.ResetEpochRequest(seed_generator, iter_reset_fn)
         self.request_queue.put(request)
         self.request_sent(request)
 
@@ -270,16 +270,6 @@ class IterDataPipeQueueProtocolClient(ProtocolClient):
         self.request_queue.put(request)
         self.request_sent(request)
 
-    def get_response_reset_iterator(self, block=False):
-        try:
-            response = self.response_queue.get(block=block)
-        except EmptyException:
-            raise EmptyQueue("queue is empty")
-        self.request_served(response)
-
-        if not isinstance(response, communication.messages.ResetIteratorResponse):
-            raise Exception("Invalid response received")
-
     def get_response_reset_epoch(self, block=False):
         try:
             response = self.response_queue.get(block=block)
@@ -289,6 +279,16 @@ class IterDataPipeQueueProtocolClient(ProtocolClient):
 
         if not isinstance(response, communication.messages.ResetEpochResponse):
             raise Exception("Invalid response received")
+
+    def get_response_limit(self, block=False):
+        try:
+            response = self.response_queue.get(block=block)
+        except EmptyException:
+            raise EmptyQueue("queue is empty")
+        self.request_served(response)
+
+        if not isinstance(response, communication.messages.LimitResponse):
+            raise Exception("Invalid response received when expecting `LimitResponse`")
 
     def get_response_pause(self, block=False):
         try:

--- a/torchdata/dataloader2/utils/worker.py
+++ b/torchdata/dataloader2/utils/worker.py
@@ -7,7 +7,6 @@
 import random
 
 from dataclasses import dataclass
-from functools import partial
 from multiprocessing.queues import Queue
 from typing import Callable, Optional
 
@@ -117,41 +116,11 @@ def _set_global_random_state(seed_generator: SeedGenerator, distributed_shared: 
         numpy.random.seed(np_seed)
 
 
-def dispatch_process_reset_fn(
-    datapipe: DataPipe,
-    worker_info: WorkerInfo,
-    seed_generator: SeedGenerator,
-    iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None,
-    custom_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
-) -> DataPipe:
-    r"""
-    Based on the distributed shared random seed, this function is used to set the random state
-    of the non-repliable ``DataPipe`` graph and the global random states for the dispatch process.
-    This function would guarantee that all distributed dispatching processes share the
-    same random state to ensure the same shuffle order.
-    """
-    # Set global random states
-    _set_global_random_state(seed_generator, distributed_shared=True)
-
-    graph = traverse_dps(datapipe)
-    dps = list_dps(graph)
-    set_datapipes_seed(dps, seed_generator=seed_generator, distributed_shared=True)
-
-    if iter_reset_fn is not None:
-        datapipe = iter_reset_fn(datapipe)
-        assert isinstance(datapipe, (IterDataPipe, MapDataPipe))
-
-    if custom_reset_fn is not None:
-        datapipe = custom_reset_fn(datapipe, worker_info, seed_generator)
-        assert isinstance(datapipe, (IterDataPipe, MapDataPipe))
-
-    return datapipe
-
-
 def process_reset_fn(
     datapipe: DataPipe,
     worker_info: WorkerInfo,
     seed_generator: SeedGenerator,
+    distributed_shared_seed: bool = False,
     iter_reset_fn: Optional[Callable[[DataPipe], DataPipe]] = None,
     custom_reset_fn: Optional[Callable[[DataPipe, WorkerInfo, SeedGenerator], DataPipe]] = None,
 ) -> DataPipe:
@@ -160,25 +129,15 @@ def process_reset_fn(
     reset the random state of the ``DataPipe`` graph and the global random states for ``torch``,
     ``random`` and ``numpy``.
     """
-    # Reset non-sharding process first
-    graph = traverse_dps(datapipe)
-    dispatch_process_consumer_dps = find_dps(graph, communication.iter._IterateQueueDataPipes)
-
-    if len(dispatch_process_consumer_dps) > 0:
-        assert len(dispatch_process_consumer_dps) == 1
-        dispatch_process_consumer_dp = dispatch_process_consumer_dps[0]
-        # Only send the reset epoch message once
-        if worker_info.worker_id == 0:
-            # Use WorkerInfo(1, 0)
-            dispatch_reset_fn = partial(
-                dispatch_process_reset_fn, iter_reset_fn=iter_reset_fn, custom_reset_fn=custom_reset_fn
-            )
-            dispatch_process_consumer_dp.reset_epoch(dispatch_reset_fn, seed_generator)
-
     # Set global random states
-    _set_global_random_state(seed_generator)
+    _set_global_random_state(seed_generator, distributed_shared=distributed_shared_seed)
 
-    set_graph_random_seed(datapipe, seed_generator)
+    if distributed_shared_seed:
+        graph = traverse_dps(datapipe)
+        dps = list_dps(graph)
+        set_datapipes_seed(dps, seed_generator=seed_generator, distributed_shared=distributed_shared_seed)
+    else:
+        set_graph_random_seed(datapipe, seed_generator)
 
     if iter_reset_fn is not None:
         datapipe = iter_reset_fn(datapipe)


### PR DESCRIPTION
Summary:
A retry of https://github.com/pytorch/data/pull/1147
- Add pause, resume, limit API to MultiProcessingReadingService to support miniepoch API.
- When limit is requested, `IterQueueWrapper` will make sure only `limit` number of requests are sent to worker process and dispatching proccess.
- Consolidate a few API/messages
  - reset and reset_epoch is merged as a single message
  - Process reset function is shared for both worker process and dispatching process
- For pause/resume/limit/reset_epoch, add a counter to sync between loops to make sure the DataPipe graph is in-place modified once.
- Remove unused thread eventloop

Differential Revision: D45666912

