### PR TITLE
[DataPipe] Cancel future object and always run callback in FullSync during shutdown

### DIFF
--- a/torchdata/datapipes/iter/util/distributed.py
+++ b/torchdata/datapipes/iter/util/distributed.py
@@ -118,6 +118,8 @@ class _PrefetchExecutor:
     def shutdown(self):
         self._paused = False
         self._is_shutdown = True
+        while self._futures:
+            self._futures.pop().cancel()
         self._executor.shutdown(wait=True)
 
     def pause(self):

--- a/torchdata/datapipes/iter/util/distributed.py
+++ b/torchdata/datapipes/iter/util/distributed.py
@@ -94,9 +94,9 @@ class _PrefetchExecutor:
         if f.exception():
             with self._lock:
                 self._end_flag = True
-        if self.callback_fn is not None and not self._is_shutdown:
-            # Doesn't invoke `callback_fn` if `shutdown` is caleld
-            self._executor.submit(self.callback_fn, Expected(index, f.exception()))
+        if self.callback_fn is not None:
+            # Invoke `callback_fn` in order to set `FullSyncDP._done_callback` to `True`
+            self.callback_fn(Expected(index, f.exception()))
 
     def return_next(self):
         if self._futures:

--- a/torchdata/datapipes/iter/util/distributed.py
+++ b/torchdata/datapipes/iter/util/distributed.py
@@ -119,7 +119,7 @@ class _PrefetchExecutor:
         self._paused = False
         self._is_shutdown = True
         while self._futures:
-            self._futures.pop().cancel()
+            self._futures.popleft().cancel()
         self._executor.shutdown(wait=True)
 
     def pause(self):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* __->__ #1171

Differential Revision: [D46157349](https://our.internmc.facebook.com/intern/diff/D46157349)