### PR TITLE
Bug Fix: Fixed FileExistsError

### DIFF
--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -257,8 +257,7 @@ class OnDiskCacheHolderIterDataPipe(IterDataPipe):
         if not cached_file_exists:
             promise_filepath = _promise_filename(filepath, cache_uuid)
             dirname = os.path.dirname(promise_filepath)
-            if not os.path.exists(dirname):
-                os.makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
 
             with portalocker.Lock(promise_filepath, "a+", flags=portalocker.LockFlags.EXCLUSIVE) as promise_fh:
                 promise_fh.seek(0)


### PR DESCRIPTION
Fixed bug where multiple workers try to write to the same folder that doesn't exist yet, it causes a FileExistsError because a different work already created the directory structure.

Fixes #{1186}

### Changes

- Removed if statement which checks if `dirname` exists and modified to use built-in `os.makedirs` feature for checking if `dirname` exists
