### PR TITLE
Simpler file chunking

### DIFF
--- a/test/_utils/_common_utils_for_test.py
+++ b/test/_utils/_common_utils_for_test.py
@@ -87,9 +87,7 @@ def check_hash_fn(filepath, expected_hash, hash_type="md5"):
         raise ValueError("Invalid hash_type requested, should be one of {}".format(["sha256", "md5"]))
 
     with open(filepath, "rb") as f:
-        chunk = f.read(1024 ** 2)
-        while chunk:
+        while chunk := f.read(1024 ** 2):
             hash_fn.update(chunk)
-            chunk = f.read(1024 ** 2)
 
     return hash_fn.hexdigest() == expected_hash

--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -150,10 +150,8 @@ def _hash_check(filepath, hash_dict, hash_type):
     # TODO(634): Line above will require all readers (Win) to obtain proper locks,
     # I'm putting it on hold as we need to modify PyTorch core codebase heavily.
     with open(filepath, "rb") as f:
-        chunk = f.read(1024 ** 2)
-        while chunk:
+        while chunk := f.read(1024 ** 2):
             hash_func.update(chunk)
-            chunk = f.read(1024 ** 2)
 
     return hash_func.hexdigest() == hash_dict[filepath]
 


### PR DESCRIPTION
Now that Python 3.8 is the minimum supported version, we can use the new [assignment expression](https://docs.python.org/3/whatsnew/3.8.html#assignment-expression) syntax to simplify how we read files chunk-by-chunk. 