### PR TITLE
correct SampleMultiplexer docstring example

### DIFF
--- a/torchdata/datapipes/iter/util/samplemultiplexer.py
+++ b/torchdata/datapipes/iter/util/samplemultiplexer.py
@@ -31,8 +31,8 @@ class SampleMultiplexerDataPipe(IterDataPipe[T_co]):
 
     Example:
         >>> from torchdata.datapipes.iter import IterableWrapper, SampleMultiplexer
-        >>> source_dp1 = IterableWrapper([0] * 10)
-        >>> source_dp2 = IterableWrapper([1] * 10)
+        >>> source_dp1 = IterableWrapper([0] * 5)
+        >>> source_dp2 = IterableWrapper([1] * 5)
         >>> d = {source_dp1: 99999999, source_dp2: 0.0000001}
         >>> sample_mul_dp = SampleMultiplexer(pipes_to_weights_dict=d, seed=0)
         >>> list(sample_mul_dp)


### PR DESCRIPTION
### Changes

- correct docstring of SampleMultiplexerDataPipe. The examples show a result of multiplexing 2 datapipes of length 5 but the two datapipes are initialized with 10 elements each