### PR TITLE
Add aarch64 to TorchData CICD

### DIFF
--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -1,4 +1,4 @@
-name: Build Linux Wheels
+name: Build AARCH64 Linux Wheels
 
 on:
   pull_request:

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -41,6 +41,7 @@ jobs:
       package-name: ${{ matrix.package-name }}
       env-var-script: packaging/env-var-script.txt
       architecture: aarch64
+      setup-miniconda: false
       # Using "development" as trigger event so these binaries are not uploaded to official channels yet
       trigger-event: development
     secrets:

--- a/.github/workflows/build_wheels_aarch64_linux.yml
+++ b/.github/workflows/build_wheels_aarch64_linux.yml
@@ -1,0 +1,48 @@
+name: Build Linux Wheels
+
+on:
+  pull_request:
+  push:
+    branches:
+      - nightly
+  workflow_dispatch:
+
+jobs:
+  generate-matrix:
+    uses: pytorch/test-infra/.github/workflows/generate_binary_build_matrix.yml@main
+    with:
+      package-type: wheel
+      os: linux-aarch64
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      with-cuda: disable
+  build:
+    needs: generate-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repository: pytorch/data
+            pre-script: packaging/pre_build_script_linux.sh
+            post-script: packaging/post_build_script_linux.sh
+            smoke-test-script: test/smoke_test/smoke_test.py
+            package-name: torchdata
+    name: ${{ matrix.repository }}
+    uses: pytorch/test-infra/.github/workflows/build_wheels_linux.yml@main
+    with:
+      repository: ${{ matrix.repository }}
+      ref: ""
+      test-infra-repository: pytorch/test-infra
+      test-infra-ref: main
+      build-matrix: ${{ needs.generate-matrix.outputs.matrix }}
+      pre-script: ${{ matrix.pre-script }}
+      post-script: ${{ matrix.post-script }}
+      smoke-test-script: ${{ matrix.smoke-test-script }}
+      package-name: ${{ matrix.package-name }}
+      env-var-script: packaging/env-var-script.txt
+      architecture: aarch64
+      # Using "development" as trigger event so these binaries are not uploaded to official channels yet
+      trigger-event: development
+    secrets:
+      AWS_PYTORCH_UPLOADER_ACCESS_KEY_ID: ${{ secrets.PYTORCH_BINARY_AWS_ACCESS_KEY_ID }}
+      AWS_PYTORCH_UPLOADER_SECRET_ACCESS_KEY: ${{ secrets.PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/domain_ci.yml
+++ b/.github/workflows/domain_ci.yml
@@ -10,55 +10,6 @@ on:
       - gh/*/*/base
 
 jobs:
-  torchvision:
-    if: ${{ github.repository_owner == 'pytorch' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        python-version:
-          - 3.8
-          - 3.9
-    steps:
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install torch and torchvision from nightlies
-        run: |
-          pip install numpy networkx
-          pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cpu
-
-      - name: Check out torchdata repository
-        uses: actions/checkout@v3
-
-      - name: Install torchdata
-        run: |
-          pip install -r requirements.txt
-          pip install .
-
-      - name: Install test requirements
-        run: pip install pytest pytest-mock scipy iopath pycocotools h5py
-
-      - name: Extract torchvision ref
-        id: torchvision
-        run: echo "ref=$(python -c 'import torchvision; print(torchvision.version.git_version)')" >> $GITHUB_OUTPUT
-
-      - name: Check out torchvision repository
-        uses: actions/checkout@v3
-        with:
-          repository: pytorch/vision
-          ref: ${{ steps.torchvision.outputs.ref }}
-          path: vision
-
-      - name: Run torchvision builtin datasets tests
-        run: pytest --no-header -v vision/test/test_prototype_datasets_builtin.py
-
   torchtext:
     if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [**What are DataPipes?**](#what-are-datapipes) | [**Beta Usage and Feedback**](#beta-usage-and-feedback) |
 [**Contributing**](#contributing) | [**Future Plans**](#future-plans)
 
-**:warning: As of July 2023, we have paused active development on TorchData and have paused new releases. We have learnt a lot from building it and hearing from users, but also believe we need to re-evaluate the technical design and approach given how much the industry has changed since we began the project. During the rest of 2023 we will be re-evaluating our plans in this space. Please reach out if you suggestions or comments (please use [#1196](https://github.com/pytorch/data/issues/1196) for feedback).**
+**:warning: As of July 2023, we have paused active development on TorchData and have paused new releases. We have learnt
+a lot from building it and hearing from users, but also believe we need to re-evaluate the technical design and approach
+given how much the industry has changed since we began the project. During the rest of 2023 we will be re-evaluating our
+plans in this space. Please reach out if you suggestions or comments (please use
+[#1196](https://github.com/pytorch/data/issues/1196) for feedback).**
 
 `torchdata` is a library of common modular data loading primitives for easily constructing flexible and performant data
 pipelines.

--- a/packaging/post_build_script_linux.sh
+++ b/packaging/post_build_script_linux.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 set -ex
 
+cpu_arch=`uname -m`
+
 pip3 install auditwheel pkginfo
 
 for pkg in dist/torchdata*.whl; do
     echo "PkgInfo of $pkg:"
     pkginfo $pkg
 
-    auditwheel repair $pkg --plat manylinux2014_x86_64 -w wheelhouse
+    auditwheel repair $pkg --plat manylinux2014_${cpu_arch} -w wheelhouse
 
-    pkg_name=`basename ${pkg%-linux_x86_64.whl}`
-    auditwheel show wheelhouse/${pkg_name}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+    pkg_name=`basename ${pkg%-linux_${cpu_arch}.whl}`
+    auditwheel show wheelhouse/${pkg_name}-manylinux_2_17_${cpu_arch}.manylinux2014_${cpu_arch}.whl
 done


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #{issue number}

### Changes
* Adding aarch64 workflow to CICD.
* Setting setup-miniconda to `false` as conda is installed from "Set linux aarch64 CI"
* Updated `post_build_script_linux.sh` to support different CPU arch types by finding the arch from there the script is executed.
* Remove torchvision from domain_ci testing as the newer versions of torchvision do not use torchdata.

