### PR TITLE
Move build_test_upload workflow to environment pytorchbot-env

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -245,6 +245,7 @@ jobs:
     if: always() && inputs.branch != '' && inputs.do-upload == true
     needs: [get_release_type, wheel_build_test]
     runs-on: ubuntu-latest
+    environment: pytorchbot-env
     outputs:
       upload: ${{ steps.trigger_upload.outputs.value }}
     steps:
@@ -397,6 +398,7 @@ jobs:
     needs: [get_release_type, conda_build_test]
     runs-on: ubuntu-latest
     container: continuumio/miniconda3
+    environment: pytorchbot-env
     outputs:
       upload: ${{ steps.trigger_upload.outputs.value }}
     steps:


### PR DESCRIPTION
I wonder if we can delete these secrets entirely if this is no longer being actively developed