### PR TITLE
build: Just set torch>=2.0

### DIFF
--- a/.github/workflows/build_conda_linux.yml
+++ b/.github/workflows/build_conda_linux.yml
@@ -16,6 +16,7 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       with-cuda: disable
+      with-rocm: disable
   build:
     needs: generate-matrix
     strategy:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -16,6 +16,7 @@ jobs:
       test-infra-repository: pytorch/test-infra
       test-infra-ref: main
       with-cuda: disable
+      with-rocm: disable
   build:
     needs: generate-matrix
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -110,11 +110,7 @@ def _get_requirements():
 
 
 # Use new version of torch on main branch
-pytorch_package_dep = "torch>2.0"
-if os.getenv("PYTORCH_VERSION"):
-    pytorch_package_dep = pytorch_package_dep.split(">")[0]
-    pytorch_package_dep += "==" + os.getenv("PYTORCH_VERSION")
-
+pytorch_package_dep = "torch>=2"
 
 requirements = _get_requirements()
 requirements.append(pytorch_package_dep)


### PR DESCRIPTION
This project is in maintenance mode so set it free from having a hard dependency on a single version of PyTorch
