### PR TITLE
Relax torchdata torch conda requirement to >= 2.0

### DIFF
--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -19,12 +19,12 @@ requirements:
     - curl # [not win]
     - openssl # [unix]
     - zlib # [unix]
-    - torch>=2.0
+    - pytorch>=2.0
   run:
     - python
     - urllib3>=1.25
     - requests
-    - torch>=2.0
+    - pytorch>=2.0
 
 build:
   string: py{{py}}

--- a/packaging/torchdata/meta.yaml
+++ b/packaging/torchdata/meta.yaml
@@ -19,12 +19,12 @@ requirements:
     - curl # [not win]
     - openssl # [unix]
     - zlib # [unix]
-    {{ environ.get('CONDA_PYTORCH_BUILD_CONSTRAINT') }}
+    - torch>=2.0
   run:
     - python
     - urllib3>=1.25
     - requests
-    {{ environ.get('CONDA_PYTORCH_CONSTRAINT') }}
+    - torch>=2.0
 
 build:
   string: py{{py}}


### PR DESCRIPTION
This is similar to https://github.com/pytorch/data/pull/1210, but relax the requirement for conda build instead of wheel.  For example, `linux-64/torchdata-0.7.0-py39.tar.bz2` conda packages on https://anaconda.org/pytorch-test/torchdata/files currently has the following deps `openssl >=3.0.11,<4.0a0, python >=3.9,<3.10.0a0, pytorch 2.1.0, requests, urllib3 >=1.25, zlib >=1.2.13,<1.3.0a0` where [pytorch](https://anaconda.org/pytorch-test/pytorch) is fixed at `2.1.0`
