### PR TITLE
fix 'DILL_AVAILABLE' import error

### DIFF
--- a/torchdata/datapipes/iter/util/cacheholder.py
+++ b/torchdata/datapipes/iter/util/cacheholder.py
@@ -21,13 +21,13 @@ try:
 except ImportError:
     portalocker = None
 
-from torch.utils.data.datapipes.utils.common import _check_unpickable_fn, DILL_AVAILABLE
+from torch.utils.data.datapipes.utils.common import _check_unpickable_fn, dill_available
 
 from torch.utils.data.graph import traverse_dps
 from torchdata.datapipes import functional_datapipe
 from torchdata.datapipes.iter import IterableWrapper, IterDataPipe
 
-if DILL_AVAILABLE:
+if dill_available:
     import dill
 
     dill.extend(use_dill=False)


### PR DESCRIPTION
'DILL_AVAILABLE' caused import error, using dill_available instead.
from torchdata.datapipes.iter import FileOpener, IterableWrapper
   File "/opt/conda/lib/python3.8/site-packages/torchdata/__init__.py", line 9, in <module>
     from . import datapipes
   File "/opt/conda/lib/python3.8/site-packages/torchdata/datapipes/__init__.py", line 9, in <module>
     from . import iter, map, utils
   File "/opt/conda/lib/python3.8/site-packages/torchdata/datapipes/iter/__init__.py", line 79, in <module>
     from torchdata.datapipes.iter.util.cacheholder import (
   File "/opt/conda/lib/python3.8/site-packages/torchdata/datapipes/iter/util/cacheholder.py", line 24, in <module>
     from torch.utils.data.datapipes.utils.common import _check_unpickable_fn, DILL_AVAILABLE
 ImportError: cannot import name 'DILL_AVAILABLE' from 'torch.utils.data.datapipes.utils.common' (/workspace/pytorch/torch/utils/data/datapipes/utils/common.py)

refer to https://github.com/pytorch/pytorch/pull/116214
