### PR TITLE
Migrate the macOS runners label from macos-m1-12 to macos-m1-stable

### DIFF
--- a/.github/workflows/build-conda-m1.yml
+++ b/.github/workflows/build-conda-m1.yml
@@ -37,7 +37,7 @@ jobs:
       package-name: torchdata
       env-var-script: packaging/env-var-script.txt
       smoke-test-script: test/smoke_test/smoke_test.py
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       trigger-event: ${{ github.event_name }}
     secrets:
       CONDA_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/build-wheels-m1.yml
+++ b/.github/workflows/build-wheels-m1.yml
@@ -39,6 +39,6 @@ jobs:
       post-script: ""
       package-name: torchdata
       env-var-script: packaging/env-var-script.txt
-      runner-type: macos-m1-12
+      runner-type: macos-m1-stable
       smoke-test-script: test/smoke_test/smoke_test.py
       trigger-event: ${{ github.event_name }}


### PR DESCRIPTION
There is a new label for our macOS runners: "macos-m1-stable". All runners labeled "macos-m1-12" should be switched to "macos-m1-stable". [Here](https://fb.workplace.com/groups/pytorch.dev.perf.infra.teams/permalink/7546708885348237/) you can find more detailed info.