### PR TITLE
Data loader directly use loaded state dict when save right after load

### DIFF
--- a/test/dataloader2/test_dataloader2.py
+++ b/test/dataloader2/test_dataloader2.py
@@ -136,6 +136,8 @@ class DataLoader2Test(TestCase):
 
         restored_data_loader: DataLoader2 = DataLoader2(datapipe=None, reading_service=reading_service)
         restored_data_loader.load_state_dict(state)
+        new_state = restored_data_loader.state_dict()
+        self.assertDictEqual(state, new_state)
 
         restored_data_loader_datapipe = restored_data_loader.datapipe
         deserialized_datapipe = pickle.loads(state[SERIALIZED_DATAPIPE_KEY_NAME])


### PR DESCRIPTION
Summary: If no iterator is created in the middle of load_state_dict and state_dict calls, we should be able to directly return the original state dict without triggering reading service because the states are unchanged

Reviewed By: xunnanxu

Differential Revision: D54102267


