### PR TITLE
Set mypy version to match pytorch core

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip3 install -r requirements.txt
-          pip3 install mypy==0.960 numpy types-requests
+          pip3 install mypy==1.8.0 numpy types-requests
       - name: Build TorchData
         run: |
           pip3 install .


### PR DESCRIPTION
Here is the link to mypy version on pytorch core - https://github.com/pytorch/pytorch/blob/198927170d34efaeb77e1a772d96ad3615a21cba/.ci/docker/requirements-ci.txt#L88

There are mypy failures on the main branch. Trying to update the mypy version before attempting to fix them.

### Changes

- Update the mypy version
