### PR TITLE
removesuffix is not available 3.8, thus reverting the changes to rstrip

### DIFF
--- a/torchdata/datapipes/iter/util/bz2fileloader.py
+++ b/torchdata/datapipes/iter/util/bz2fileloader.py
@@ -53,7 +53,7 @@ class Bz2FileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             pathname, data_stream = data
             try:
                 extracted_fobj = bz2.open(data_stream, mode="rb")  # type: ignore[call-overload]
-                new_pathname = pathname.removesuffix(".bz2")
+                new_pathname = pathname.rstrip(".bz2")
                 yield new_pathname, StreamWrapper(extracted_fobj, data_stream, name=new_pathname)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted bzip2 stream {pathname} due to: {e}, abort!")

--- a/torchdata/datapipes/iter/util/bz2fileloader.py
+++ b/torchdata/datapipes/iter/util/bz2fileloader.py
@@ -53,7 +53,7 @@ class Bz2FileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             pathname, data_stream = data
             try:
                 extracted_fobj = bz2.open(data_stream, mode="rb")  # type: ignore[call-overload]
-                new_pathname = pathname.rstrip(".bz2")
+                new_pathname = pathname.rstrip(".bz2")  # https://github.com/pytorch/data/issues/1240
                 yield new_pathname, StreamWrapper(extracted_fobj, data_stream, name=new_pathname)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted bzip2 stream {pathname} due to: {e}, abort!")

--- a/torchdata/datapipes/iter/util/xzfileloader.py
+++ b/torchdata/datapipes/iter/util/xzfileloader.py
@@ -53,7 +53,7 @@ class XzFileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             pathname, data_stream = data
             try:
                 extracted_fobj = lzma.open(data_stream, mode="rb")  # type: ignore[call-overload]
-                new_pathname = pathname.rstrip(".xz")
+                new_pathname = pathname.rstrip(".xz")  # https://github.com/pytorch/data/issues/1240
                 yield new_pathname, StreamWrapper(extracted_fobj, data_stream, name=pathname)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted xz/lzma stream {pathname} due to: {e}, abort!")

--- a/torchdata/datapipes/iter/util/xzfileloader.py
+++ b/torchdata/datapipes/iter/util/xzfileloader.py
@@ -53,7 +53,7 @@ class XzFileLoaderIterDataPipe(IterDataPipe[Tuple[str, BufferedIOBase]]):
             pathname, data_stream = data
             try:
                 extracted_fobj = lzma.open(data_stream, mode="rb")  # type: ignore[call-overload]
-                new_pathname = pathname.removesuffix(".xz")
+                new_pathname = pathname.rstrip(".xz")
                 yield new_pathname, StreamWrapper(extracted_fobj, data_stream, name=pathname)  # type: ignore[misc]
             except Exception as e:
                 warnings.warn(f"Unable to extract files from corrupted xz/lzma stream {pathname} due to: {e}, abort!")


### PR DESCRIPTION
Without these changes, it will result in CI failing. When 3.8 support is dropped, this change can be landed.

Fixes #{issue number}

### Changes
- change removesuffix back to rstrip
