### PR TITLE
Stateful dataloader

### DIFF
--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -1,4 +1,4 @@
-name: Run DataPipes Tests
+name: Run StatefulDataLoader Tests
 on:
   push:
     branches:
@@ -83,11 +83,6 @@ jobs:
           pip3 install -r requirements.txt
           make doctest
           cd ..
-      - name: Run DataPipes tests with pytest
+      - name: Run StatefulDataLoader tests with pytest
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run:
-          pytest --no-header -v test --ignore=test/test_period.py --ignore=test/test_text_examples.py
-          --ignore=test/test_audio_examples.py --ignore=test/test_aistore.py
-          --ignore=test/dataloader2/test_dataloader2.py --ignore=test/dataloader2/test_mprs.py
-          --ignore=test/test_distributed.py --ignore=test/stateful_dataloader/test_dataloader.py
-          --ignore=test/stateful_dataloader/test_state_dict.py
+        run: pytest --no-header -v test/stateful_dataloader

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -15,3 +15,4 @@ datasets
 graphviz
 adlfs
 awscli>=1.27.66
+psutil

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import ctypes
 import errno
 import faulthandler

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -2390,6 +2390,7 @@ class IntegrationTestDataLoaderDataPipe(TestCase):
     Verify the behavior of a certain ``DataPipes`` with ``DataLoader``
     """
 
+    @unittest.skip
     def test_shuffler_iterdatapipe(self):
         r"""
         Verify ``IterDataPipe.shuffle`` is controlled by ``DataLoader``

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -2438,7 +2438,8 @@ class IntegrationTestDataLoaderDataPipe(TestCase):
                 self.assertEqual(sorted(dl_res[0]), sorted(dl_res[2]))
 
                 if dl._iterator is not None:
-                    dl._iterator._shutdown_workers()
+                    if num_workers > 0:
+                        dl._iterator._shutdown_workers()
                     dl._iterator = None
                 del dl
 

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -1,0 +1,2901 @@
+import math
+import sys
+import errno
+import os
+import ctypes
+import faulthandler
+import torch
+import gc
+import time
+import signal
+import unittest
+import itertools
+import warnings
+import tempfile
+import torch.utils.data.datapipes as dp
+from torch import multiprocessing as mp
+from torch.utils.data import (
+    ChainDataset,
+    ConcatDataset,
+    Dataset,
+    IterableDataset,
+    IterDataPipe,
+    Subset,
+    TensorDataset,
+    StackDataset,
+    _utils,
+    # DataLoader,
+)
+from torchdata.stateful_dataloader import StatefulDataLoader as DataLoader
+from torch.utils.data._utils import MP_STATUS_CHECK_INTERVAL
+from torch.utils.data.dataset import random_split
+from torch.utils.data.datapipes.iter import IterableWrapper
+from torch._utils import ExceptionWrapper
+from torch.testing._internal.common_utils import (TestCase, run_tests, TEST_NUMPY, IS_WINDOWS, IS_JETSON,
+                                                  IS_CI, NO_MULTIPROCESSING_SPAWN, skipIfRocm, slowTest,
+                                                  load_tests, TEST_WITH_ASAN, TEST_WITH_TSAN, IS_SANDCASTLE,
+                                                  IS_MACOS, TEST_CUDA, parametrize, skipIfNoDill)
+from torch.testing._internal.common_device_type import instantiate_device_type_tests
+import functools
+import operator
+
+
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    HAS_PSUTIL = False
+    err_msg = ("psutil not found. Some critical data loader tests relying on it "
+               "(e.g., TestDataLoader.test_proper_exit) will not run.")
+    if IS_CI:
+        raise ImportError(err_msg) from None
+    else:
+        warnings.warn(err_msg)
+
+
+try:
+    import numpy as np
+    HAS_NUMPY = True
+except ImportError:
+    HAS_NUMPY = False
+skipIfNoNumpy = unittest.skipIf(not HAS_NUMPY, "no NumPy")
+
+# load_tests from torch.testing._internal.common_utils is used to automatically filter tests for
+# sharding on sandcastle. This line silences flake warnings
+load_tests = load_tests
+
+if TEST_CUDA:
+    torch.cuda.memory._set_allocator_settings('expandable_segments:False')
+
+if not NO_MULTIPROCESSING_SPAWN:
+    # We want to use `spawn` if able because some of our tests check that the
+    # data loader terminiates gracefully. To prevent hanging in the testing
+    # process, such data loaders are run in a separate subprocess.
+    #
+    # We also want to test the `pin_memory=True` configuration, thus `spawn` is
+    # required to launch such processes and they initialize the CUDA context.
+    #
+    # Mixing different start method is a recipe for disaster (e.g., using a fork
+    # `mp.Event` with a spawn `mp.Process` segfaults). So we set this globally
+    # to avoid bugs.
+    #
+    # Get a multiprocessing context because some test / third party library will
+    # set start_method when imported, and setting again triggers `RuntimeError`.
+    mp = mp.get_context(method='spawn')
+
+
+# 60s of timeout?
+# Yes, in environments where physical CPU resources are shared, e.g., CI, the
+# time for a inter-process communication can be highly varying.  With 15~17s of
+# timeout, we have observed flakiness in some CI builds (see
+# pytorch/pytorch#14501, pytorch/pytorch#16608).  We follow the CPython
+# multiprocessing setup and set the timeout to 60s here:
+#
+# https://github.com/python/cpython/blob/e8113f51a8bdf33188ee30a1c038a298329e7bfa/Lib/test/_test_multiprocessing.py#L73
+JOIN_TIMEOUT = 60.0  # seconds
+
+
+supported_multiprocessing_contexts = [None] + list(torch.multiprocessing.get_all_start_methods())
+
+
+# collate_fn that returns the batch cloned; defined globally here for pickle purposes.
+def _clone_collate(b):
+    return [x.clone() for x in b]
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestDatasetRandomSplit(TestCase):
+    def test_lengths_must_equal_dataset_size(self):
+        with self.assertRaises(ValueError):
+            random_split([1, 2, 3, 4], [1, 2])
+
+    def test_splits_have_correct_size(self):
+        splits = random_split([1, 2, 3, 4, 5, 6], [2, 4])
+        self.assertEqual(len(splits), 2)
+        self.assertEqual(len(splits[0]), 2)
+        self.assertEqual(len(splits[1]), 4)
+
+        splits = random_split([1, 2, 3, 4, 5, 6], [0.5, 0.5])
+        self.assertEqual(len(splits), 2)
+        self.assertEqual(len(splits[0]), 3)
+        self.assertEqual(len(splits[1]), 3)
+
+        # Odd size splits
+        self.assertEqual(
+            len(random_split(range(3), [0.5, 0.5], generator=torch.Generator().manual_seed(1))),
+            2
+        )
+
+        # Odd sized round-robin splits
+        splits = random_split(range(106), [0.1, 0.2, 0.3, 0.4],
+                              generator=torch.Generator().manual_seed(1))
+        self.assertEqual(len(splits[0]), 11)
+        self.assertEqual(len(splits[1]), 22)
+        self.assertEqual(len(splits[2]), 31)
+        self.assertEqual(len(splits[3]), 42)
+
+
+    def test_splits_are_mutually_exclusive(self):
+        data = [5, 2, 3, 4, 1, 6]
+        splits = random_split(data, [2, 4])
+        all_values = []
+        all_values.extend(list(splits[0]))
+        all_values.extend(list(splits[1]))
+        data.sort()
+        all_values.sort()
+        self.assertListEqual(data, all_values)
+
+        splits = random_split(data, [0.33, 0.67])
+        all_values = []
+        all_values.extend(list(splits[0]))
+        all_values.extend(list(splits[1]))
+        data.sort()
+        all_values.sort()
+        self.assertListEqual(data, all_values)
+
+        data = [1, 2, 3, 4]
+        splits = random_split(data, [0.25, 0.75])
+        all_values = []
+        all_values.extend(list(splits[0]))
+        all_values.extend(list(splits[1]))
+        data.sort()
+        all_values.sort()
+        self.assertListEqual(data, all_values)
+
+    def test_splits_indexing_type(self):
+        r"""Indices generated by random_split
+          should be of integer type
+        """
+        class CustomDataset:
+            def __init__(self, test_object, custom_list):
+                self.data = custom_list
+                self.test_object = test_object
+
+            def __getitem__(self, key):
+                self.test_object.assertEqual(type(key), int)
+                return self.data[key]
+
+            def __len__(self):
+                return len(self.data)
+
+        x = [1, 2, 3, 4, 5]
+        dataset = CustomDataset(self, x)
+        dataset = random_split(dataset, [5])[0]
+        data_loader = DataLoader(dataset)
+        for batch in data_loader:
+            pass
+
+        # fractional splitting
+        dataset = CustomDataset(self, x)
+        dataset = random_split(dataset, [1.0])[0]
+        data_loader = DataLoader(dataset)
+        for batch in data_loader:
+            pass
+
+    def test_splits_reproducibility(self):
+        self.assertEqual(
+            [list(x) for x in random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(1))],
+            [[5, 6, 1], [2, 0, 8, 9, 3, 7, 4]],
+        )
+        self.assertEqual(
+            random_split(range(100), [60, 40], generator=torch.Generator().manual_seed(42)),
+            random_split(range(100), [60, 40], generator=torch.Generator().manual_seed(42)),
+        )
+        self.assertEqual(
+            random_split(range(100), [0.5, 0.5], generator=torch.Generator().manual_seed(42)),
+            random_split(range(100), [0.5, 0.5], generator=torch.Generator().manual_seed(42)),
+        )
+        self.assertEqual(
+            random_split(range(100), [0.33, 0.33, 0.34], generator=torch.Generator().manual_seed(42)),
+            random_split(range(100), [0.33, 0.33, 0.34], generator=torch.Generator().manual_seed(42)),
+        )
+
+    def test_incomplete_fractional_splits(self):
+        with self.assertRaises(ValueError):
+            # should raise since the sum of fractions is not 1
+            random_split([1, 2, 3, 4], [0.1])
+
+        with self.assertRaises(ValueError):
+            # should raise since fraction > 1
+            random_split([1, 2, 3, 4], [1.1])
+
+    def test_splits_generator(self):
+        # A random_split without a specific generator should affect the default one
+        state = torch.get_rng_state()
+        a = torch.rand(10)
+        torch.set_rng_state(state)
+        random_split(range(10), [5, 5])
+        b = torch.rand(10)
+        self.assertNotEqual(a, b)
+
+        # A random_split with a specific generator should not affect the default one
+        state = torch.get_rng_state()
+        a = torch.rand(10)
+        torch.set_rng_state(state)
+        random_split(range(10), [5, 5], generator=torch.Generator().manual_seed(42))
+        b = torch.rand(10)
+        self.assertEqual(a, b)
+
+    def test_slicing_of_subset_of_dataset(self):
+        # Testing slicing a subset initialized with a dataset
+        dataset = TensorDataset(torch.tensor([1, 2, 3, 4, 5]))
+        subset_of_dataset = Subset(dataset, [0, 1, 2, 3, 4])
+        self.assertEqual(subset_of_dataset[:], dataset[:])
+        self.assertEqual(subset_of_dataset[1:2], dataset[1:2])
+        self.assertEqual(subset_of_dataset[0:-1:2], dataset[0:-1:2])
+        # Testing slicing of subset from random split
+        subset1, subset2 = random_split(dataset, [3, 2])
+        self.assertEqual(subset1[:], dataset[subset1.indices[:]])
+        self.assertEqual(subset1[0:2], dataset[subset1.indices[0:2]])
+        self.assertEqual(subset1[0:-1:2], dataset[subset1.indices[0:-1:2]])
+
+    def test_slicing_of_subset_of_subset(self):
+        # Testing slicing a subset initialized with a subset
+        dataset = TensorDataset(torch.tensor([1, 2, 3, 4, 5]))
+        subset_of_dataset = Subset(dataset, [0, 1, 2, 3, 4])
+        subset_of_subset = Subset(subset_of_dataset, [0, 1, 2, 3, 4])
+        self.assertEqual(subset_of_subset[:], dataset[:])
+        self.assertEqual(subset_of_subset[0:2], dataset[0:2])
+        self.assertEqual(subset_of_subset[0:-1:2], dataset[0:-1:2])
+        # Testing slicing of subset of subset from random split
+        subset1, subset2 = random_split(dataset, [4, 1])
+        subset_of_subset1, subset_of_subset2 = random_split(subset1, [3, 1])
+        idx = [subset1.indices[i] for i in subset_of_subset1.indices]
+        self.assertEqual(subset_of_subset1[:], dataset[idx.copy()])
+        self.assertEqual(subset_of_subset1[0:2], dataset[idx[0:2]])
+        self.assertEqual(subset_of_subset1[0:-1:2], dataset[idx[0:-1:2]])
+
+
+class CUDACountingDataset(Dataset):
+    def __init__(self, n):
+        super().__init__()
+        self.n = n
+
+    def __getitem__(self, i):
+        return torch.as_tensor(i, device='cuda')
+
+    def __len__(self):
+        return self.n
+
+
+class CountingDataset(Dataset):
+    def __init__(self, n):
+        super().__init__()
+        self.n = n
+
+    def __getitem__(self, i):
+        return i
+
+    def __len__(self):
+        return self.n
+
+
+class CountingIterableDataset(IterableDataset):
+    def __init__(self, n):
+        super().__init__()
+        self.n = n
+
+    def __iter__(self):
+        return iter(range(self.n))
+
+    def __len__(self):
+        return self.n
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestTensorDataset(TestCase):
+
+    def test_len(self):
+        source = TensorDataset(torch.randn(15, 10, 2, 3, 4, 5), torch.randperm(15))
+        self.assertEqual(len(source), 15)
+
+    def test_getitem(self):
+        t = torch.randn(15, 10, 2, 3, 4, 5)
+        l = torch.randn(15, 10)
+        source = TensorDataset(t, l)
+        for i in range(15):
+            self.assertEqual(t[i], source[i][0])
+            self.assertEqual(l[i], source[i][1])
+
+    def test_getitem_1d(self):
+        t = torch.randn(15)
+        l = torch.randn(15)
+        source = TensorDataset(t, l)
+        for i in range(15):
+            self.assertEqual(t[i], source[i][0])
+            self.assertEqual(l[i], source[i][1])
+
+    def test_single_tensor(self):
+        t = torch.randn(5, 10)
+        source = TensorDataset(t)
+        self.assertEqual(len(source), 5)
+        for i in range(5):
+            self.assertEqual(t[i], source[i][0])
+
+    def test_many_tensors(self):
+        t0 = torch.randn(5, 10, 2, 3, 4, 5)
+        t1 = torch.randn(5, 10)
+        t2 = torch.randn(5, 10, 2, 5)
+        t3 = torch.randn(5, 10, 3, 7)
+        source = TensorDataset(t0, t1, t2, t3)
+        self.assertEqual(len(source), 5)
+        for i in range(5):
+            self.assertEqual(t0[i], source[i][0])
+            self.assertEqual(t1[i], source[i][1])
+            self.assertEqual(t2[i], source[i][2])
+            self.assertEqual(t3[i], source[i][3])
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestStackDataset(TestCase):
+
+    def test_empty(self):
+        with self.assertRaisesRegex(ValueError, "At least one dataset should be passed"):
+            StackDataset()
+
+    def test_mixed(self):
+        with self.assertRaisesRegex(ValueError, "Supported either"):
+            StackDataset(TensorDataset(torch.randn(15, 10)), a=TensorDataset(torch.randn(10, 15)))
+
+    def test_size_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "Size mismatch between datasets"):
+            StackDataset(TensorDataset(torch.randn(15, 10)), TensorDataset(torch.randn(10, 15)))
+        with self.assertRaisesRegex(ValueError, "Size mismatch between datasets"):
+            StackDataset(a=TensorDataset(torch.randn(15, 10)), b=TensorDataset(torch.randn(10, 15)))
+
+    def test_len(self):
+        source = StackDataset(TensorDataset(torch.randn(15, 10)), TensorDataset(torch.randn(15)))
+        self.assertEqual(len(source), 15)
+        source = StackDataset(TensorDataset(torch.randn(15, 10)))
+        self.assertEqual(len(source), 15)
+        source = StackDataset(a=TensorDataset(torch.randn(15, 10)), b=TensorDataset(torch.randn(15)))
+        self.assertEqual(len(source), 15)
+        source = StackDataset(a=TensorDataset(torch.randn(15, 10)))
+        self.assertEqual(len(source), 15)
+
+    def test_single(self):
+        t = TensorDataset(torch.randn(15, 10))
+        source = StackDataset(t)
+        for i in range(15):
+            self.assertEqual(t[i], source[i][0])
+        source = StackDataset(a=t)
+        for i in range(15):
+            self.assertEqual(t[i], source[i]['a'])
+
+    def test_getitem(self):
+        t = TensorDataset(torch.randn(15, 10))
+        l = TensorDataset(torch.randn(15, 5, 4))
+        source = StackDataset(t, l)
+        for i in range(15):
+            self.assertEqual(t[i], source[i][0])
+            self.assertEqual(l[i], source[i][1])
+        source = StackDataset(a=t, b=l)
+        for i in range(15):
+            self.assertEqual(t[i], source[i]['a'])
+            self.assertEqual(l[i], source[i]['b'])
+
+    def test_getitems(self):
+        class GetItemsDataset(Dataset):
+            def __init__(self):
+                self.data = torch.randn(4)
+
+            def __getitem__(self, item):
+                return self.data[item]
+
+            def __getitems__(self, items):
+                return self.data[items]
+
+            def __len__(self):
+                return 4
+
+        t = GetItemsDataset()
+        l = [1, 2, 3, 4]
+
+        source = StackDataset(t, l)
+        batch = source.__getitems__([0, 1, 2, 3])
+        for i in range(4):
+            self.assertEqual(t[i], batch[i][0])
+            self.assertEqual(l[i], batch[i][1])
+
+        source = StackDataset(t=t, l=l)
+        batch = source.__getitems__([0, 1, 2, 3])
+        for i in range(4):
+            self.assertEqual(t[i], batch[i]['t'])
+            self.assertEqual(l[i], batch[i]['l'])
+
+    def test_getitems_raises_index_error(self):
+        class GetItemsDataset(Dataset):
+            def __init__(self):
+                self.data = torch.randn(4)
+
+            def __getitem__(self, item):
+                return self.data[item]
+
+            def __getitems__(self, items):
+                return self.data[items]
+
+            def __len__(self):
+                return 4
+
+        t = GetItemsDataset()
+        l = [1, 2, 3, 4]
+
+        source = StackDataset(t, l)
+
+        with self.assertRaises(IndexError):
+            source.__getitems__([0, 4])
+
+    def test_getitems_value_error(self):
+        class GetItemsDataset(Dataset):
+            def __init__(self):
+                self.data = torch.randn(4)
+
+            def __getitem__(self, item):
+                return self.data[item]
+
+            def __getitems__(self, items):
+                return self.data[items][:-1]  # return less
+
+            def __len__(self):
+                return 4
+
+        t = GetItemsDataset()
+        l = [1, 2, 3, 4]
+
+        source = StackDataset(t, l)
+
+        with self.assertRaisesRegex(ValueError,
+                                    "Nested dataset's output size mismatch. Expected 4, got 3"):
+            source.__getitems__([0, 1, 2, 3])
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestConcatDataset(TestCase):
+
+    def test_concat_two_singletons(self):
+        result = ConcatDataset([[0], [1]])
+        self.assertEqual(2, len(result))
+        self.assertEqual(0, result[0])
+        self.assertEqual(1, result[1])
+
+    def test_concat_two_non_singletons(self):
+        result = ConcatDataset([[0, 1, 2, 3, 4],
+                                [5, 6, 7, 8, 9]])
+        self.assertEqual(10, len(result))
+        self.assertEqual(0, result[0])
+        self.assertEqual(5, result[5])
+
+    def test_concat_two_non_singletons_with_empty(self):
+        # Adding an empty dataset somewhere is correctly handled
+        result = ConcatDataset([[0, 1, 2, 3, 4],
+                                [],
+                                [5, 6, 7, 8, 9]])
+        self.assertEqual(10, len(result))
+        self.assertEqual(0, result[0])
+        self.assertEqual(5, result[5])
+
+    def test_concat_raises_index_error(self):
+        result = ConcatDataset([[0, 1, 2, 3, 4],
+                                [5, 6, 7, 8, 9]])
+        with self.assertRaises(IndexError):
+            # this one goes to 11
+            result[11]
+
+    def test_add_dataset(self):
+        d1 = TensorDataset(torch.rand(7, 3, 28, 28), torch.rand(7))
+        d2 = TensorDataset(torch.rand(7, 3, 28, 28), torch.rand(7))
+        d3 = TensorDataset(torch.rand(7, 3, 28, 28), torch.rand(7))
+        result = d1 + d2 + d3
+        self.assertEqual(21, len(result))
+        self.assertEqual(0, (d1[0][0] - result[0][0]).abs().sum())
+        self.assertEqual(0, (d2[0][0] - result[7][0]).abs().sum())
+        self.assertEqual(0, (d3[0][0] - result[14][0]).abs().sum())
+
+    def test_iterable_dataset_err(self):
+        d1 = TensorDataset(torch.rand(7, 3, 28, 28), torch.rand(7))
+        it1 = CountingIterableDataset(5)
+        it2 = CountingIterableDataset(10)
+
+        with self.assertRaisesRegex(AssertionError, "does not support IterableDataset"):
+            ConcatDataset([d1, it2, it1])
+
+        with self.assertRaisesRegex(AssertionError, "does not support IterableDataset"):
+            ConcatDataset([it2])
+
+        with self.assertRaisesRegex(AssertionError, "does not support IterableDataset"):
+            ConcatDataset([it1, d1])
+
+
+# takes in dummy var so this can also be used as a `worker_init_fn`
+def set_faulthander_if_available(_=None):
+    faulthandler.enable(sys.__stderr__)
+    if not IS_WINDOWS:
+        # windows does not have faulthandler.register
+        # chain=False prevents the default behavior of killing the process
+        faulthandler.register(signal.SIGUSR1, file=sys.__stderr__, chain=False)
+
+
+set_faulthander_if_available()
+
+# Process `pid` must have called `set_faulthander_if_available`
+def print_traces_of_all_threads(pid):
+    if not IS_WINDOWS:
+        # use the custom signal if available
+        os.kill(pid, signal.SIGUSR1)
+    else:
+        # otherwise we can still use the handler given by faulthandler.enable()
+        # at the cost of killing the process.
+        os.kill(pid, signal.SIGSEGV)
+
+    # wait in parent process to give subprocess some time to print
+    time.sleep(5)
+
+
+# The following `ErrorTrackingProcess` stores the first encountered exception in
+# its `.exception` attribute.
+# Inspired by https://stackoverflow.com/a/33599967
+class ErrorTrackingProcess(mp.Process):
+
+    # Why no *args?
+    #   py2 doesn't support def fn(x, *args, key=val, **kwargs)
+    # Setting disable_stderr=True may generate a lot of unrelated error outputs
+    # but could be helpful for debugging.
+    def __init__(self, disable_stderr=True, **kwargs):
+        super().__init__(**kwargs)
+        self._pconn, self._cconn = mp.Pipe()
+        self._exception = None
+        self.disable_stderr = disable_stderr
+
+    def run(self):
+        set_faulthander_if_available()
+        if self.disable_stderr:
+            # Disable polluting stderr with errors that are supposed to happen.
+            with open(os.devnull, 'w') as devnull:
+                os.dup2(devnull.fileno(), sys.stderr.fileno())
+        try:
+            super().run()
+            self._cconn.send(None)
+        except Exception:
+            self._cconn.send(ExceptionWrapper(sys.exc_info()))
+            raise
+
+    def print_traces_of_all_threads(self):
+        assert self.is_alive(), "can only use print_traces_of_all_threads if the process is alive"
+        assert not self.disable_stderr, "do not disable stderr if you use print_traces_of_all_threads"
+        # On platforms without `SIGUSR1`, `set_faulthander_if_available` sets
+        # `faulthandler.enable()`, and `print_traces_of_all_threads` may kill
+        # the process. So let's poll the exception first
+        _ = self.exception
+        print_traces_of_all_threads(self.pid)
+
+    @property
+    def exception(self):
+        if self._pconn.poll():
+            self._exception = self._pconn.recv()
+        if self._exception is None:
+            return None
+        else:
+            return self._exception.exc_type(self._exception.exc_msg)
+
+    # ESRCH means that os.kill can't finds alive proc
+    def send_signal(self, signum, ignore_ESRCH=False):
+        try:
+            os.kill(self.pid, signum)
+        except OSError as e:
+            if not ignore_ESRCH or e.errno != errno.ESRCH:
+                raise
+
+
+class ErrorDataset(Dataset):
+
+    def __init__(self, size):
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+
+class SegfaultDataset(Dataset):
+
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, idx):
+        return ctypes.string_at(0)
+
+    def __len__(self):
+        return self.size
+
+
+class SleepDataset(Dataset):
+
+    def __init__(self, size, sleep_sec):
+        self.size = size
+        self.sleep_sec = sleep_sec
+        self.sleeped = False
+
+    def __getitem__(self, idx):
+        if not self.sleeped:
+            time.sleep(self.sleep_sec)
+            self.sleeped = True
+        return idx
+
+    def __len__(self):
+        return self.size
+
+
+class SeedDataset(Dataset):
+
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, idx):
+        return torch.initial_seed()
+
+    def __len__(self):
+        return self.size
+
+
+class WorkerSpecificIterableDataset(IterableDataset):
+    def __init__(self, sizes_for_all_workers):
+        self.sizes_for_all_workers = sizes_for_all_workers
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        assert worker_info is not None
+        return iter(range(self.sizes_for_all_workers[worker_info.id]))
+
+    def __len__(self):
+        return sum(self.sizes_for_all_workers)
+
+
+# Inspired by https://stackoverflow.com/a/26703365
+# If all workers will call `sync_once`, they will be blocked until all workers
+# reach the call (i.e., acting like a barrier).
+# This can be used to ensure that each worker at least processes one data.
+class SynchronizedDataset(Dataset):
+
+    def __init__(self, size, batch_size, num_workers):
+        assert size >= num_workers * batch_size
+        self.count = mp.Value('i', 0, lock=True)
+        self.barrier = mp.Semaphore(0)
+        self.num_workers = num_workers
+        self.size = size
+
+    def sync_once(self):
+        with self.count.get_lock():
+            self.count.value += 1
+            if self.count.value == self.num_workers:
+                self.barrier.release()
+        self.barrier.acquire()
+        self.barrier.release()
+
+    def __getitem__(self, idx):
+        raise NotImplementedError
+
+    def __len__(self):
+        return self.size
+
+
+class EmptyTensorDataset(torch.utils.data.Dataset):
+    def __init__(self, len):
+        self.len = len
+
+    def __len__(self):
+        return self.len
+
+    def __getitem__(self, any):
+        return torch.empty(0)
+
+
+class SynchronizedSeedDataset(SynchronizedDataset):
+    def __getitem__(self, idx):
+        self.sync_once()
+        return torch.initial_seed()
+
+
+def _test_timeout(persistent_workers):
+    dataset = SleepDataset(10, 3)
+    dataloader = DataLoader(dataset, batch_size=2, num_workers=2, timeout=1,
+                            persistent_workers=persistent_workers)
+    _ = next(iter(dataloader))
+
+
+def _test_timeout_pin_memory(persistent_workers):
+    dataset = SleepDataset(10, 3)
+    dataloader = DataLoader(dataset, batch_size=2, num_workers=2, timeout=1, pin_memory=True,
+                            persistent_workers=persistent_workers)
+    _ = next(iter(dataloader))
+
+
+def _test_large_sampler_indices(persistent_workers):
+    # See
+    #   test_large_sampler_indices
+    #   https://github.com/pytorch/pytorch/issues/48666
+
+    dataloader = DataLoader(
+        EmptyTensorDataset(10000000),
+        batch_size=40960,
+        persistent_workers=persistent_workers,
+        num_workers=1)
+
+    it = iter(dataloader)
+
+    for x in it:
+        assert x.numel() == 0
+        raise RuntimeError('My Error')
+
+
+def disable_stderr(worker_id):
+    r"""
+    Avoids printing "ERROR: Unexpected segmentation fault encountered in worker."
+    from workers. Since worker signal handler prints with low-level write(),
+    this has to be done on OS level via dup.
+
+    This is used as worker_init_fn for test_segfault.
+    """
+    sys.stderr.flush()  # flush library buffers that dup2 knows nothing about
+    # Can't use a with-block because otherwise the fd will be closed when this
+    # function ends.
+    with open(os.devnull, 'w') as devnull:
+        os.dup2(devnull.fileno(), sys.stderr.fileno())
+
+
+def _test_segfault():
+    dataset = SegfaultDataset(10)
+    dataloader = DataLoader(dataset, batch_size=2, num_workers=2, worker_init_fn=disable_stderr)
+    _ = next(iter(dataloader))
+
+
+def _test_no_segfault():
+    dataset = [1, 2, 3]
+    num_threads = torch.get_num_threads()
+    if num_threads < 4:
+        torch.set_num_threads(4)
+    else:
+        torch.set_num_threads(num_threads)
+    mp_ctx = torch.multiprocessing.get_context(method='fork')
+    dataloader = DataLoader(dataset, num_workers=1, worker_init_fn=disable_stderr,
+                            multiprocessing_context=mp_ctx)
+    _ = next(iter(dataloader))
+
+
+class TestProperExitDataset(Dataset):
+    def __init__(self, size, error_event):
+        self.size = size
+        self.error_event = error_event
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, idx):
+        worker_info = torch.utils.data.get_worker_info()
+        if self.error_event is not None and self.error_event.is_set() and \
+                worker_info.id == worker_info.num_workers - 1:
+            # only error in the last worker
+            raise RuntimeError('Worker error')
+        return torch.tensor([idx])
+
+
+class TestProperExitIterableDataset(IterableDataset):
+    def __init__(self, size, error_event):
+        self.error_event = error_event
+        self.size = size
+        self.remaining = size
+
+    def __len__(self):
+        return self.size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if self.error_event is not None and self.error_event.is_set() and \
+                worker_info.id == worker_info.num_workers - 1:
+            # only error in the last worker
+            raise RuntimeError('Worker error')
+        self.remaining -= 1
+        if self.remaining < 0:
+            raise StopIteration
+        return torch.tensor(-1000)
+
+
+# See TestDataLoader.test_proper_exit for usage
+def _test_proper_exit(is_iterable_dataset, use_workers, pin_memory, exit_method,
+                      hold_iter_reference, loader_setup_event, tester_setup_event,
+                      persistent_workers):
+    num_workers = 2 if use_workers else 0
+
+    if exit_method == 'worker_error' or exit_method == 'worker_kill':
+        assert use_workers is True
+
+    if exit_method == 'worker_error':
+        worker_error_event = mp.Event()
+    else:
+        worker_error_event = None
+
+    if is_iterable_dataset:
+        ds = TestProperExitIterableDataset(7, worker_error_event)
+    else:
+        ds = TestProperExitDataset(12, worker_error_event)
+
+    loader = DataLoader(ds, batch_size=1, shuffle=False,
+                        num_workers=num_workers, pin_memory=pin_memory,
+                        worker_init_fn=set_faulthander_if_available,
+                        persistent_workers=persistent_workers)
+
+    error_it = 2
+
+    if use_workers:
+        # 2 is the magical per-worker prefetch number...
+        # FIXME: change this after the number becomes configurable.
+        if is_iterable_dataset:
+            assert len(ds) * num_workers > (error_it + 2 + 1)
+        else:
+            assert len(loader) > (error_it + 2 + 1) * num_workers
+    else:
+        if is_iterable_dataset:
+            assert len(ds) > error_it + 1
+        else:
+            assert len(loader) > error_it + 1
+
+    it = iter(loader)
+    if use_workers:
+        workers = it._workers
+
+    def kill_pid(pid):
+        psutil_p = psutil.Process(pid)
+        psutil_p.kill()
+        psutil_p.wait(JOIN_TIMEOUT)
+        assert not psutil_p.is_running()
+
+    for i, _ in enumerate(it):
+        if i == 0:
+            if not hold_iter_reference:
+                del it
+                del loader
+            loader_setup_event.set()
+            tester_setup_event.wait()
+            # ensure that the workers are still alive
+            if use_workers:
+                for w in workers:
+                    assert w.is_alive()
+            if worker_error_event is not None:
+                worker_error_event.set()
+
+        if i == error_it:
+            if exit_method == 'loader_error':
+                raise RuntimeError('Loader error')
+            elif exit_method == 'loader_kill':
+                kill_pid(os.getpid())
+            elif exit_method == 'worker_kill':
+                kill_pid(workers[-1].pid)  # kill last worker
+
+    if not hold_iter_reference:
+        # Tries to trigger the __del__ clean-up rather than the automatic
+        # exiting of daemonic children. Technically it should be automatically
+        # triggered, but I don't want to rely on the implementation detail of
+        # Python gc.
+        gc.collect()
+
+
+class TestWorkerInfoDataset(SynchronizedDataset):
+    def __getitem__(self, idx):
+        self.sync_once()
+        return torch.tensor(self.value)
+
+
+# Should be used as worker_init_fn with TestWorkerInfoDataset.
+# See _test_get_worker_info below for usage.
+def _test_worker_info_init_fn(worker_id):
+    worker_info = torch.utils.data.get_worker_info()
+    assert worker_id == worker_info.id, "worker_init_fn and worker_info should have consistent id"
+    assert worker_id < worker_info.num_workers, "worker_init_fn and worker_info should have valid id"
+    assert worker_info.seed == torch.initial_seed(), "worker_init_fn and worker_info should have consistent seed"
+    dataset = worker_info.dataset
+    assert isinstance(dataset, TestWorkerInfoDataset), "worker_info should have correct dataset copy"
+    assert not hasattr(dataset, 'value'), "worker_info should have correct dataset copy"
+    # test that WorkerInfo attributes are read-only
+    try:
+        worker_info.id = 3999
+    except RuntimeError as e:
+        assert str(e) == "Cannot assign attributes to WorkerInfo objects"
+    try:
+        worker_info.a = 3
+    except RuntimeError as e:
+        assert str(e) == "Cannot assign attributes to WorkerInfo objects"
+    for k in ['id', 'num_workers', 'seed', 'dataset']:
+        assert f"{k}=" in repr(worker_info)
+    dataset.value = [worker_id, os.getpid()]
+
+
+def _test_get_worker_info():
+    # get_worker_info returns None in main proc
+    assert torch.utils.data.get_worker_info() is None
+    num_workers = 2
+    batch_size = 2
+    dataset = TestWorkerInfoDataset(6, batch_size, num_workers)
+    dataloader = DataLoader(dataset, batch_size=batch_size,
+                            num_workers=num_workers,
+                            worker_init_fn=_test_worker_info_init_fn)
+    it = iter(dataloader)
+    data = []
+    for d in it:
+        data.append(d)  # noqa: PERF402
+    worker_pids = [w.pid for w in it._workers]
+    data = torch.cat(data, 0)
+    for d in data:
+        # each `d` is a [worker_id, worker_pid] pair, which is set in
+        # _test_worker_info_init_fn
+        assert d[1] == worker_pids[d[0]]
+    # get_worker_info returns None in main proc after data loading
+    assert torch.utils.data.get_worker_info() is None
+    # main proc dataset was never assigned this attribute
+    assert not hasattr(dataset, 'value')
+    try:
+        _ = dataset[0]
+    except AttributeError:
+        return
+    raise RuntimeError('Expected AttributeError')
+
+
+# test custom init function
+def init_fn(worker_id):
+    torch.manual_seed(12345)
+
+
+# used with test_error_in_init
+class ErrorIterableDataset(IterableDataset):
+    def __iter__(self):
+        raise RuntimeError("Error in __iter__")
+
+
+# used with test_error_in_init
+def error_worker_init_fn(_):
+    raise RuntimeError("Error in worker_init_fn")
+
+
+class BulkLoadingDataset(Dataset):
+    def __init__(self, length):
+        self.length = length
+
+    def __getitem__(self, indices):
+        assert isinstance(indices, (list, tuple))
+        return torch.as_tensor(indices)
+
+    def __len__(self):
+        return self.length
+
+
+class BulkLoadingSampler(torch.utils.data.Sampler):
+    def __init__(self, dataset, batch_size):
+        self.dataset = dataset
+        self.batch_size = batch_size
+
+    def __iter__(self):
+        for x in torch.randperm(len(self.dataset)).split(self.batch_size):
+            yield x.tolist()
+
+    def __len__(self):
+        return int(math.ceil(len(self.dataset) / float(self.batch_size)))
+
+
+class TestMultiEpochDataset(IterableDataset):
+    def __init__(self, length):
+        self.length = length
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        assert worker_info is not None
+        worker_id = worker_info.id
+        for idx in range(self.length // worker_info.num_workers):
+            yield worker_id
+
+    def __len__(self):
+        return self.length
+
+
+class CustomList(list):
+    pass
+
+
+class CustomDict(dict):
+    pass
+
+
+def row_processor(row):
+    return np.add(row, 1)
+
+
+def filter_len(row):
+    return len(row) == 4
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
+class TestDataLoader(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.data = torch.randn(100, 2, 3, 5)
+        self.labels = torch.randperm(50).repeat(2)
+        self.dataset = TensorDataset(self.data, self.labels)
+        self.persistent_workers = False
+
+    def _get_data_loader(self, dataset, **kwargs):
+        persistent_workers = kwargs.get('persistent_workers', self.persistent_workers)
+        if persistent_workers and kwargs.get('num_workers', 0) == 0:
+            persistent_workers = False
+        kwargs['persistent_workers'] = persistent_workers
+        return DataLoader(dataset, **kwargs)
+
+    def _test_sequential(self, loader):
+        batch_size = loader.batch_size
+        if batch_size is None:
+            for idx, (sample, target) in enumerate(loader):
+                self.assertEqual(sample, self.data[idx])
+                self.assertEqual(target, self.labels[idx])
+            self.assertEqual(idx, len(self.dataset) - 1)
+        else:
+            for i, (sample, target) in enumerate(loader):
+                idx = i * batch_size
+                self.assertEqual(sample, self.data[idx:idx + batch_size])
+                self.assertEqual(target, self.labels[idx:idx + batch_size])
+            self.assertEqual(i, math.floor((len(self.dataset) - 1) / batch_size))
+
+    def _test_shuffle(self, loader):
+        found_data = dict.fromkeys(range(self.data.size(0)), 0)
+        found_labels = dict.fromkeys(range(self.labels.size(0)), 0)
+        batch_size = loader.batch_size
+        if batch_size is None:
+            for i, (batch_samples, batch_targets) in enumerate(loader):
+                sample, target = (batch_samples, batch_targets)
+                for data_point_idx, data_point in enumerate(self.data):
+                    if data_point.eq(sample).all():
+                        self.assertFalse(found_data[data_point_idx])
+                        found_data[data_point_idx] += 1
+                        break
+                self.assertEqual(target, self.labels[data_point_idx])
+                found_labels[data_point_idx] += 1
+                self.assertEqual(sum(found_data.values()), (i + 1))
+                self.assertEqual(sum(found_labels.values()), (i + 1))
+            self.assertEqual(i, (len(self.dataset) - 1))
+        else:
+            for i, (batch_samples, batch_targets) in enumerate(loader):
+                for sample, target in zip(batch_samples, batch_targets):
+                    for data_point_idx, data_point in enumerate(self.data):
+                        if data_point.eq(sample).all():
+                            self.assertFalse(found_data[data_point_idx])
+                            found_data[data_point_idx] += 1
+                            break
+                    self.assertEqual(target, self.labels[data_point_idx])
+                    found_labels[data_point_idx] += 1
+                self.assertEqual(sum(found_data.values()), (i + 1) * batch_size)
+                self.assertEqual(sum(found_labels.values()), (i + 1) * batch_size)
+            self.assertEqual(i, math.floor((len(self.dataset) - 1) / batch_size))
+
+    def _test_error(self, loader):
+        it = iter(loader)
+        errors = 0
+        while True:
+            try:
+                next(it)
+            except NotImplementedError:
+                errors += 1
+            except StopIteration:
+                self.assertEqual(errors,
+                                 math.ceil(float(len(loader.dataset)) / loader.batch_size))
+                return
+
+    def test_error_in_init(self):
+        for num_workers in [0, 2]:
+            loader = self._get_data_loader(ErrorIterableDataset(), num_workers=num_workers)
+            with self.assertRaisesRegex(RuntimeError, 'Error in __iter__'):
+                list(iter(loader))
+
+        loader = self._get_data_loader(self.dataset, num_workers=2, worker_init_fn=error_worker_init_fn)
+        with self.assertRaisesRegex(RuntimeError, 'Error in worker_init_fn'):
+            list(iter(loader))
+
+    def test_typing(self):
+        from typing import List
+        # Make sure there is no TypeError
+
+        class SomeDatasetClass(Dataset[List[torch.Tensor]]):
+            pass
+
+        def _create_dataloader(is_train: bool) -> DataLoader[List[torch.Tensor]]:
+            pass
+
+    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
+    def test_fd_limit_exceeded(self):
+        # See NOTE [ DataLoader on Linux and open files limit ]
+        import subprocess
+        subprocess.check_output([sys.executable, '-c', """\
+import torch
+import resource
+from torch.utils.data import IterableDataset
+from torchdata.stateful_dataloader import StatefulDataLoader as DataLoader
+
+class RandomDataset(IterableDataset):
+    def __init__(self, len, size):
+        super(RandomDataset).__init__()
+        self.len = len
+        self.size = size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.len <= 0:
+            raise StopIteration
+        self.len -= 1
+        return torch.randn(self.size)
+
+try:
+    keep_fds_alive = []
+    resource.setrlimit(resource.RLIMIT_NOFILE, (100, 100))
+    for random_t in DataLoader(RandomDataset(200, (2,2)), multiprocessing_context="fork",
+                               num_workers=1):
+      random_t.max(dim=0)
+      keep_fds_alive.append(random_t)
+except RuntimeError as e:
+    assert "ulimit -n" in str(e)
+    assert "set_sharing_strategy" in str(e)
+"""])
+
+    def test_invalid_assign_after_init(self):
+        dl = self._get_data_loader(self.dataset)
+        for attr in ('batch_size', 'sampler', 'batch_sampler', 'drop_last', 'dataset'):
+            def fn():
+                setattr(dl, attr, {})
+
+            self.assertRaises(ValueError, fn)
+
+    def test_sequential_nonbatch(self):
+        self._test_sequential(self._get_data_loader(self.dataset, batch_size=None))
+
+    def test_sequential_batch(self):
+        self._test_sequential(self._get_data_loader(self.dataset))
+        self._test_sequential(self._get_data_loader(self.dataset, batch_size=2))
+
+    def test_bulk_loading_nobatch(self):
+        n = 35
+        bs = 4
+        ds = BulkLoadingDataset(n)
+        sampler = BulkLoadingSampler(ds, batch_size=4)
+
+        for num_workers in [0, 4]:
+            dl = self._get_data_loader(ds, num_workers=num_workers, batch_size=None, sampler=sampler, pin_memory=TEST_CUDA)
+            self.assertFalse(dl._auto_collation)
+            samples = list(dl)
+            self.assertEqual(samples[0].is_pinned(), TEST_CUDA)
+            self.assertEqual(set(torch.cat(samples, 0).tolist()), set(range(n)))
+
+    def test_growing_dataset(self):
+        dataset = [torch.ones(4) for _ in range(4)]
+        dataloader_seq = self._get_data_loader(dataset, shuffle=False)
+        dataloader_shuffle = self._get_data_loader(dataset, shuffle=True)
+        dataset.append(torch.ones(4))
+        self.assertEqual(len(dataloader_seq), 5)
+        self.assertEqual(len(dataloader_shuffle), 5)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_sequential_pin_memory(self):
+        loader = self._get_data_loader(self.dataset, batch_size=2, pin_memory=True)
+        for input, target in loader:
+            self.assertTrue(input.is_pinned())
+            self.assertTrue(target.is_pinned())
+
+    @unittest.skipIf(IS_JETSON, "Not working on Jetson")
+    def test_multiple_dataloaders(self):
+        for multiprocessing_context in supported_multiprocessing_contexts:
+            loader1_it = iter(self._get_data_loader(self.dataset, num_workers=1))
+            loader2_it = iter(self._get_data_loader(self.dataset, num_workers=2, multiprocessing_context=multiprocessing_context))
+            next(loader1_it)
+            next(loader1_it)
+            next(loader2_it)
+            next(loader2_it)
+            next(loader1_it)
+            next(loader2_it)
+            del loader1_it
+            del loader2_it
+
+    def test_segfault(self):
+        p = ErrorTrackingProcess(target=_test_segfault)
+        p.start()
+        p.join(JOIN_TIMEOUT)
+        try:
+            self.assertFalse(p.is_alive())
+            self.assertNotEqual(p.exitcode, 0)
+            if IS_WINDOWS:
+                self.assertIsInstance(p.exception, OSError)
+                self.assertRegex(str(p.exception), r'access violation reading ')
+            else:
+                self.assertIsInstance(p.exception, RuntimeError)
+                self.assertRegex(str(p.exception), r'DataLoader worker \(pid \d+\) is killed by signal: ')
+        finally:
+            p.terminate()
+
+    # Tests if the child process forked by the DataLoader segfaults due to having more than 3 threads
+    # in the parent process after at least one set_num_threads invocation in the parent process.
+    # After forking, set_num_threads(1) in the child process entails handling some inherited data-structures
+    # of the Caffe2 thread-pool of the parent process, culminating in a segfault.
+    # Reference: https://github.com/pytorch/pytorch/issues/54752
+    @unittest.skipIf(IS_WINDOWS, "Needs fork")
+    def test_no_segfault(self):
+        p = ErrorTrackingProcess(target=_test_no_segfault)
+        p.start()
+        p.join(JOIN_TIMEOUT)
+        try:
+            self.assertFalse(p.is_alive())
+            if p.exception:
+                self.assertIsInstance(p.exception, RuntimeError)
+                self.assertRegex(str(p.exception), r'DataLoader worker \(pid \d+\) is killed by signal: ')
+                self.fail("Segfault occurred in worker process after fork")
+        finally:
+            p.terminate()
+
+    def test_timeout(self):
+        if TEST_CUDA and not NO_MULTIPROCESSING_SPAWN:
+            # This test runs in a subprocess, which can only initialize CUDA with spawn.
+            # _test_timeout_pin_memory with pin_memory=True initializes CUDA when the iterator is
+            # constructed.
+            targets = (_test_timeout, _test_timeout_pin_memory)
+        else:
+            targets = (_test_timeout,)
+        for target in targets:
+            p = ErrorTrackingProcess(target=target, args=(self.persistent_workers,))
+            p.start()
+            p.join(JOIN_TIMEOUT)
+            try:
+                self.assertFalse(p.is_alive())
+                self.assertNotEqual(p.exitcode, 0)
+                self.assertIsInstance(p.exception, RuntimeError)
+                self.assertRegex(str(p.exception), r'DataLoader timed out after \d+ seconds')
+            finally:
+                p.terminate()
+
+    def test_large_sampler_indices(self):
+        # Test that the data loader cleanly exit when the process errors
+        #   1. having an reference to the iterator
+        #   2. using a sampler that yields big elements s.t. _index_queues putters block
+        #
+        # More context: https://github.com/pytorch/pytorch/issues/48666
+
+        p = ErrorTrackingProcess(target=_test_large_sampler_indices, args=(self.persistent_workers,))
+        p.start()
+        p.join(JOIN_TIMEOUT)
+        try:
+            self.assertFalse(p.is_alive())
+            self.assertNotEqual(p.exitcode, 0)
+            self.assertIsInstance(p.exception, RuntimeError)
+            self.assertRegex(str(p.exception), r'My Error')
+        finally:
+            p.terminate()
+
+    def test_invalid_ctor_args_combinations(self):
+        # general
+        with self.assertRaisesRegex(ValueError, "num_workers option should be non-negative"):
+            self._get_data_loader(self.dataset, num_workers=-1)
+        with self.assertRaisesRegex(ValueError, "timeout option should be non-negative"):
+            self._get_data_loader(self.dataset, timeout=-1)
+
+        # disable auto-batching
+        with self.assertRaisesRegex(ValueError,
+                                    "batch_size=None option disables auto-batching and is mutually exclusive"):
+            self._get_data_loader(self.dataset, batch_size=None, drop_last=True)
+
+        valid_ctx = list(torch.multiprocessing.get_all_start_methods())[-1]
+        with self.assertRaisesRegex(ValueError, r"multi-process loading \(num_workers > 0\), but got"):
+            self._get_data_loader(self.dataset, num_workers=0, multiprocessing_context=valid_ctx)
+        with self.assertRaisesRegex(ValueError, "should specify a valid start method in"):
+            self._get_data_loader(self.dataset, num_workers=1, multiprocessing_context='bad')
+        with self.assertRaisesRegex(TypeError, "multiprocessing_context option should be a valid context "):
+            self._get_data_loader(self.dataset, num_workers=1, multiprocessing_context=object())
+
+        # map-style
+        sampler = torch.utils.data.SequentialSampler(self.dataset)
+        batch_sampler = torch.utils.data.BatchSampler(sampler, 3, False)
+        with self.assertRaisesRegex(ValueError, "sampler option is mutually exclusive with shuffle"):
+            self._get_data_loader(self.dataset, batch_size=11, sampler=sampler, shuffle=True)
+        with self.assertRaisesRegex(ValueError, "sampler option is mutually exclusive with shuffle"):
+            self._get_data_loader(self.dataset, batch_sampler=batch_sampler, sampler=sampler, shuffle=True)
+        with self.assertRaisesRegex(ValueError, "sampler option is mutually exclusive with shuffle"):
+            self._get_data_loader(self.dataset, batch_sampler=batch_sampler, sampler=sampler, shuffle=3)
+        with self.assertRaisesRegex(ValueError, "batch_sampler option is mutually exclusive with"):
+            self._get_data_loader(self.dataset, batch_size=11, batch_sampler=batch_sampler)
+        with self.assertRaisesRegex(ValueError, "batch_sampler option is mutually exclusive with"):
+            self._get_data_loader(self.dataset, shuffle=True, batch_sampler=batch_sampler)
+        with self.assertRaisesRegex(ValueError, "batch_sampler option is mutually exclusive with"):
+            self._get_data_loader(self.dataset, drop_last=True, batch_sampler=batch_sampler)
+        with self.assertRaisesRegex(ValueError, "batch_sampler option is mutually exclusive with"):
+            self._get_data_loader(self.dataset, drop_last=3, batch_sampler=batch_sampler)
+
+        # iterable-style
+        dataset = CountingIterableDataset(20)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified shuffle"):
+            self._get_data_loader(dataset, shuffle=True)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified shuffle"):
+            self._get_data_loader(dataset, shuffle=3)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified sampler"):
+            self._get_data_loader(dataset, sampler=torch.utils.data.SequentialSampler(dataset))
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified sampler"):
+            self._get_data_loader(dataset, sampler=3)
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified batch_sampler"):
+            self._get_data_loader(dataset, batch_sampler=torch.utils.data.BatchSampler(
+                torch.utils.data.SequentialSampler(dataset), 3, False))
+        with self.assertRaisesRegex(ValueError, "DataLoader with IterableDataset: expected unspecified batch_sampler"):
+            self._get_data_loader(dataset, batch_sampler=3)
+
+    def test_builtin_collection_conversion(self):
+        for coll_ty in (list, tuple):
+            for num_workers in (0, 1):
+                # map-style dataset
+                dataset = CountingDataset(20)
+                # no auto-batching
+                fetched = coll_ty(self._get_data_loader(dataset, batch_size=None, num_workers=num_workers))
+                self.assertEqual(fetched, coll_ty(range(20)))
+                # auto-batching
+                fetched = coll_ty(self._get_data_loader(dataset, batch_size=2, num_workers=num_workers))
+                self.assertEqual(fetched, coll_ty(torch.tensor([i, i + 1]) for i in range(0, 20, 2)))
+
+                # iterable-style dataset
+                dataset = CountingIterableDataset(20)
+                # no auto-batching
+                fetched = coll_ty(self._get_data_loader(dataset, batch_size=None, num_workers=num_workers))
+                self.assertEqual(fetched, coll_ty(range(20)))
+                # auto-batching
+                # this IterableDataset isn't configured for each worker, so for
+                # the equality test below to be valid, we cannot have more than 1 workers.
+                assert num_workers in [0, 1], "invalid test"
+                fetched = coll_ty(self._get_data_loader(dataset, batch_size=2, num_workers=num_workers))
+                self.assertEqual(fetched, coll_ty(torch.tensor([i, i + 1]) for i in range(0, 20, 2)))
+
+    def test_iterable_style_dataset(self):
+        # [no auto-batching] single process loading
+        dataset = CountingIterableDataset(20)
+        dataloader = self._get_data_loader(dataset, batch_size=None)
+        fetched = list(dataloader)
+        self.assertEqual(len(fetched), 20)
+        for i, d in enumerate(fetched):
+            # non-batched should not convert ints into tensors
+            self.assertIsInstance(d, int)
+            self.assertEqual(d, i)
+        # DataLoader should match len of the iterable-style dataset (if implemented)
+        self.assertEqual(len(dataloader), len(dataset))
+
+        # [no auto-batching] multiprocessing loading
+        num_workers = 3
+        sizes_for_all_workers = [0, 4, 20]
+        expected = sorted(functools.reduce(operator.iadd, (list(range(s)) for s in sizes_for_all_workers), []))
+        assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
+        for prefetch_factor in [2, 3, 4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            dataloader = self._get_data_loader(dataset, num_workers=num_workers, batch_size=None,
+                                               worker_init_fn=set_faulthander_if_available,
+                                               prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = sorted(dataloader_iter)
+            for a, b in zip(fetched, expected):
+                # non-batched should not convert ints into tensors
+                self.assertIsInstance(a, int)
+                self.assertEqual(a, b)
+            # DataLoader should match len of the iterable-style dataset (if implemented)
+            self.assertEqual(len(dataloader), len(dataset))
+            # When loading more than len(dataset) data, after accessing len(dataloader),
+            # we should get a warning. See NOTE [ IterableDataset and __len__ ].
+            dataset = CountingIterableDataset(20)
+            dataloader = self._get_data_loader(dataset, num_workers=num_workers,
+                                               worker_init_fn=set_faulthander_if_available,
+                                               prefetch_factor=prefetch_factor)
+            it = iter(dataloader)
+            for _ in range(40):
+                self.assertNotWarn(lambda: next(it), "Should not warn before accessing len(dataloader)")
+            self.assertEqual(len(dataloader), len(dataset))
+            self.assertEqual(len(dataloader), 20)
+            it = iter(dataloader)
+            for _ in range(20):
+                self.assertNotWarn(lambda: next(it), "Should not warn before exceeding length")
+            for _ in range(3):
+                with self.assertWarnsRegex(
+                    UserWarning,
+                    r"but [0-9]+ samples have been fetched\. For multiprocessing data-loading, this",
+                        msg="Should always warn after exceeding length"):
+                    next(it)
+        # [no auto-batching] test that workers exit gracefully
+        workers = dataloader_iter._workers
+        del dataloader_iter
+        del dataloader
+        try:
+            for w in workers:
+                w.join(JOIN_TIMEOUT)
+                self.assertFalse(w.is_alive())
+                self.assertEqual(w.exitcode, 0)
+        finally:
+            for w in workers:
+                w.terminate()
+
+        # [auto-batching] single process loading
+        dataset = CountingIterableDataset(20)
+        fetched = list(self._get_data_loader(dataset, batch_size=7))
+        self.assertEqual(len(fetched), 3)
+        self.assertEqual(fetched[0].tolist(), list(range(7)))
+        self.assertEqual(fetched[1].tolist(), list(range(7, 14)))
+        self.assertEqual(fetched[2].tolist(), list(range(14, 20)))
+
+        # [auto-batching] multiprocessing loading
+        num_workers = 3
+        sizes_for_all_workers = [0, 4, 20]
+        expected = sorted(functools.reduce(operator.iadd, (list(range(s)) for s in sizes_for_all_workers), []))
+        assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
+        for prefetch_factor in [2, 3, 4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            # worker 0 should return 0 batches
+            # worker 1 should return 1 batches
+            # worker 2 should return 3 batches
+            dataloader = self._get_data_loader(dataset, num_workers=num_workers, batch_size=7, prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = list(dataloader_iter)
+            self.assertEqual(len(fetched), 4)
+            fetched = {tuple(t.tolist()) for t in fetched}
+            self.assertEqual(fetched, {tuple(range(4)), tuple(range(7)), tuple(range(7, 14)), tuple(range(14, 20))})
+
+            # [auto-batching] test that workers exit gracefully
+            workers = dataloader_iter._workers
+            del dataloader_iter
+            del dataloader
+            try:
+                for w in workers:
+                    w.join(JOIN_TIMEOUT)
+                    self.assertFalse(w.is_alive())
+                    self.assertEqual(w.exitcode, 0)
+            finally:
+                for w in workers:
+                    w.terminate()
+        # [auto-batching & drop_last] single process loading
+        dataset = CountingIterableDataset(20)
+        fetched = list(self._get_data_loader(dataset, batch_size=7, drop_last=True))
+        self.assertEqual(len(fetched), 2)
+        self.assertEqual(fetched[0].tolist(), list(range(7)))
+        self.assertEqual(fetched[1].tolist(), list(range(7, 14)))
+
+        # [auto-batching & drop_last] multiprocessing loading
+        num_workers = 3
+        sizes_for_all_workers = [0, 4, 20]
+        expected = sorted(functools.reduce(operator.iadd, (list(range(s)) for s in sizes_for_all_workers), []))
+        assert len(sizes_for_all_workers) == num_workers, 'invalid test case'
+        for prefetch_factor in [2, 3, 4]:
+            dataset = WorkerSpecificIterableDataset(sizes_for_all_workers)
+            # worker 0 should return 0 batches
+            # worker 1 should return 1 batches
+            # worker 2 should return 3 batches
+            dataloader = self._get_data_loader(dataset, num_workers=num_workers, batch_size=7, drop_last=True,
+                                               worker_init_fn=set_faulthander_if_available,
+                                               prefetch_factor=prefetch_factor)
+            dataloader_iter = iter(dataloader)
+            fetched = list(dataloader_iter)
+            self.assertEqual(len(fetched), 2)
+            fetched = {tuple(t.tolist()) for t in fetched}
+            self.assertEqual(fetched, {tuple(range(7)), tuple(range(7, 14))})
+
+            # [auto-batching & drop_last] test that workers exit gracefully
+            workers = dataloader_iter._workers
+            del dataloader_iter
+            del dataloader
+            try:
+                for w in workers:
+                    w.join(JOIN_TIMEOUT)
+                    self.assertFalse(w.is_alive())
+                    self.assertEqual(w.exitcode, 0)
+            finally:
+                for w in workers:
+                    w.terminate()
+
+    def test_chain_iterable_style_dataset(self):
+        # chaining (concatenation)
+        dataset1 = CountingIterableDataset(20)
+        dataset2 = CountingIterableDataset(15)
+        expected = list(range(20)) + list(range(15))
+        for num_workers in [0, 1]:
+            for chained_dataset in [dataset1 + dataset2, ChainDataset([dataset1, dataset2])]:
+                fetched = list(self._get_data_loader(chained_dataset, num_workers=num_workers))
+                self.assertEqual(len(fetched), len(expected))
+                for e, d in zip(expected, fetched):
+                    self.assertIsInstance(d, torch.Tensor)
+                    self.assertEqual(e, d)
+
+        with self.assertRaisesRegex(AssertionError, "ChainDataset only supports IterableDataset"):
+            list(iter(dataset1 + self.dataset))
+
+        with self.assertRaisesRegex(AssertionError, "ChainDataset only supports IterableDataset"):
+            list(iter(ChainDataset([dataset1, self.dataset])))
+
+    @unittest.skipIf(IS_MACOS, "Not working on macos")
+    @unittest.skipIf(IS_MACOS or IS_JETSON, "Not working on macos or Jetson")
+    @skipIfRocm  # https://github.com/pytorch/pytorch/issues/90940
+    def test_multiprocessing_contexts(self):
+        reference = [
+            torch.arange(3),
+            torch.arange(3, 6),
+            torch.arange(6, 9),
+            torch.arange(9, 11),
+        ]
+        counting_ds_n = 11
+        dl_common_args = dict(num_workers=3, batch_size=3, pin_memory=(not TEST_CUDA))
+        for ctx in supported_multiprocessing_contexts:
+            # windows and jetson devices don't support sharing cuda tensor; ROCm does not yet fully support IPC
+            if ctx in ['spawn', 'forkserver'] and TEST_CUDA and not IS_WINDOWS and not IS_JETSON:
+                ds_cls = CUDACountingDataset
+            else:
+                ds_cls = CountingDataset
+            self.assertEqual(
+                reference, list(self._get_data_loader(ds_cls(counting_ds_n), multiprocessing_context=ctx, **dl_common_args)))
+            if ctx is not None:
+                # test ctx object
+                ctx = mp.get_context(ctx)
+                self.assertEqual(
+                    reference, list(self._get_data_loader(ds_cls(counting_ds_n), multiprocessing_context=ctx, **dl_common_args)))
+
+    def _test_multiprocessing_iterdatapipe(self, with_dill):
+        # Testing to make sure that function from global scope (e.g. imported from library) can be serialized
+        # and used with multiprocess DataLoader
+
+        reference = [torch.as_tensor([[2, 3, 4, 5]], dtype=torch.int64),
+                     torch.as_tensor([[2, 3, 4, 5]], dtype=torch.int64)]
+        datapipe: IterDataPipe = IterableWrapper([[1, 2, 3, 4], [1, 2, 3, 4, 5, 6]])
+        datapipe = datapipe.map(row_processor)
+        datapipe = datapipe.filter(lambda row: len(row) == 4) if with_dill else datapipe.filter(filter_len)
+
+        dl_common_args = dict(num_workers=2, batch_size=2, shuffle=True, pin_memory=(not TEST_CUDA))
+        for ctx in supported_multiprocessing_contexts:
+            self.assertEqual(reference,
+                             [t.type(torch.int64)
+                              for t in self._get_data_loader(datapipe, multiprocessing_context=ctx, **dl_common_args)])
+            if ctx is not None:
+                # test ctx object
+                ctx = mp.get_context(ctx)
+                self.assertEqual(reference,
+                                 [t.type(torch.int64)
+                                  for t in
+                                  self._get_data_loader(datapipe, multiprocessing_context=ctx, **dl_common_args)])
+
+    @skipIfNoNumpy
+    @unittest.skipIf(IS_JETSON, "Not working on Jetson")
+    def test_multiprocessing_iterdatapipe(self):
+        self._test_multiprocessing_iterdatapipe(with_dill=False)
+
+    @unittest.expectedFailure
+    @skipIfNoNumpy
+    @unittest.skipIf(IS_JETSON, "Not working on Jetson")
+    @skipIfNoDill
+    def test_multiprocessing_iterdatapipe_with_dill(self):
+        self._test_multiprocessing_iterdatapipe(with_dill=True)
+
+    def test_worker_seed(self):
+        num_workers = 6
+        batch_size = 1
+        dataset = SynchronizedSeedDataset(num_workers, batch_size, num_workers)
+        dataloader = self._get_data_loader(dataset, batch_size=batch_size, num_workers=num_workers)
+        seeds = set()
+        for batch in dataloader:
+            seeds.add(batch[0])
+        self.assertEqual(len(seeds), num_workers)
+
+    def test_worker_seed_reproducibility(self):
+        def get_dataloader():
+            return DataLoader(dataset, batch_size=batch_size, num_workers=num_workers, generator=torch.Generator().manual_seed(42))
+
+        num_workers = 6
+        batch_size = 1
+        dataset = SynchronizedSeedDataset(num_workers, batch_size, num_workers)
+        self.assertEqual({int(batch) for batch in get_dataloader()}, {int(batch) for batch in get_dataloader()})
+
+    def test_multi_epochs_reproducibility(self):
+        num_workers = 2
+        batch_size = 10
+        num_epochs = 3
+
+        dataset = TestMultiEpochDataset(batch_size * num_workers)
+        dataloader = self._get_data_loader(dataset, batch_size=batch_size,
+                                           shuffle=False, num_workers=num_workers)
+
+        for ind in range(num_epochs):
+            for batch_idx, sample in enumerate(dataloader):
+                self.assertEqual(sample.tolist(), [batch_idx % num_workers] * batch_size)
+
+    def test_worker_init_fn(self):
+        dataset = SeedDataset(4)
+        dataloader = self._get_data_loader(dataset, batch_size=2, num_workers=2,
+                                           worker_init_fn=init_fn)
+        for batch in dataloader:
+            self.assertEqual(12345, batch[0])
+            self.assertEqual(12345, batch[1])
+
+    def test_get_worker_info(self):
+        p = ErrorTrackingProcess(target=_test_get_worker_info)
+        p.start()
+        p.join(JOIN_TIMEOUT)
+        try:
+            self.assertFalse(p.is_alive())
+            self.assertEqual(p.exitcode, 0)
+        finally:
+            p.terminate()
+
+    def test_shuffle(self):
+        self._test_shuffle(self._get_data_loader(self.dataset, shuffle=True))
+
+    def test_shuffle_batch_none(self):
+        self._test_shuffle(DataLoader(self.dataset, batch_size=None, shuffle=True))
+
+    def test_shuffle_batch(self):
+        self._test_shuffle(self._get_data_loader(self.dataset, batch_size=2, shuffle=True))
+
+    def test_shuffle_reproducibility(self):
+        for fn in (
+            lambda: DataLoader(self.dataset, shuffle=True, num_workers=0, generator=torch.Generator().manual_seed(42)),
+            lambda: DataLoader(self.dataset, shuffle=True, num_workers=2, generator=torch.Generator().manual_seed(42)),
+        ):
+            self.assertEqual(list(fn()), list(fn()))
+
+    def test_sequential_workers(self):
+        self._test_sequential(self._get_data_loader(self.dataset, num_workers=4))
+
+    def test_seqential_batch_workers(self):
+        self._test_sequential(self._get_data_loader(self.dataset, batch_size=2, num_workers=4))
+
+    def test_seqential_batch_workers_prefetch(self):
+        self._test_sequential(DataLoader(self.dataset, batch_size=2, num_workers=4, prefetch_factor=3))
+
+    def test_shuffle_workers(self):
+        self._test_shuffle(self._get_data_loader(self.dataset, shuffle=True, num_workers=4))
+
+    def test_shuffle_batch_workers(self):
+        self._test_shuffle(self._get_data_loader(self.dataset, batch_size=2, shuffle=True, num_workers=4))
+
+    def test_shuffle_batch_workers_prefetch(self):
+        self._test_shuffle(DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, prefetch_factor=3))
+
+    def test_random_sampler(self):
+
+        from collections import Counter
+        from torch.utils.data import RandomSampler
+
+        def sample_stat(sampler, num_samples):
+            counts = Counter(sampler)
+            count_repeated = sum(val > 1 for val in counts.values())
+            return (count_repeated, min(counts.keys()), max(counts.keys()), sum(counts.values()))
+
+        # test sample with replacement
+        n = len(self.dataset) + 1  # ensure at least one sample is drawn more than once
+        sampler_with_replacement = RandomSampler(self.dataset, replacement=True, num_samples=n)
+        count_repeated, minval, maxval, count_total = sample_stat(sampler_with_replacement, n)
+        self.assertTrue(count_repeated > 0)
+        self.assertTrue(minval >= 0)
+        self.assertTrue(maxval < len(self.dataset))
+        self.assertTrue(count_total == n)
+
+        # test sample without replacement and without specified num_samples
+        sampler_without_replacement = RandomSampler(self.dataset)
+        count_repeated, minval, maxval, count_total = sample_stat(sampler_without_replacement, len(self.dataset))
+        self.assertTrue(count_repeated == 0)
+        self.assertTrue(minval == 0)
+        self.assertTrue(maxval == len(self.dataset) - 1)
+        self.assertTrue(count_total == len(self.dataset))
+
+        # test sample without replacement and with specified num_samples
+        n = len(self.dataset) * 2
+        sampler_without_replacement = RandomSampler(self.dataset, num_samples=n)
+        count_repeated, minval, maxval, count_total = sample_stat(sampler_without_replacement, len(self.dataset))
+        self.assertTrue(count_repeated == len(self.dataset))
+        self.assertTrue(minval == 0)
+        self.assertTrue(maxval == len(self.dataset) - 1)
+        self.assertTrue(count_total == n)
+
+        n = len(self.dataset) - 1
+        sampler_without_replacement = RandomSampler(self.dataset, num_samples=n)
+        count_repeated, minval, maxval, count_total = sample_stat(sampler_without_replacement, len(self.dataset))
+        self.assertTrue(count_repeated == 0)
+        self.assertTrue(minval >= 0)
+        self.assertTrue(maxval < len(self.dataset))
+        self.assertTrue(count_total == n)
+
+        n = len(self.dataset) + 1
+        sampler_without_replacement = RandomSampler(self.dataset, num_samples=n)
+        count_repeated, minval, maxval, count_total = sample_stat(sampler_without_replacement, len(self.dataset))
+        self.assertTrue(count_repeated == 1)
+        self.assertTrue(minval == 0)
+        self.assertTrue(maxval == len(self.dataset) - 1)
+        self.assertTrue(count_total == n)
+
+        # raise error when replacement is non-boolean
+        with self.assertRaisesRegex(TypeError, "replacement should be a boolean value, but got replacement=0"):
+            RandomSampler(self.dataset, replacement=0)
+
+    def test_random_sampler_len_with_replacement(self):
+        from torch.utils.data import RandomSampler
+        # add 5 extra samples
+        num_samples = len(self.dataset) + 5
+        sampler = RandomSampler(self.dataset,
+                                replacement=True,
+                                num_samples=num_samples)
+        # test len method
+        self.assertEqual(num_samples, len(sampler))
+
+        # test with iteration
+        count_num_samples = sum(1 for _ in sampler)
+        self.assertEqual(num_samples, count_num_samples)
+
+        # test with dataloader, batch_size = 1
+        batch_size = 1
+        count_num_samples_in_data_loader = len(self._get_data_loader(
+            self.dataset, batch_size=batch_size, sampler=sampler))
+        self.assertEqual(num_samples, count_num_samples_in_data_loader)
+
+        # test with dataloader, batch_size = 6
+        batch_size = 6
+        count_num_samples_in_data_loader = len(self._get_data_loader(
+            self.dataset, batch_size=batch_size, sampler=sampler))
+        self.assertEqual(int(math.ceil(float(num_samples) / batch_size)),
+                         count_num_samples_in_data_loader)
+
+    def test_random_sampler_len_without_replacement(self):
+        from torch.utils.data import RandomSampler
+        # add 5 extra samples
+        num_samples = len(self.dataset) + 5
+        sampler = RandomSampler(self.dataset,
+                                replacement=False,
+                                num_samples=num_samples)
+        # test len method
+        self.assertEqual(num_samples, len(sampler))
+
+        # test with iteration
+        count_num_samples = sum(1 for _ in sampler)
+        self.assertEqual(num_samples, count_num_samples)
+
+        # test with dataloader, batch_size = 1
+        batch_size = 1
+        count_num_samples_in_data_loader = len(self._get_data_loader(
+            self.dataset, batch_size=batch_size, sampler=sampler))
+        self.assertEqual(num_samples, count_num_samples_in_data_loader)
+
+        # test with dataloader, batch_size = 6
+        batch_size = 6
+        count_num_samples_in_data_loader = len(self._get_data_loader(
+            self.dataset, batch_size=batch_size, sampler=sampler))
+        self.assertEqual(num_samples // batch_size + (num_samples % batch_size > 0),
+                         count_num_samples_in_data_loader)
+
+    def test_distributed_sampler_invalid_rank(self):
+        from torch.utils.data.distributed import DistributedSampler
+        dataset = torch.IntTensor(range(10))
+        with self.assertRaisesRegex(ValueError, "Invalid rank"):
+            sampler = DistributedSampler(dataset, 3, 3)
+
+        with self.assertRaisesRegex(ValueError, "Invalid rank"):
+            sampler = DistributedSampler(dataset, 3, -1)
+
+    def test_duplicating_data_with_drop_last(self):
+
+        from torch.utils.data.distributed import DistributedSampler
+
+        num_processes = 4
+        num_batches = 9
+        data_set = torch.IntTensor(range(num_batches))
+        scanned_data = torch.IntTensor([])
+        for i in range(num_processes):
+            s = DistributedSampler(data_set, num_processes, i)
+            d_loader = self._get_data_loader(data_set, batch_size=int(num_batches / num_processes), drop_last=True, sampler=s)
+            for data in d_loader:
+                scanned_data = torch.cat((scanned_data, data), 0)
+
+        self.assertEqual(scanned_data.size(), scanned_data.unique().size())
+
+    def test_sampler_reproducibility(self):
+        from torch.utils.data import RandomSampler, WeightedRandomSampler, SubsetRandomSampler
+
+        weights = [0.1, 0.9, 0.4, 0.7, 3.0, 0.6]
+        for fn in (
+            lambda: RandomSampler(self.dataset, num_samples=5, replacement=True, generator=torch.Generator().manual_seed(42)),
+            lambda: RandomSampler(self.dataset, replacement=False, generator=torch.Generator().manual_seed(42)),
+            lambda: WeightedRandomSampler(weights, num_samples=5, replacement=True, generator=torch.Generator().manual_seed(42)),
+            lambda: WeightedRandomSampler(weights, num_samples=5, replacement=False, generator=torch.Generator().manual_seed(42)),
+            lambda: SubsetRandomSampler(range(10), generator=torch.Generator().manual_seed(42)),
+        ):
+            self.assertEqual(list(fn()), list(fn()))
+
+        for sampler in (
+            RandomSampler(self.dataset, num_samples=5, replacement=True),
+            RandomSampler(self.dataset, replacement=False),
+            WeightedRandomSampler(weights, num_samples=5, replacement=True),
+            WeightedRandomSampler(weights, num_samples=5, replacement=False),
+            SubsetRandomSampler(range(10)),
+        ):
+            torch.manual_seed(0)
+            l1 = list(sampler) + list(sampler)
+
+            torch.manual_seed(0)
+            l2 = list(sampler) + list(sampler)
+            self.assertEqual(l1, l2)
+
+            its = (iter(sampler), iter(sampler))
+            ls = ([], [])
+            for idx in range(len(sampler)):
+                for i in range(2):
+                    if idx == 0:
+                        torch.manual_seed(0)
+                    ls[i].append(next(its[i]))
+            self.assertEqual(ls[0], ls[1])
+
+    def _test_sampler(self, **kwargs):
+        indices = range(2, 12)  # using a regular iterable
+        dl = self._get_data_loader(self.dataset, sampler=indices, batch_size=2, **kwargs)
+        self.assertEqual(len(dl), 5)
+        for i, (input, _target) in enumerate(dl):
+            self.assertEqual(len(input), 2)
+            self.assertEqual(input, self.data[i * 2 + 2:i * 2 + 4])
+
+    def test_sampler(self):
+        self._test_sampler()
+        self._test_sampler(num_workers=4)
+        if not NO_MULTIPROCESSING_SPAWN:
+            self._test_batch_sampler(num_workers=4, multiprocessing_context='spawn')
+
+    def _test_batch_sampler(self, **kwargs):
+        # [(0, 1), (2, 3, 4), (5, 6), (7, 8, 9), ...]
+        batches = []  # using a regular iterable
+        for i in range(0, 20, 5):
+            batches.append(tuple(range(i, i + 2)))
+            batches.append(tuple(range(i + 2, i + 5)))
+
+        dl = self._get_data_loader(self.dataset, batch_sampler=batches, **kwargs)
+        self.assertEqual(len(dl), 8)
+        for i, (input, _target) in enumerate(dl):
+            if i % 2 == 0:
+                offset = i * 5 // 2
+                self.assertEqual(len(input), 2)
+                self.assertEqual(input, self.data[offset:offset + 2])
+            else:
+                offset = i * 5 // 2
+                self.assertEqual(len(input), 3)
+                self.assertEqual(input, self.data[offset:offset + 3])
+
+    def test_batch_sampler(self):
+        self._test_batch_sampler()
+        self._test_batch_sampler(num_workers=4)
+        if not NO_MULTIPROCESSING_SPAWN:
+            self._test_batch_sampler(num_workers=4, multiprocessing_context='spawn')
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_shuffle_pin_memory(self):
+        loader = self._get_data_loader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
+        for input, target in loader:
+            self.assertTrue(input.is_pinned())
+            self.assertTrue(target.is_pinned())
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_numpy(self):
+        import numpy as np
+
+        class TestDataset(torch.utils.data.Dataset):
+            def __getitem__(self, i):
+                return np.ones((2, 3, 4)) * i
+
+            def __len__(self):
+                return 1000
+
+        loader = self._get_data_loader(TestDataset(), batch_size=12)
+        batch = next(iter(loader))
+        self.assertIsInstance(batch, torch.DoubleTensor)
+        self.assertEqual(batch.size(), torch.Size([12, 2, 3, 4]))
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_numpy_gen_state(self):
+        from torch.utils.data._utils.worker import _generate_state
+        # Using NumPy generated states as the reference to test `_generate_state`
+        # having the same result.
+        # Test case: ((worker_id, base_seed), expected_state)
+        test_cases = [
+            ((4, 13434589827475259383), (2884386318, 1088094898, 3523808998, 3860348662)),
+            ((1, 15014285634777110771), (1934848465, 763213760, 2959016433, 179751970)),
+            ((10, 978296274032934101), (1759791917, 3550927336, 1225977135, 1036538043)),
+            ((12, 11868770762134256968), (3974661794, 3331131333, 3630387033, 2885815368)),
+            ((9, 15378787925219019706), (3815056996, 3162224466, 2735102421, 3190253477)),
+            ((5, 9055612723125076328), (3522565701, 3368424109, 959377806, 621878693)),
+            ((15, 14617792358407278405), (3402479508, 1588702753, 1169536393, 3675067356)),
+            ((9, 17363320784006640087), (957989458, 2518334477, 1421725660, 3086155459)),
+            ((12, 480002904169484764), (2732851467, 1762620729, 4055801988, 1277640511)),
+            ((15, 16803975943592702950), (3479415043, 4022359553, 295994005, 3358606349)),
+            ((9, 11704776406047813044), (1968928009, 710113752, 2442656196, 1587420279)),
+            ((10, 16357891985431864516), (1271733898, 4197047399, 3727213786, 2338547348)),
+            ((2, 17423369006318065007), (544294336, 1911284083, 3299147734, 3231058347)),
+            ((2, 2889492011444113593), (3721591783, 2595811276, 2212881745, 977682627)),
+            ((0, 8979703111668486195), (4276723937, 2556068849, 2962827292, 233130238)),
+            ((6, 6269787272229682235), (2548857855, 1216457374, 1012973562, 2999759647))
+        ]
+
+        for (worker_id, base_seed), exp in test_cases:
+            self.assertEqual(exp, _generate_state(base_seed, worker_id))
+
+    def test_error(self):
+        self._test_error(self._get_data_loader(ErrorDataset(100), batch_size=2, shuffle=True))
+
+    def test_error_workers(self):
+        self._test_error(self._get_data_loader(ErrorDataset(41), batch_size=2, shuffle=True, num_workers=4))
+
+    @unittest.skipIf(IS_WINDOWS, "FIXME: stuck test")
+    def test_partial_workers(self):
+        r"""Check that workers exit even if the iterator is not exhausted."""
+        if TEST_CUDA:
+            pin_memory_configs = (True, False)
+        else:
+            pin_memory_configs = (False,)
+
+        for pin_memory in pin_memory_configs:
+            loader = iter(self._get_data_loader(self.dataset, batch_size=2, num_workers=4, pin_memory=pin_memory))
+            workers = loader._workers
+            if pin_memory:
+                pin_memory_thread = loader._pin_memory_thread
+            for i, _ in enumerate(loader):
+                if i == 10:
+                    break
+            assert i == 10
+            del loader
+            for w in workers:
+                w.join(JOIN_TIMEOUT)
+                self.assertFalse(w.is_alive(), 'subprocess not terminated')
+            if pin_memory:
+                pin_memory_thread.join(JOIN_TIMEOUT)
+                self.assertFalse(pin_memory_thread.is_alive())
+
+    # Takes 2.5min to finish, see https://github.com/pytorch/pytorch/issues/46065
+    @skipIfRocm
+    @unittest.skipIf(not HAS_PSUTIL, "psutil not found")
+    @slowTest
+    def test_proper_exit(self):
+        (r'''There might be ConnectionResetError or leaked semaphore warning '''
+         r'''(due to dirty process exit), but they are all safe to ignore''')
+
+        # TODO: test the case where the pin_memory_thread triggers an
+        #       error/fatal signal. I haven't found out how to properly do that.
+
+        for is_iterable_dataset, use_workers, pin_memory, hold_iter_reference in \
+                itertools.product([True, False], repeat=4):
+
+            # `hold_iter_reference` specifies whether we hold a reference to the
+            # iterator. This is interesting because Python3 error traces holds a
+            # reference to the frames, which hold references to all the local
+            # variables including the iterator, and then the iterator dtor may
+            # not be called before process end. It is important to see that the
+            # processes still exit in both cases.
+
+            if pin_memory and (not TEST_CUDA or NO_MULTIPROCESSING_SPAWN or IS_WINDOWS):
+                # This test runs in a subprocess, which can only initialize CUDA with spawn.
+                # DataLoader with pin_memory=True initializes CUDA when its iterator is constructed.
+                # For windows, pin_memory sometimes causes CUDA oom.
+                continue
+
+            # `exit_method` controls the way the loader process ends.
+            #   - `*_kill` means that `*` is killed by OS.
+            #   - `*_error` means that `*` raises an error.
+            #   - `None` means that no error happens.
+            # In all cases, all processes should end properly.
+            if use_workers:
+                # TODO: Fix test for 'loader_kill' that would cause running out of shared memory.
+                # Killing loader process would prevent DataLoader iterator clean up all queues
+                # and worker processes
+                exit_methods = [None, 'loader_error', 'worker_error', 'worker_kill']
+                persistent_workers = self.persistent_workers
+            else:
+                exit_methods = [None, 'loader_error', 'loader_kill']
+                persistent_workers = False
+
+            for exit_method in exit_methods:
+                if exit_method == 'worker_kill':
+                    # FIXME: This sometimes hangs. See #16608.
+                    continue
+
+                desc = []
+                desc.append(f'is_iterable_dataset={is_iterable_dataset}')
+                desc.append(f'use_workers={use_workers}')
+                desc.append(f'pin_memory={pin_memory}')
+                desc.append(f'hold_iter_reference={hold_iter_reference}')
+                desc.append(f'exit_method={exit_method}')
+                desc = 'test_proper_exit with ' + ', '.join(desc)
+
+                # Event that the loader process uses to signal testing process
+                # that various things are setup, including that the worker pids
+                # are specified in `worker_pids` array.
+                loader_setup_event = mp.Event()
+
+                # Event that this process has finished setting up, and the
+                # loader process can now proceed to trigger error events or
+                # finish normally.
+                tester_setup_event = mp.Event()
+
+                loader_p = ErrorTrackingProcess(target=_test_proper_exit,
+                                                args=(is_iterable_dataset, use_workers, pin_memory,
+                                                      exit_method, hold_iter_reference,
+                                                      loader_setup_event, tester_setup_event,
+                                                      persistent_workers),
+                                                disable_stderr=False)
+                loader_p.start()
+                loader_psutil_p = psutil.Process(loader_p.pid)
+
+                # Wait for loader process to set everything up, e.g., starting
+                # workers.
+                loader_setup_event.wait(timeout=JOIN_TIMEOUT)
+                if not loader_setup_event.is_set():
+                    fail_msg = desc + ': loader process failed to setup within given time'
+                    if loader_p.exception is not None:
+                        fail_msg += f', and had exception {loader_p.exception}'
+                    elif not loader_p.is_alive():
+                        fail_msg += f', and exited with code {loader_p.exitcode} but had no exception'
+                    else:
+                        fail_msg += ', and is still alive.'
+                    if loader_p.is_alive():
+                        # this may kill the process, needs to run after the above lines
+                        loader_p.print_traces_of_all_threads()
+                    self.fail(fail_msg)
+
+                # We are certain that the workers have started now.
+                worker_psutil_ps = loader_psutil_p.children()
+
+                def fail(reason):
+                    report_psutil_attrs = ['pid', 'name', 'cpu_times', 'io_counters',
+                                           'memory_full_info', 'num_ctx_switches',
+                                           'open_files', 'threads', 'status',
+                                           'nice', 'ionice']
+                    if reason is None:
+                        err_msg = desc
+                    else:
+                        err_msg = f'{desc}: {reason}'
+                    err_msg += '\nLoader info:\n\t'
+                    if loader_psutil_p.is_running():
+                        err_msg += str(loader_psutil_p.as_dict(attrs=report_psutil_attrs))
+                        # this may kill the process, needs to run after the above line
+                        loader_p.print_traces_of_all_threads()
+                    else:
+                        err_msg += f'exited with code {loader_p.exitcode}'
+                    if use_workers:
+                        err_msg += '\nWorker(s) info:'
+                        for idx, worker_psutil_p in enumerate(worker_psutil_ps):
+                            err_msg += f'\n\tWorker {idx}:\n\t\t'
+                            if worker_psutil_p.is_running():
+                                err_msg += str(worker_psutil_p.as_dict(attrs=report_psutil_attrs))
+                                # this may kill the process, needs to run after the above line
+                                print_traces_of_all_threads(worker_psutil_p.pid)
+                            else:
+                                err_msg += 'exited with unknown code'
+                    self.fail(err_msg)
+
+                tester_setup_event.set()
+
+                try:
+                    loader_p.join(JOIN_TIMEOUT + MP_STATUS_CHECK_INTERVAL)
+                    if loader_p.is_alive():
+                        fail_reason = 'loader process did not terminate'
+                        if loader_p.exception is not None:
+                            fail(fail_reason + f', and had exception {loader_p.exception}')
+                        else:
+                            fail(fail_reason + ', and had no exception')
+                    _, alive = psutil.wait_procs(worker_psutil_ps, timeout=(MP_STATUS_CHECK_INTERVAL + JOIN_TIMEOUT))
+                    if len(alive) > 0:
+                        fail('worker process (pid(s) {}) did not terminate'.format(
+                            ', '.join(str(p.pid) for p in alive)))
+                    if exit_method is None:
+                        if loader_p.exitcode != 0:
+                            fail(f'loader process had nonzero exitcode {loader_p.exitcode}')
+                    else:
+                        if loader_p.exitcode == 0:
+                            fail('loader process had zero exitcode')
+                        if exit_method == 'loader_error':
+                            if not isinstance(loader_p.exception, RuntimeError) or \
+                                    'Loader error' not in str(loader_p.exception):
+                                fail(f'loader process did not raise expected exception, but had {loader_p.exception}')
+                        elif exit_method == 'worker_kill':
+                            if isinstance(loader_p.exception, RuntimeError):
+                                if 'DataLoader worker (pid' not in str(loader_p.exception):
+                                    fail('loader process did not raise expected exception, but had {}'.format(
+                                        loader_p.exception))
+                            elif isinstance(loader_p.exception, ConnectionRefusedError):
+                                # Sometimes, when the worker is being killed and is freeing its
+                                # resources, the unpickling in loader process will be met an
+                                # a `ConnectionRefusedError` as it can not open a socket to receive
+                                # resource. In such cases, the worker may not have fully exited,
+                                # and the loader can't know this via `is_alive` check or `SIGCHLD`
+                                # handler. So we permit this as an allowed error as well.
+                                # After all, we are happy as long as it terminates.
+                                pass
+                            else:
+                                fail(f'loader process did not raise expected exception, but had {loader_p.exception}')
+                        elif exit_method == 'worker_error':
+                            if not isinstance(loader_p.exception, RuntimeError) or \
+                                    'Worker error' not in str(loader_p.exception):
+                                fail(f'loader process did not raise expected exception, but had {loader_p.exception}')
+                finally:
+                    loader_p.terminate()
+
+    def test_len(self):
+        def check_len(dl, expected):
+            self.assertEqual(len(dl), expected)
+            n = 0
+            for _ in dl:
+                n += 1
+            self.assertEqual(n, expected)
+        check_len(self.dataset, 100)
+        check_len(self._get_data_loader(self.dataset, batch_size=2), 50)
+        check_len(self._get_data_loader(self.dataset, batch_size=3), 34)
+
+    def test_iterabledataset_len(self):
+        class IterableDataset(torch.utils.data.IterableDataset):
+            def __len__(self):
+                return 10
+
+            def __iter__(self):
+                return iter(range(10))
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1)
+        self.assertEqual(len(iterable_loader), 10)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=1, drop_last=True)
+        self.assertEqual(len(iterable_loader), 10)
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2)
+        self.assertEqual(len(iterable_loader), 5)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=2, drop_last=True)
+        self.assertEqual(len(iterable_loader), 5)
+
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3)
+        self.assertEqual(len(iterable_loader), 4)
+        iterable_loader = DataLoader(IterableDataset(), batch_size=3, drop_last=True)
+        self.assertEqual(len(iterable_loader), 3)
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_numpy_scalars(self):
+        import numpy as np
+
+        class ScalarDataset(torch.utils.data.Dataset):
+            def __init__(self, dtype):
+                self.dtype = dtype
+
+            def __getitem__(self, i):
+                return self.dtype()
+
+            def __len__(self):
+                return 4
+
+        dtypes = {
+            np.float64: torch.DoubleTensor,
+            np.float32: torch.FloatTensor,
+            np.float16: torch.HalfTensor,
+            np.int64: torch.LongTensor,
+            np.int32: torch.IntTensor,
+            np.int16: torch.ShortTensor,
+            np.int8: torch.CharTensor,
+            np.uint8: torch.ByteTensor,
+        }
+        for dt, tt in dtypes.items():
+            dset = ScalarDataset(dt)
+            loader = self._get_data_loader(dset, batch_size=2)
+            batch = next(iter(loader))
+            self.assertIsInstance(batch, tt)
+
+    def test_default_convert_mapping_keep_type(self):
+        data = CustomDict({"a": 1, "b": 2})
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, data)
+
+    def test_default_convert_sequence_keep_type(self):
+        data = CustomList([1, 2, 3])
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, data)
+
+    def test_default_convert_sequence_dont_keep_type(self):
+        data = range(2)
+        converted = _utils.collate.default_convert(data)
+
+        self.assertEqual(converted, [0, 1])
+
+    def test_default_collate_dtype(self):
+        arr = [1, 2, -1]
+        collated = _utils.collate.default_collate(arr)
+        self.assertEqual(collated, torch.tensor(arr))
+        self.assertEqual(collated.dtype, torch.int64)
+
+        arr = [1.1, 2.3, -0.9]
+        collated = _utils.collate.default_collate(arr)
+        self.assertEqual(collated, torch.tensor(arr, dtype=torch.float64))
+
+        arr = [True, False]
+        collated = _utils.collate.default_collate(arr)
+        self.assertEqual(collated, torch.tensor(arr))
+        self.assertEqual(collated.dtype, torch.bool)
+
+        # Should be a no-op
+        arr = ['a', 'b', 'c']
+        self.assertEqual(arr, _utils.collate.default_collate(arr))
+
+    def test_default_collate_mapping_keep_type(self):
+        batch = [CustomDict({"a": 1, "b": 2}), CustomDict({"a": 3, "b": 4})]
+        collated = _utils.collate.default_collate(batch)
+
+        expected = CustomDict({"a": torch.tensor([1, 3]), "b": torch.tensor([2, 4])})
+        self.assertEqual(collated, expected)
+
+    def test_default_collate_sequence_keep_type(self):
+        batch = [CustomList([1, 2, 3]), CustomList([4, 5, 6])]
+        collated = _utils.collate.default_collate(batch)
+
+        expected = CustomList([
+            torch.tensor([1, 4]),
+            torch.tensor([2, 5]),
+            torch.tensor([3, 6]),
+        ])
+        self.assertEqual(collated, expected)
+
+    def test_default_collate_sequence_dont_keep_type(self):
+        batch = [range(2), range(2)]
+        collated = _utils.collate.default_collate(batch)
+
+        self.assertEqual(collated, [torch.tensor([0, 0]), torch.tensor([1, 1])])
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_bad_numpy_types(self):
+        import numpy as np
+
+        # Should be a no-op
+        arr = np.array(['a', 'b', 'c'])
+        self.assertEqual(arr, _utils.collate.default_collate(arr))
+
+        arr = np.array([[['a', 'b', 'c']]])
+        self.assertRaises(TypeError, lambda: _utils.collate.default_collate(arr))
+
+        arr = np.array([object(), object(), object()])
+        self.assertRaises(TypeError, lambda: _utils.collate.default_collate(arr))
+
+        arr = np.array([[[object(), object(), object()]]])
+        self.assertRaises(TypeError, lambda: _utils.collate.default_collate(arr))
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_numpy_memmap(self):
+        import numpy as np
+
+        with tempfile.TemporaryFile() as f:
+            arr = np.array([[0, 1], [2, 3], [4, 5], [6, 7]])
+            arr_memmap = np.memmap(f, dtype=arr.dtype, mode='w+', shape=arr.shape)
+            arr_memmap[:] = arr[:]
+            arr_new = np.memmap(f, dtype=arr.dtype, mode='r', shape=arr.shape)
+            tensor = _utils.collate.default_collate(list(arr_new))
+
+        self.assertTrue((tensor == tensor.new_tensor([[0, 1], [2, 3], [4, 5], [6, 7]])).all().item())
+
+    def test_default_collate_bad_sequence_type(self):
+        batch = [['X'], ['X', 'X']]
+        self.assertRaises(RuntimeError, lambda: _utils.collate.default_collate(batch))
+        self.assertRaises(RuntimeError, lambda: _utils.collate.default_collate(batch[::-1]))
+
+    @unittest.skipIf(not TEST_NUMPY, "numpy unavailable")
+    def test_default_collate_shared_tensor(self):
+        import numpy as np
+        t_in = torch.zeros(1)
+        n_in = np.zeros(1)
+
+        self.assertEqual(t_in.is_shared(), False)
+
+        self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), False)
+        self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), False)
+
+        # FIXME: fix the following hack that makes `default_collate` believe
+        #        that it is in a worker process (since it tests
+        #        `get_worker_info() != None`), even though it is not.
+        old = _utils.worker._worker_info
+        try:
+            _utils.worker._worker_info = 'x'
+            self.assertEqual(_utils.collate.default_collate([t_in]).is_shared(), True)
+            self.assertEqual(_utils.collate.default_collate([n_in]).is_shared(), True)
+        finally:
+            _utils.worker._worker_info = old
+
+    def test_excessive_thread_creation_warning(self):
+        with self.assertWarnsRegex(
+            UserWarning,
+                r"excessive worker creation might get DataLoader running slow or even freeze"):
+            dataloader = DataLoader(self.dataset, batch_size=2, num_workers=1000)
+
+
+class TestDataLoaderDeviceType(TestCase):
+    @parametrize("context", [ctx for ctx in supported_multiprocessing_contexts if ctx is not None])
+    def test_nested_tensor_multiprocessing(self, device, context):
+        # The 'fork' multiprocessing context doesn't work for CUDA so skip it
+        if 'cuda' in device and context == "fork":
+            # TODO: Skip this better in a better way when the test framework allows
+            return
+
+        dataset = [torch.nested.nested_tensor([torch.randn(5)], device=device) for _ in range(10)]
+
+        pin_memory_settings = [False]
+        if device == 'cpu' and torch.cuda.is_available():
+            pin_memory_settings.append(True)
+
+        for pin_memory in pin_memory_settings:
+            loader = DataLoader(
+                dataset,
+                batch_size=1,
+                num_workers=4,
+                collate_fn=_clone_collate,
+                pin_memory=pin_memory,
+                multiprocessing_context=context,
+            )
+
+            for i, batch in enumerate(loader):
+                self.assertEqual(batch[0], dataset[i])
+
+        # Error case: default collate_fn doesn't currently support batches of nested tensors.
+        # Following the current semantics, we'd need to stack them, which isn't possible atm.
+        with self.assertRaisesRegex(
+                RuntimeError, "not currently supported by the default collate_fn"):
+            loader = DataLoader(
+                dataset,
+                batch_size=1,
+                num_workers=4,
+                multiprocessing_context=context,
+            )
+
+            next(iter(loader))
+
+
+class IntegrationTestDataLoaderDataPipe(TestCase):
+    r"""
+    Verify the behavior of a certain ``DataPipes`` with ``DataLoader``
+    """
+
+    def test_shuffler_iterdatapipe(self):
+        r"""
+        Verify ``IterDataPipe.shuffle`` is controlled by ``DataLoader``
+        to generate different seeds deterministically per epoch.
+        """
+        exp = list(range(100))
+
+        def _create_dp(buffer_size):
+            input_ds = dp.iter.IterableWrapper(exp)
+            return input_ds.shuffle(buffer_size=buffer_size).sharding_filter()
+
+        for bs in (5, 20, 33):
+            # Test Deterministic
+            for num_workers, pw in itertools.product((0, 1, 2), (True, False)):
+                if num_workers == 0 and pw:
+                    continue
+
+                shuffle_dp = _create_dp(bs)
+
+                mp_ctx = "spawn" if num_workers > 0 else None
+                dl = DataLoader(
+                    shuffle_dp,
+                    num_workers=num_workers,
+                    shuffle=True,
+                    multiprocessing_context=mp_ctx,
+                    persistent_workers=pw
+                )
+
+                # No seed
+                dl_res_ns = list(dl)
+                self.assertEqual(sorted(dl_res_ns), exp)
+
+                # Same seeds
+                dl_res = []
+                for epoch in range(2):
+                    torch.manual_seed(123)
+                    dl_res.append(list(dl))
+                self.assertEqual(dl_res[0], dl_res[1])
+                self.assertEqual(sorted(dl_res[0]), exp)
+
+                # Different seeds
+                torch.manual_seed(321)
+                dl_res.append(list(dl))
+
+                self.assertEqual(len(dl_res[0]), len(dl_res[2]))
+                self.assertNotEqual(dl_res[0], dl_res[2])
+                self.assertEqual(sorted(dl_res[0]), sorted(dl_res[2]))
+
+                if dl._iterator is not None:
+                    dl._iterator._shutdown_workers()
+                    dl._iterator = None
+                del dl
+
+
+class StringDataset(Dataset):
+    def __init__(self):
+        self.s = '12345'
+
+    def __len__(self):
+        return len(self.s)
+
+    def __getitem__(self, ndx):
+        return (self.s[ndx], ndx)
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestStringDataLoader(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset = StringDataset()
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_shuffle_pin_memory(self):
+        loader = DataLoader(self.dataset, batch_size=2, shuffle=True, num_workers=4, pin_memory=True)
+        for (s, n) in loader:
+            self.assertIsInstance(s[0], str)
+            self.assertTrue(n.is_pinned())
+
+
+class DictDataset(Dataset):
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, ndx):
+        return {
+            'a_tensor': torch.empty(4, 2).fill_(ndx),
+            'another_dict': {
+                'a_number': ndx,
+            },
+        }
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestDictDataLoader(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset = DictDataset()
+
+    def test_sequential_batch(self):
+        for persistent_workers in (False, True):
+            if persistent_workers:
+                loader = DataLoader(self.dataset, batch_size=2, shuffle=False,
+                                    persistent_workers=persistent_workers, num_workers=1)
+            else:
+                loader = DataLoader(self.dataset, batch_size=2, shuffle=False,
+                                    persistent_workers=persistent_workers)
+            batch_size = loader.batch_size
+            for i, sample in enumerate(loader):
+                idx = i * batch_size
+                self.assertEqual(set(sample.keys()), {'a_tensor', 'another_dict'})
+                self.assertEqual(set(sample['another_dict'].keys()), {'a_number'})
+
+                t = sample['a_tensor']
+                self.assertEqual(t.size(), torch.Size([batch_size, 4, 2]))
+                self.assertTrue((t[0] == idx).all())
+                self.assertTrue((t[1] == idx + 1).all())
+
+                n = sample['another_dict']['a_number']
+                self.assertEqual(n.size(), torch.Size([batch_size]))
+                self.assertEqual(n[0], idx)
+                self.assertEqual(n[1], idx + 1)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_pin_memory(self):
+        loader = DataLoader(self.dataset, batch_size=2, pin_memory=True)
+        for sample in loader:
+            self.assertTrue(sample['a_tensor'].is_pinned())
+            self.assertTrue(sample['another_dict']['a_number'].is_pinned())
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_pin_memory_device(self):
+        loader = DataLoader(self.dataset, batch_size=2, pin_memory=True, pin_memory_device='cuda')
+        for sample in loader:
+            self.assertTrue(sample['a_tensor'].is_pinned(device='cuda'))
+            self.assertTrue(sample['another_dict']['a_number'].is_pinned(device='cuda'))
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_pin_memory_with_only_device(self):
+        loader = DataLoader(self.dataset, batch_size=2, pin_memory_device='cuda')
+        for sample in loader:
+            self.assertFalse(sample['a_tensor'].is_pinned(device='cuda'))
+            self.assertFalse(sample['another_dict']['a_number'].is_pinned(device='cuda'))
+
+class DummyDataset(torch.utils.data.Dataset):
+    def __init__(self):
+        self.data = list(range(10))
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        if torch.is_tensor(idx):
+            idx = idx.tolist()
+        # The persistent workers always maintain the original
+        # dataset through the dataloader lifetime
+        # so the attributes will remain the same as the
+        # first time the workers where spawned (dataloader iteration)
+        assert self.start == 0
+        return self.data[idx]
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN, "DataLoader tests hang in ASAN, see: https://github.com/pytorch/pytorch/issues/66223")
+class TestDataLoaderPersistentWorkers(TestDataLoader):
+
+    def setUp(self):
+        super().setUp()
+        self.persistent_workers = True
+
+    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @unittest.skipIf(IS_WINDOWS, "No 'resource' module on Windows")
+    def test_fd_limit_exceeded(self):
+        # See NOTE [ DataLoader on Linux and open files limit ]
+        import subprocess
+        subprocess.check_output([sys.executable, '-c', """\
+import torch
+import resource
+from torch.utils.data import IterableDataset
+from torchdata.stateful_dataloader import StatefulDataLoader as DataLoader
+
+class RandomDataset(IterableDataset):
+    def __init__(self, len, size):
+        super(RandomDataset).__init__()
+        self.len = len
+        self.size = size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.len <= 0:
+            raise StopIteration
+        self.len -= 1
+        return torch.randn(self.size)
+
+try:
+    keep_fds_alive = []
+    resource.setrlimit(resource.RLIMIT_NOFILE, (100, 100))
+    for random_t in DataLoader(RandomDataset(200, (2,2)), multiprocessing_context="fork",
+                               num_workers=1, persistent_workers=True):
+      random_t.max(dim=0)
+      keep_fds_alive.append(random_t)
+except RuntimeError as e:
+    assert "ulimit -n" in str(e)
+    assert "set_sharing_strategy" in str(e)
+"""])
+
+    def test_dataset_not_reset(self):
+        dataset = DummyDataset()
+        pin_memory_configs = [False]
+        if TEST_CUDA:
+            pin_memory_configs.append(True)
+        for pin_memory in pin_memory_configs:
+            dataloader = self._get_data_loader(dataset, num_workers=2, pin_memory=pin_memory)
+            dataset.start = 0
+            for i in range(10):
+                for x in dataloader:
+                    pass
+                # Changing the start value here doesn't have any effect in the dataset
+                # cached by the workers. since they are not recreated between epochs
+                # and can cache values safely
+                dataset.start = i
+
+    @unittest.skipIf(IS_SANDCASTLE, "subprocess doesn't work in FB internal CI")
+    @unittest.skipIf(IS_WINDOWS, "Needs fork")
+    def test_early_exit(self):
+        import subprocess
+        proc = subprocess.check_output([sys.executable, '-c', """\
+import torch
+from torch.utils.data import IterableDataset
+from torchdata.stateful_dataloader import StatefulDataLoader as DataLoader
+
+class RandomDataset(IterableDataset):
+    def __init__(self, len, size):
+        super(RandomDataset).__init__()
+        self.len = len
+        self.size = size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.len <= 0:
+            raise StopIteration
+        self.len -= 1
+        return torch.randn(self.size)
+
+if __name__ == '__main__':
+    dl = DataLoader(
+        RandomDataset(64, (28, 28)),
+        batch_size=16,
+        num_workers=2,
+        pin_memory=True,
+        persistent_workers=True,
+        multiprocessing_context="fork",
+    )
+
+    for _ in dl:
+        break
+"""])
+
+
+class NamedTupleDataset(Dataset):
+    from collections import namedtuple
+    Batch = namedtuple('Batch', ['data', 'label', 'random_tensor'])
+    Data = namedtuple('Data', ['positive', 'negative'])
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, ndx):
+        return self.Batch(data=self.Data(positive=ndx, negative=-ndx),
+                          label=str(ndx), random_tensor=torch.randn(3))
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestNamedTupleDataLoader(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset = NamedTupleDataset()
+
+    def test_dataloader_with_namedtuple(self):
+        # auto-collation
+        loader = DataLoader(self.dataset, batch_size=2, pin_memory=TEST_CUDA)
+        for batch in loader:
+            self.assertIsInstance(batch, NamedTupleDataset.Batch)
+            self.assertEqual(batch.random_tensor.is_pinned(), TEST_CUDA)
+            self.assertIsInstance(batch.data, NamedTupleDataset.Data)
+            self.assertIsInstance(batch.data.positive, torch.Tensor)
+            self.assertEqual(batch.data.positive.is_pinned(), TEST_CUDA)
+        # no auto-collation
+        loader = DataLoader(self.dataset, batch_size=None, pin_memory=TEST_CUDA)
+        for batch in loader:
+            self.assertIsInstance(batch, NamedTupleDataset.Batch)
+            self.assertEqual(batch.random_tensor.is_pinned(), TEST_CUDA)
+            self.assertIsInstance(batch.data, NamedTupleDataset.Data)
+            self.assertNotIsInstance(batch.data.positive, torch.Tensor)
+
+class SimpleCustomBatch:
+    def __init__(self, data):
+        transposed_data = list(zip(*data))
+        self.inp = torch.stack(transposed_data[0], 0)
+        self.tgt = torch.stack(transposed_data[1], 0)
+
+    def pin_memory(self):
+        self.inp = self.inp.pin_memory()
+        self.tgt = self.tgt.pin_memory()
+        return self
+
+    def is_pinned(self):
+        return self.inp.is_pinned() and self.tgt.is_pinned()
+
+# Workaround for https://github.com/pytorch/pytorch/issues/50661
+# Classes from  `__main__` can not be correctly unpickled from spawned module
+# See https://docs.python.org/3/library/multiprocessing.html#multiprocessing-programming
+self_module = __import__(os.path.splitext(os.path.basename(__file__))[0])
+
+def collate_wrapper(batch):
+    return self_module.SimpleCustomBatch(batch)
+
+
+def collate_into_packed_sequence(batch):
+    data = torch.stack([sample[0] for sample in batch], 1)
+    t, b = data.size()
+    lengths = torch.randint(1, t, size=(b,), dtype=torch.int64)
+    return torch.nn.utils.rnn.pack_padded_sequence(data, lengths, enforce_sorted=False)
+
+
+def collate_into_packed_sequence_batch_first(batch):
+    data = torch.stack([sample[0] for sample in batch], 0)
+    b, t = data.size()
+    lengths = torch.randint(1, t, size=(b,), dtype=torch.int64)
+    return torch.nn.utils.rnn.pack_padded_sequence(data, lengths, batch_first=True, enforce_sorted=False)
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+class TestCustomPinFn(TestCase):
+    def setUp(self):
+        super().setUp()
+        inps = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+        tgts = torch.arange(10 * 5, dtype=torch.float32).view(10, 5)
+        self.dataset = TensorDataset(inps, tgts)
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_custom_batch_pin(self):
+        test_cases = [
+            (collate_wrapper, self_module.SimpleCustomBatch),
+            (collate_into_packed_sequence, torch.nn.utils.rnn.PackedSequence),
+            (collate_into_packed_sequence_batch_first, torch.nn.utils.rnn.PackedSequence),
+        ]
+        for collate_fn, elem_cls in test_cases:
+            loader = DataLoader(self.dataset, batch_size=2, collate_fn=collate_fn,
+                                pin_memory=True)
+            for sample in loader:
+                self.assertIsInstance(sample, elem_cls)
+                self.assertTrue(sample.is_pinned())
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    def test_custom_batch_pin_worker(self):
+        test_cases = [
+            (collate_wrapper, self_module.SimpleCustomBatch),
+            (collate_into_packed_sequence, torch.nn.utils.rnn.PackedSequence),
+            (collate_into_packed_sequence_batch_first, torch.nn.utils.rnn.PackedSequence),
+        ]
+        for collate_fn, elem_cls in test_cases:
+            loader = DataLoader(self.dataset, batch_size=2, collate_fn=collate_fn,
+                                pin_memory=True, num_workers=1)
+            for sample in loader:
+                self.assertIsInstance(sample, elem_cls)
+                self.assertTrue(sample.is_pinned())
+
+
+class TestWorkerQueueDataset(Dataset):
+    def __init__(self, data):
+        self.data = data
+        self.worker_id = None
+
+    def worker_init_fn(self, worker_id):
+        self.worker_id = worker_id
+
+    def __getitem__(self, item):
+        return self.worker_id, self.data[item]
+
+    def __len__(self):
+        return len(self.data)
+
+
+@unittest.skipIf(
+    TEST_WITH_TSAN,
+    "Fails with TSAN with the following error: starting new threads after multi-threaded "
+    "fork is not supported. Dying (set die_after_fork=0 to override)")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "Flaky with ASAN, see https://github.com/pytorch/pytorch/issues/65727")
+class TestIndividualWorkerQueue(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.dataset = TestWorkerQueueDataset(list(range(128)))
+
+    def _run_ind_worker_queue_test(self, batch_size, num_workers):
+        loader = DataLoader(
+            self.dataset, batch_size=batch_size, shuffle=False, num_workers=num_workers,
+            timeout=5, worker_init_fn=self.dataset.worker_init_fn
+        )
+        current_worker_idx = 0
+        for i, (worker_ids, sample) in enumerate(loader):
+            self.assertEqual(worker_ids.tolist(), [current_worker_idx] * batch_size)
+            self.assertEqual(sample.tolist(), list(range(i * batch_size, (i + 1) * batch_size)))
+            current_worker_idx += 1
+            if current_worker_idx == num_workers:
+                current_worker_idx = 0
+
+    def test_ind_worker_queue(self):
+        max_num_workers = None
+        if hasattr(os, 'sched_getaffinity'):
+            try:
+                max_num_workers = len(os.sched_getaffinity(0))
+            except Exception:
+                pass
+        if max_num_workers is None:
+            cpu_count = os.cpu_count()
+            if cpu_count is not None:
+                # Use half number of CPUs
+                max_num_workers = cpu_count // 2
+
+        if max_num_workers is None:
+            max_num_workers = 1
+
+        for batch_size in (8, 16, 32, 64):
+            for num_workers in range(0, min(6, max_num_workers)):
+                self._run_ind_worker_queue_test(batch_size=batch_size, num_workers=num_workers + 1)
+
+
+class SetAffinityDataset(IterableDataset):
+
+    def __iter__(self):
+        torch.randperm(1)
+        after = os.sched_getaffinity(0)
+        return iter(after)
+
+@unittest.skipIf(
+    not hasattr(os, 'sched_setaffinity'),
+    "os.sched_setaffinity is not available")
+class TestSetAffinity(TestCase):
+    def test_set_affinity_in_worker_init(self):
+        # Query the current affinity mask to avoid setting a disallowed one
+        old_affinity = os.sched_getaffinity(0)
+        if not old_affinity:
+            self.skipTest("No affinity information")
+        # Choose any
+        expected_affinity = list(old_affinity)[-1]
+
+        def worker_set_affinity(_):
+            os.sched_setaffinity(0, [expected_affinity])
+
+
+        dataset = SetAffinityDataset()
+
+        dataloader = DataLoader(
+            dataset, num_workers=2, worker_init_fn=worker_set_affinity)
+        for sample in dataloader:
+            self.assertEqual(sample, [expected_affinity])
+
+class ConvDataset(Dataset):
+    def __init__(self):
+        self.x = torch.ones(1, 1, 24000)
+        # Call convolution on parent process
+        self[0]
+
+    def __len__(self):
+        return 1
+
+    def __getitem__(self, index):
+        return torch.nn.functional.conv1d(self.x, torch.ones(1, 1, 2))
+
+
+@unittest.skipIf(IS_WINDOWS, "Needs fork")
+@unittest.skipIf(
+    TEST_WITH_ASAN,
+    "This test hangs when running with ASAN, see https://github.com/pytorch/pytorch/issues/75492")
+class TestConvAfterFork(TestCase):
+    # Tests crash reported in https://github.com/pytorch/pytorch/issues/53565
+    def test_conv_after_fork(self):
+        loader = DataLoader(ConvDataset(), num_workers=1)
+        for x in loader:
+            self.assertEqual(x.shape, (1, 1, 1, 23999))
+
+
+instantiate_device_type_tests(TestDataLoaderDeviceType, globals())
+
+
+if __name__ == '__main__':
+    run_tests()

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -1669,7 +1669,6 @@ except RuntimeError as e:
     def test_multiprocessing_iterdatapipe(self):
         self._test_multiprocessing_iterdatapipe(with_dill=False)
 
-    @unittest.expectedFailure
     @skipIfNoNumpy
     @unittest.skipIf(IS_JETSON, "Not working on Jetson")
     @skipIfNoDill

--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -24,7 +24,6 @@ from torch.utils.data import (
     TensorDataset,
     StackDataset,
     _utils,
-    # DataLoader,
 )
 from torchdata.stateful_dataloader import StatefulDataLoader as DataLoader
 from torch.utils.data._utils import MP_STATUS_CHECK_INTERVAL
@@ -2390,7 +2389,6 @@ class IntegrationTestDataLoaderDataPipe(TestCase):
     Verify the behavior of a certain ``DataPipes`` with ``DataLoader``
     """
 
-    @unittest.skip
     def test_shuffler_iterdatapipe(self):
         r"""
         Verify ``IterDataPipe.shuffle`` is controlled by ``DataLoader``

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -47,25 +47,20 @@ class DummyIterableDataset(torch.utils.data.IterableDataset):
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
         if worker_info:
-            num_workers = worker_info.num_workers
             worker_id = worker_info.id
         else:
-            num_workers = 1
             worker_id = 0
             self.sizes_for_all_workers = [sum(self.sizes_for_all_workers)]
 
         start = sum(self.sizes_for_all_workers[:worker_id])
-        iter_data = list(range(start, start+self.sizes_for_all_workers[worker_id]))
+        iter_data = list(range(start, start + self.sizes_for_all_workers[worker_id]))
         return DummyIterator(iter_data, self.shuffle)
 
 
 class DummyMapDataset(torch.utils.data.Dataset):
     def __init__(self, size, shuffle):
         self.size = size
-        self.data = [
-            {"id": i, "strcol": f"strcol_{i}", "listcol": [i, i + 1, i + 2]}
-            for i in range(size)
-        ]
+        self.data = [{"id": i, "strcol": f"strcol_{i}", "listcol": [i, i + 1, i + 2]} for i in range(size)]
         self.shuffle = shuffle
         self.g = torch.Generator()
         self.g.manual_seed(1)
@@ -92,9 +87,7 @@ def identity(x):
 
 
 class TestStatefulDataLoaderIterable(unittest.TestCase):
-    def _run_and_checkpoint(
-        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
-    ):
+    def _run_and_checkpoint(self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False):
         dataset = DummyIterableDataset([0, 100, 37], shuffle=shuffle)
         dl = StatefulDataLoader(
             dataset=dataset,
@@ -105,7 +98,7 @@ class TestStatefulDataLoaderIterable(unittest.TestCase):
         )
         exp = list(dl)
 
-        if interrupt == None:
+        if interrupt is None:
             interrupt = len(exp)
 
         batches = []
@@ -164,9 +157,7 @@ class TestStatefulDataLoaderIterable(unittest.TestCase):
     def test_mp_every_n_steps(self):
         batch_size = 7
         for every_n_steps, interrupt in itertools.product([2, 5], [0, 1, 10]):
-            with self.subTest(
-                every_n_steps=every_n_steps, batch_size=batch_size, interrupt=interrupt
-            ):
+            with self.subTest(every_n_steps=every_n_steps, batch_size=batch_size, interrupt=interrupt):
                 self._run_and_checkpoint(
                     num_workers=3,
                     batch_size=batch_size,
@@ -185,10 +176,9 @@ class TestStatefulDataLoaderIterable(unittest.TestCase):
                     shuffle=True,
                 )
 
+
 class TestStatefulDataLoaderMap(TestStatefulDataLoaderIterable):
-    def _run_and_checkpoint(
-        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
-    ):
+    def _run_and_checkpoint(self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False):
         if num_workers == 0:
             return
         dataset = DummyMapDataset(100, shuffle=shuffle)
@@ -205,7 +195,7 @@ class TestStatefulDataLoaderMap(TestStatefulDataLoaderIterable):
             sampler=sampler,
         )
 
-        if interrupt == None:
+        if interrupt is None:
             interrupt = len(dl)
 
         it = iter(dl)
@@ -248,10 +238,8 @@ class GeneratorIterable(torch.utils.data.IterableDataset):
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
         if worker_info:
-            num_workers = worker_info.num_workers
             worker_id = worker_info.id
         else:
-            num_workers = 1
             worker_id = 0
             self.sizes_for_all_workers = [sum(self.sizes_for_all_workers)]
         self.i = 0
@@ -260,7 +248,7 @@ class GeneratorIterable(torch.utils.data.IterableDataset):
             self.resume = None
         start = sum(self.sizes_for_all_workers[:worker_id])
         skip = self.i
-        for i in range(start+skip, start+self.sizes_for_all_workers[worker_id]):
+        for i in range(start + skip, start + self.sizes_for_all_workers[worker_id]):
             self.i += 1
             yield i
         # self.i = 0
@@ -273,9 +261,7 @@ class GeneratorIterable(torch.utils.data.IterableDataset):
 
 
 class TestStatefulDataLoaderGenerator(TestStatefulDataLoaderIterable):
-    def _run_and_checkpoint(
-        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
-    ):
+    def _run_and_checkpoint(self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False):
         dataset = GeneratorIterable([0, 100, 37])
         dl = StatefulDataLoader(
             dataset=dataset,
@@ -286,7 +272,7 @@ class TestStatefulDataLoaderGenerator(TestStatefulDataLoaderIterable):
         )
         exp = list(dl)
 
-        if interrupt == None:
+        if interrupt is None:
             interrupt = len(exp)
 
         dataset = GeneratorIterable([0, 100, 37])
@@ -322,7 +308,6 @@ class TestStatefulDataLoaderGenerator(TestStatefulDataLoaderIterable):
 
 
 class TestSnapshotZero(unittest.TestCase):
-
     def test_generator(self):
         num_workers = 3
         every_n_steps = 10
@@ -414,7 +399,6 @@ class TestSnapshotZero(unittest.TestCase):
 
 
 class TestSnapshotEnd(unittest.TestCase):
-
     def test_generator(self):
         num_workers = 3
         every_n_steps = 10

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1,0 +1,260 @@
+import itertools
+import unittest
+from typing import Iterator
+
+import torch
+
+from torchdata.stateful_dataloader import Stateful, StatefulDataLoader
+
+
+class DummyIterator(Iterator, Stateful):
+    def __init__(self, samples):
+        self.samples = samples
+        self.i = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i >= len(self.samples):
+            raise StopIteration
+        sample = self.samples[self.i]
+        self.i += 1
+        return sample
+
+    def state_dict(self):
+        return {"i": self.i}
+
+    def load_state_dict(self, state_dict):
+        self.i = state_dict["i"]
+
+
+class DummyIterableDataset(torch.utils.data.IterableDataset):
+    def __init__(self, start_row_pairs):
+        self.shards = []
+        for start, num_rows in start_row_pairs:
+            samples = []
+            for i in range(start, start + num_rows):
+                samples.append(
+                    {
+                        "id": i,
+                        "strcol": f"strcol_{i}",
+                        "floatcol": i + 0.1,
+                        "listcol": [i, i + 1, i + 2],
+                    }
+                )
+
+            self.shards.append(samples)
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info:
+            num_workers = worker_info.num_workers
+            worker_id = worker_info.id
+        else:
+            num_workers = 1
+            worker_id = 0
+
+        iter_data = []
+        for shard in self.shards[worker_id : len(self.shards) : num_workers]:
+            iter_data.extend(shard)
+        return DummyIterator(iter_data)
+
+
+def identity(x):
+    return x
+
+
+class TestStatefulDataLoader(unittest.TestCase):
+    # @pytest.mark.parametrize("num_workers", [0, 3])
+    # @pytest.mark.parametrize("batch_size", [None, 7])
+    # @pytest.mark.parametrize("pw", [False, True])
+    # @pytest.mark.parametrize("interrupt", [0, 1, 10, None])
+    # @pytest.mark.parametrize("iter_state", [False, True])
+    def test_single_shard(self):
+        for num_workers, batch_size, pw, interrupt, iter_state in itertools.product(
+            [0, 3],  # num_workers
+            [None, 7],  # batch_size
+            [False, True],  # pw
+            [0, 1, 10, None],  # interrupt
+            [False, True],  # iter_state
+        ):
+            with self.subTest(
+                num_workers=num_workers, batch_size=batch_size, pw=pw, interrupt=interrupt, iter_state=iter_state
+            ):
+                if num_workers == 0 and pw:
+                    continue
+                if not iter_state:
+                    continue
+                dataset = DummyIterableDataset([(0, 100)])
+                dl = StatefulDataLoader(dataset=dataset, num_workers=num_workers, collate_fn=identity)
+                exp = list(dl)
+
+                if interrupt == None:
+                    interrupt = len(exp)
+
+                batches = []
+                it = iter(dl) if iter_state else dl
+                for i in range(interrupt):
+                    batches.append(next(it))
+                state_dict = it.state_dict()
+                self.assertEqual(batches, exp[:interrupt])
+
+                # Restore new instance from state
+                dl = StatefulDataLoader(dataset=dataset, num_workers=num_workers, collate_fn=identity)
+                it = iter(dl) if iter_state else dl
+                it.load_state_dict(state_dict)
+                for batch in it:
+                    batches.append(batch)
+
+                self.assertEqual(batches, exp)
+
+    # @parameterized.expand(
+    #     [
+    #         20,
+    #         10000,
+    #     ]
+    # )
+    # def test_multiworker(self, num_rows):
+    #     pairs = []
+    #     worker_rows = num_rows // 4
+    #     for i in range(4):
+    #         pairs.append((i * worker_rows, worker_rows))
+
+    #     ds = DummyDataset(pairs)
+    #     # Check dataloader inline
+    #     dl = StatefulDataLoader(dataset=ds, batch_size=4)
+    #     for i, batch in enumerate(dl):
+    #         exp_ids = [i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]
+    #         try:
+    #             # Handle truncated last batch
+    #             exp_ids = exp_ids[: exp_ids.index(num_rows)]
+    #         except ValueError:
+    #             pass
+
+    #         batch = rows_to_dict([json.loads(line) for line in batch])
+    #         self.assertEqual(set(batch.keys()), {"id", "strcol", "floatcol", "listcol"})
+    #         self.assertEqual(batch["id"], exp_ids)
+    #         self.assertEqual(batch["strcol"], [f"strcol_{j}" for j in exp_ids])
+    #         self.assertEqual(batch["floatcol"], [j + 0.1 for j in exp_ids])
+    #         self.assertEqual(
+    #             batch["listcol"],
+    #             [[j, j + 1, j + 2] for j in exp_ids],
+    #         )
+
+    #     dl = StatefulDataLoader(dataset=ds, batch_size=4, num_workers=4)
+    #     for i, batch in enumerate(dl):
+    #         worker = i % 4
+    #         base_id = worker * worker_rows + (i // 4) * 4
+    #         exp_ids = [
+    #             base_id,
+    #             base_id + 1,
+    #             base_id + 2,
+    #             base_id + 3,
+    #         ]
+    #         try:
+    #             # Handle truncated last batch
+    #             cutoff = exp_ids.index((worker + 1) * worker_rows)
+    #             exp_ids = exp_ids[:cutoff]
+    #         except ValueError:
+    #             pass
+
+    #         batch = rows_to_dict([json.loads(line) for line in batch])
+    #         self.assertEqual(set(batch.keys()), {"id", "strcol", "floatcol", "listcol"})
+    #         self.assertEqual(batch["id"], exp_ids, (i, base_id, worker_rows))
+    #         self.assertEqual(batch["strcol"], [f"strcol_{j}" for j in exp_ids])
+    #         self.assertEqual(batch["floatcol"], [j + 0.1 for j in exp_ids])
+    #         self.assertEqual(
+    #             batch["listcol"],
+    #             [[j, j + 1, j + 2] for j in exp_ids],
+    #         )
+
+    # @parameterized.expand(
+    #     list(
+    #         itertools.product(
+    #             [0, 1, 4],  # num_workers
+    #             [2, 10],  # interrupt
+    #             [False, True],  # iter_state
+    #             [False, True],  # persistent_workers
+    #         )
+    #     )
+    # )
+    # def test_state(self, num_workers, interrupt, iter_state, persistent_workers):
+    #     if persistent_workers and num_workers == 0:
+    #         return
+    #     num_rows = 1000
+    #     pairs = []
+    #     worker_rows = num_rows // 4
+    #     for i in range(4):
+    #         pairs.append((i * worker_rows, worker_rows))
+
+    #     ds = DummyDataset(pairs)
+
+    #     dl = StatefulDataLoader(
+    #         dataset=ds,
+    #         batch_size=4,
+    #         num_workers=num_workers,
+    #         persistent_workers=persistent_workers,
+    #     )
+    #     exp_result = []
+    #     for batch in dl:
+    #         exp_result.append([json.loads(x) for x in batch])
+
+    #     dl = StatefulDataLoader(
+    #         dataset=ds,
+    #         batch_size=4,
+    #         num_workers=num_workers,
+    #         persistent_workers=persistent_workers,
+    #     )
+    #     it = iter(dl)
+    #     result = []
+    #     for _ in range(interrupt):
+    #         batch = next(it)
+    #         result.append([json.loads(x) for x in batch])
+    #     if iter_state:
+    #         state_dict = it.state_dict()
+    #     else:
+    #         state_dict = dl.state_dict()
+    #     partial_result = copy.deepcopy(result)
+
+    #     # Test with new dataloader instance
+    #     dl = StatefulDataLoader(
+    #         dataset=ds,
+    #         batch_size=4,
+    #         num_workers=num_workers,
+    #         persistent_workers=persistent_workers,
+    #     )
+    #     if iter_state:
+    #         it = iter(dl)
+    #         it.load_state_dict(state_dict)
+    #     else:
+    #         dl.load_state_dict(state_dict)
+    #         it = iter(dl)
+    #     for batch in it:
+    #         result.append([json.loads(x) for x in batch])
+    #     self.assertEqual(result, exp_result)
+
+    #     # Test fresh start with new iterator
+    #     result = []
+    #     for batch in dl:
+    #         result.append([json.loads(x) for x in batch])
+    #     self.assertEqual(result, exp_result)
+
+    #     # Try with new instance of dataset
+    #     ds = DummyDataset(pairs)
+    #     dl = StatefulDataLoader(
+    #         dataset=ds,
+    #         batch_size=4,
+    #         num_workers=num_workers,
+    #         persistent_workers=persistent_workers,
+    #     )
+    #     result = copy.deepcopy(partial_result)
+    #     if iter_state:
+    #         it = iter(dl)
+    #         it.load_state_dict(state_dict)
+    #     else:
+    #         dl.load_state_dict(state_dict)
+    #         it = iter(dl)
+    #     for batch in it:
+    #         result.append([json.loads(x) for x in batch])
+    #     self.assertEqual(result, exp_result)

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -65,6 +65,20 @@ class DummyMapDataset(torch.utils.data.Dataset):
         self.g = torch.Generator()
         self.g.manual_seed(1)
 
+    def __getstate__(self):
+        """pickling generators fails on windows and mac, this makes sure
+        unit tests can proceed on those platforms
+        """
+        state = dict(self.__dict__)
+        del state["g"]
+        state["g_state"] = self.g.get_state()
+
+    def __setstate__(self, state):
+        g_state = state.pop("g_state")
+        self.__dict__ = state
+        self.g = torch.Generator()
+        self.g.set_state(g_state)
+
     def __len__(self):
         return self.size
 

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import unittest
 from typing import Iterator
@@ -8,8 +9,12 @@ from torchdata.stateful_dataloader import Stateful, StatefulDataLoader
 
 
 class DummyIterator(Iterator, Stateful):
-    def __init__(self, samples):
+    def __init__(self, samples, shuffle):
         self.samples = samples
+        self.shuffle = shuffle
+        self.g = torch.Generator()
+        self.g.manual_seed(1)
+        self.size = len(self.samples)
         self.i = 0
 
     def __iter__(self):
@@ -18,33 +23,26 @@ class DummyIterator(Iterator, Stateful):
     def __next__(self):
         if self.i >= len(self.samples):
             raise StopIteration
-        sample = self.samples[self.i]
+        if self.shuffle:
+            i = torch.randint(self.size, (1,), generator=self.g).item()
+        else:
+            i = self.i
+        sample = self.samples[i]
         self.i += 1
         return sample
 
     def state_dict(self):
-        return {"i": self.i}
+        return {"i": self.i, "g": self.g.get_state()}
 
     def load_state_dict(self, state_dict):
         self.i = state_dict["i"]
+        self.g.set_state(state_dict["g"])
 
 
 class DummyIterableDataset(torch.utils.data.IterableDataset):
-    def __init__(self, start_row_pairs):
-        self.shards = []
-        for start, num_rows in start_row_pairs:
-            samples = []
-            for i in range(start, start + num_rows):
-                samples.append(
-                    {
-                        "id": i,
-                        "strcol": f"strcol_{i}",
-                        "floatcol": i + 0.1,
-                        "listcol": [i, i + 1, i + 2],
-                    }
-                )
-
-            self.shards.append(samples)
+    def __init__(self, sizes_for_all_workers, shuffle=False):
+        self.sizes_for_all_workers = sizes_for_all_workers
+        self.shuffle = shuffle
 
     def __iter__(self):
         worker_info = torch.utils.data.get_worker_info()
@@ -54,212 +52,269 @@ class DummyIterableDataset(torch.utils.data.IterableDataset):
         else:
             num_workers = 1
             worker_id = 0
+            self.sizes_for_all_workers = [sum(self.sizes_for_all_workers)]
 
-        iter_data = []
-        for shard in self.shards[worker_id : len(self.shards) : num_workers]:
-            iter_data.extend(shard)
-        return DummyIterator(iter_data)
+        start = sum(self.sizes_for_all_workers[:worker_id])
+        iter_data = list(range(start, start+self.sizes_for_all_workers[worker_id]))
+        return DummyIterator(iter_data, self.shuffle)
+
+
+class DummyMapDataset(torch.utils.data.Dataset):
+    def __init__(self, size, shuffle):
+        self.size = size
+        self.data = [
+            {"id": i, "strcol": f"strcol_{i}", "listcol": [i, i + 1, i + 2]}
+            for i in range(size)
+        ]
+        self.shuffle = shuffle
+        self.g = torch.Generator()
+        self.g.manual_seed(1)
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, i):
+        if self.shuffle:
+            i = torch.randint(self.size, (1,), generator=self.g).item()
+        return self.data[i]
+
+    def state_dict(self):
+        return {
+            "g": self.g.get_state(),
+        }
+
+    def load_state_dict(self, state_dict):
+        self.g.set_state(state_dict["g"])
 
 
 def identity(x):
     return x
 
 
-class TestStatefulDataLoader(unittest.TestCase):
-    def test_single_shard(self):
-        for num_workers, batch_size, pw, interrupt, iter_state in itertools.product(
-            [0, 3],  # num_workers
-            [None, 7],  # batch_size
-            [False, True],  # pw
-            [0, 1, 10, None],  # interrupt
-            [False, True],  # iter_state
-        ):
+class TestStatefulDataLoaderIterable(unittest.TestCase):
+    def _run_and_checkpoint(
+        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
+    ):
+        dataset = DummyIterableDataset([0, 100, 37], shuffle=shuffle)
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+        )
+        exp = list(dl)
+
+        if interrupt == None:
+            interrupt = len(exp)
+
+        batches = []
+        it = iter(dl)
+        for i in range(interrupt):
+            batches.append(next(it))
+        state_dict = dl.state_dict()
+
+        self.assertEqual(batches, exp[:interrupt])
+
+        # Restore new instance from state
+        dataset = DummyIterableDataset([0, 100, 37], shuffle=shuffle)
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+        )
+        dl.load_state_dict(state_dict)
+        for batch in dl:
+            batches.append(batch)
+
+        self.assertEqual(batches, exp)
+
+    def test_no_mp(self):
+        for batch_size, interrupt in itertools.product([None, 7], [1, 10, None]):
+            with self.subTest(batch_size=batch_size, interrupt=interrupt):
+                self._run_and_checkpoint(
+                    num_workers=0,
+                    batch_size=batch_size,
+                    pw=False,
+                    interrupt=interrupt,
+                )
+
+    def test_mp_x(self):
+        for batch_size, interrupt in itertools.product([None, 7], [1, 10, None]):
+            with self.subTest(batch_size=batch_size, interrupt=interrupt):
+                self._run_and_checkpoint(
+                    num_workers=3,
+                    batch_size=batch_size,
+                    pw=False,
+                    interrupt=interrupt,
+                )
+
+    def test_mp_pw(self):
+        for batch_size, interrupt in itertools.product([None, 7], [1, 10, None]):
+            with self.subTest(batch_size=batch_size, interrupt=interrupt):
+                self._run_and_checkpoint(
+                    num_workers=3,
+                    batch_size=batch_size,
+                    pw=True,
+                    interrupt=interrupt,
+                )
+
+    def test_mp_every_n_steps(self):
+        batch_size = 7
+        for every_n_steps, interrupt in itertools.product([2, 5], [1, 10, None]):
             with self.subTest(
-                num_workers=num_workers, batch_size=batch_size, pw=pw, interrupt=interrupt, iter_state=iter_state
+                every_n_steps=every_n_steps, batch_size=batch_size, interrupt=interrupt
             ):
-                if num_workers == 0 and pw:
-                    continue
-                dataset = DummyIterableDataset([(0, 100)])
-                dl = StatefulDataLoader(dataset=dataset, num_workers=num_workers, collate_fn=identity)
-                exp = list(dl)
+                self._run_and_checkpoint(
+                    num_workers=3,
+                    batch_size=batch_size,
+                    pw=True,
+                    interrupt=interrupt,
+                )
 
-                if interrupt == None:
-                    interrupt = len(exp)
+    def test_random_state(self):
+        for num_workers, interrupt in itertools.product([0, 3], [1, 10, None]):
+            with self.subTest(num_workers=num_workers, interrupt=interrupt):
+                self._run_and_checkpoint(
+                    num_workers=num_workers,
+                    batch_size=7,
+                    pw=False,
+                    interrupt=interrupt,
+                    shuffle=True,
+                )
 
-                batches = []
-                it = iter(dl)
-                for i in range(interrupt):
-                    batches.append(next(it))
-                if iter_state:
-                    state_dict = it.state_dict()
-                else:
-                    state_dict = dl.state_dict()
+class TestStatefulDataLoaderMap(TestStatefulDataLoaderIterable):
+    def _run_and_checkpoint(
+        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
+    ):
+        if num_workers == 0:
+            return
+        dataset = DummyMapDataset(100, shuffle=shuffle)
+        generator = torch.Generator()
+        generator.manual_seed(13)
+        sampler = torch.utils.data.RandomSampler(dataset, generator=generator)
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+            batch_size=batch_size,
+            sampler=sampler,
+        )
 
-                self.assertEqual(batches, exp[:interrupt])
+        if interrupt == None:
+            interrupt = len(dl)
 
-                # Restore new instance from state
-                dl = StatefulDataLoader(dataset=dataset, num_workers=num_workers, collate_fn=identity)
-                if iter_state:
-                    it = iter(dl)
-                    it.load_state_dict(state_dict)
-                else:
-                    dl.load_state_dict(state_dict)
-                    it = iter(dl)
-                for batch in it:
-                    batches.append(batch)
+        it = iter(dl)
+        for i in range(interrupt):
+            next(it)
 
-                self.assertEqual(batches, exp)
+        state_dict = dl.state_dict()
+        exp = []
+        for batch in it:
+            exp.append(batch)
 
-    # @parameterized.expand(
-    #     [
-    #         20,
-    #         10000,
-    #     ]
-    # )
-    # def test_multiworker(self, num_rows):
-    #     pairs = []
-    #     worker_rows = num_rows // 4
-    #     for i in range(4):
-    #         pairs.append((i * worker_rows, worker_rows))
+        # Restore new instance from state
+        # dataset = DummyMapDataset(100, shuffle=shuffle)
+        generator = torch.Generator()
+        generator.manual_seed(13)
+        sampler = torch.utils.data.RandomSampler(dataset, generator=generator)
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+            batch_size=batch_size,
+            sampler=sampler,
+        )
+        dl.load_state_dict(state_dict)
+        batches = []
+        for batch in dl:
+            batches.append(batch)
 
-    #     ds = DummyDataset(pairs)
-    #     # Check dataloader inline
-    #     dl = StatefulDataLoader(dataset=ds, batch_size=4)
-    #     for i, batch in enumerate(dl):
-    #         exp_ids = [i * 4, i * 4 + 1, i * 4 + 2, i * 4 + 3]
-    #         try:
-    #             # Handle truncated last batch
-    #             exp_ids = exp_ids[: exp_ids.index(num_rows)]
-    #         except ValueError:
-    #             pass
-
-    #         batch = rows_to_dict([json.loads(line) for line in batch])
-    #         self.assertEqual(set(batch.keys()), {"id", "strcol", "floatcol", "listcol"})
-    #         self.assertEqual(batch["id"], exp_ids)
-    #         self.assertEqual(batch["strcol"], [f"strcol_{j}" for j in exp_ids])
-    #         self.assertEqual(batch["floatcol"], [j + 0.1 for j in exp_ids])
-    #         self.assertEqual(
-    #             batch["listcol"],
-    #             [[j, j + 1, j + 2] for j in exp_ids],
-    #         )
-
-    #     dl = StatefulDataLoader(dataset=ds, batch_size=4, num_workers=4)
-    #     for i, batch in enumerate(dl):
-    #         worker = i % 4
-    #         base_id = worker * worker_rows + (i // 4) * 4
-    #         exp_ids = [
-    #             base_id,
-    #             base_id + 1,
-    #             base_id + 2,
-    #             base_id + 3,
-    #         ]
-    #         try:
-    #             # Handle truncated last batch
-    #             cutoff = exp_ids.index((worker + 1) * worker_rows)
-    #             exp_ids = exp_ids[:cutoff]
-    #         except ValueError:
-    #             pass
-
-    #         batch = rows_to_dict([json.loads(line) for line in batch])
-    #         self.assertEqual(set(batch.keys()), {"id", "strcol", "floatcol", "listcol"})
-    #         self.assertEqual(batch["id"], exp_ids, (i, base_id, worker_rows))
-    #         self.assertEqual(batch["strcol"], [f"strcol_{j}" for j in exp_ids])
-    #         self.assertEqual(batch["floatcol"], [j + 0.1 for j in exp_ids])
-    #         self.assertEqual(
-    #             batch["listcol"],
-    #             [[j, j + 1, j + 2] for j in exp_ids],
-    #         )
-
-    # @parameterized.expand(
-    #     list(
-    #         itertools.product(
-    #             [0, 1, 4],  # num_workers
-    #             [2, 10],  # interrupt
-    #             [False, True],  # iter_state
-    #             [False, True],  # persistent_workers
-    #         )
-    #     )
-    # )
-    # def test_state(self, num_workers, interrupt, iter_state, persistent_workers):
-    #     if persistent_workers and num_workers == 0:
-    #         return
-    #     num_rows = 1000
-    #     pairs = []
-    #     worker_rows = num_rows // 4
-    #     for i in range(4):
-    #         pairs.append((i * worker_rows, worker_rows))
-
-    #     ds = DummyDataset(pairs)
-
-    #     dl = StatefulDataLoader(
-    #         dataset=ds,
-    #         batch_size=4,
-    #         num_workers=num_workers,
-    #         persistent_workers=persistent_workers,
-    #     )
-    #     exp_result = []
-    #     for batch in dl:
-    #         exp_result.append([json.loads(x) for x in batch])
-
-    #     dl = StatefulDataLoader(
-    #         dataset=ds,
-    #         batch_size=4,
-    #         num_workers=num_workers,
-    #         persistent_workers=persistent_workers,
-    #     )
-    #     it = iter(dl)
-    #     result = []
-    #     for _ in range(interrupt):
-    #         batch = next(it)
-    #         result.append([json.loads(x) for x in batch])
-    #     if iter_state:
-    #         state_dict = it.state_dict()
-    #     else:
-    #         state_dict = dl.state_dict()
-    #     partial_result = copy.deepcopy(result)
-
-    #     # Test with new dataloader instance
-    #     dl = StatefulDataLoader(
-    #         dataset=ds,
-    #         batch_size=4,
-    #         num_workers=num_workers,
-    #         persistent_workers=persistent_workers,
-    #     )
-    #     if iter_state:
-    #         it = iter(dl)
-    #         it.load_state_dict(state_dict)
-    #     else:
-    #         dl.load_state_dict(state_dict)
-    #         it = iter(dl)
-    #     for batch in it:
-    #         result.append([json.loads(x) for x in batch])
-    #     self.assertEqual(result, exp_result)
-
-    #     # Test fresh start with new iterator
-    #     result = []
-    #     for batch in dl:
-    #         result.append([json.loads(x) for x in batch])
-    #     self.assertEqual(result, exp_result)
-
-    #     # Try with new instance of dataset
-    #     ds = DummyDataset(pairs)
-    #     dl = StatefulDataLoader(
-    #         dataset=ds,
-    #         batch_size=4,
-    #         num_workers=num_workers,
-    #         persistent_workers=persistent_workers,
-    #     )
-    #     result = copy.deepcopy(partial_result)
-    #     if iter_state:
-    #         it = iter(dl)
-    #         it.load_state_dict(state_dict)
-    #     else:
-    #         dl.load_state_dict(state_dict)
-    #         it = iter(dl)
-    #     for batch in it:
-    #         result.append([json.loads(x) for x in batch])
-    #     self.assertEqual(result, exp_result)
+        self.assertEqual(batches, exp)
 
 
-if __name__ ==  "__main__":
+class GeneratorIterable(torch.utils.data.IterableDataset):
+    def __init__(self, sizes_for_all_workers):
+        self.sizes_for_all_workers = sizes_for_all_workers
+        self.i = 0
+
+    def __iter__(self):
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info:
+            num_workers = worker_info.num_workers
+            worker_id = worker_info.id
+        else:
+            num_workers = 1
+            worker_id = 0
+            self.sizes_for_all_workers = [sum(self.sizes_for_all_workers)]
+
+        start = sum(self.sizes_for_all_workers[:worker_id])
+        skip = self.i
+        for i in range(start+skip, start+self.sizes_for_all_workers[worker_id]):
+            self.i += 1
+            yield i
+
+    def state_dict(self):
+        return {"i": self.i}
+
+    def load_state_dict(self, state):
+        self.i = state["i"]
+
+
+class TestStatefulDataLoaderGenerator(TestStatefulDataLoaderIterable):
+    def _run_and_checkpoint(
+        self, num_workers, batch_size, pw, interrupt, every_n_steps=1, shuffle=False
+    ):
+        dataset = GeneratorIterable([0, 100, 37])
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+        )
+        exp = list(dl)
+
+        if interrupt == None:
+            interrupt = len(exp)
+
+        dataset = GeneratorIterable([0, 100, 37])
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+        )
+        batches = []
+        it = iter(dl)
+        for i in range(interrupt):
+            batches.append(next(it))
+        state_dict = dl.state_dict()
+
+        self.assertEqual(batches, exp[:interrupt])
+
+        # Restore new instance from state
+        dataset = GeneratorIterable([0, 100, 37])
+        dl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=num_workers,
+            collate_fn=identity,
+            snapshot_every_n_steps=every_n_steps,
+            persistent_workers=pw,
+        )
+        dl.load_state_dict(state_dict)
+        for batch in dl:
+            batches.append(batch)
+
+        self.assertEqual(batches, exp)
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -500,11 +500,9 @@ class TestSnapshotEnd(unittest.TestCase):
                 persistent_workers=pw,
                 batch_size=bs,
             )
-            exp = list(dl)
+            list(dl)
             state_end = dl.state_dict()
-
-            batches = list(dl)  # simple restart
-            self.assertEqual(batches, exp)
+            exp = list(dl)
 
             dataset = DummyMapDataset(100, shuffle=True)
             dl = StatefulDataLoader(
@@ -515,9 +513,6 @@ class TestSnapshotEnd(unittest.TestCase):
                 persistent_workers=pw,
                 batch_size=bs,
             )
-            it = iter(dl)
-            for _ in range(2):
-                next(it)
             dl.load_state_dict(state_end)
             batches = list(dl)
 
@@ -527,7 +522,7 @@ class TestSnapshotEnd(unittest.TestCase):
         num_workers = 3
         every_n_steps = 10
         for pw, bs in itertools.product([False, True], [None, 4]):
-            dataset = DummyMapDataset(100)
+            dataset = DummyMapDataset(100, shuffle=False)
             dl = StatefulDataLoader(
                 dataset=dataset,
                 shuffle=True,  # Use default RandomSampler
@@ -537,24 +532,20 @@ class TestSnapshotEnd(unittest.TestCase):
                 persistent_workers=pw,
                 batch_size=bs,
             )
-            exp = list(dl)
+            list(dl)
             state_end = dl.state_dict()
+            exp = list(dl)
 
-            batches = list(dl)  # simple restart
-            self.assertEqual(batches, exp)
-
-            dataset = DummyMapDataset(100)
+            dataset = DummyMapDataset(100, shuffle=False)
             dl = StatefulDataLoader(
                 dataset=dataset,
+                shuffle=True,  # Use default RandomSampler
                 num_workers=num_workers,
                 collate_fn=identity,
                 snapshot_every_n_steps=every_n_steps,
                 persistent_workers=pw,
                 batch_size=bs,
             )
-            it = iter(dl)
-            for _ in range(2):
-                next(it)
             dl.load_state_dict(state_end)
             batches = list(dl)
 

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import copy
 import itertools
 import unittest
@@ -226,7 +232,7 @@ class TestStatefulDataLoaderMap(TestStatefulDataLoaderIterable):
             interrupt = len(dl)
 
         it = iter(dl)
-        for i in range(interrupt):
+        for _ in range(interrupt):
             next(it)
 
         state_dict = dl.state_dict()
@@ -273,7 +279,7 @@ class TestStatefulSampler(TestStatefulDataLoaderIterable):
             interrupt = len(dl)
 
         it = iter(dl)
-        for i in range(interrupt):
+        for _ in range(interrupt):
             next(it)
 
         state_dict = dl.state_dict()
@@ -370,7 +376,7 @@ class TestStatefulDataLoaderGenerator(TestStatefulDataLoaderIterable):
         )
         batches = []
         it = iter(dl)
-        for i in range(interrupt):
+        for _ in range(interrupt):
             batches.append(next(it))
         state_dict = dl.state_dict()
 
@@ -417,7 +423,7 @@ class TestStatefulDataLoaderGeneratorNoState(TestStatefulDataLoaderIterable):
         )
         batches = []
         it = iter(dl)
-        for i in range(interrupt):
+        for _ in range(interrupt):
             batches.append(next(it))
         state_dict = dl.state_dict()
 

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -72,6 +72,7 @@ class DummyMapDataset(torch.utils.data.Dataset):
         state = dict(self.__dict__)
         del state["g"]
         state["g_state"] = self.g.get_state()
+        return state
 
     def __setstate__(self, state):
         g_state = state.pop("g_state")

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -1,6 +1,4 @@
+from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 
-
-__all__ = [
-    "StatefulDataLoader"
-]
+__all__ = ["Stateful", "StatefulDataLoader"]

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -1,0 +1,6 @@
+from .stateful_dataloader import StatefulDataLoader
+
+
+__all__ = [
+    "StatefulDataLoader"
+]

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -39,8 +39,8 @@ class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
                 return
 
 
-torch.utils.data.sampler.RandomSampler = RandomSampler
-torch.utils.data.dataloader.RandomSampler = RandomSampler
+torch.utils.data.sampler.RandomSampler = RandomSampler  # type: ignore[misc]
+torch.utils.data.dataloader.RandomSampler = RandomSampler  # type: ignore[misc]
 
 
 class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
@@ -51,7 +51,7 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
         self.sampler_iter = iter(sampler)
 
     def state_dict(self) -> Dict[str, Any]:
-        sd = {"samples_yielded": self.samples_yielded}
+        sd: Dict[str, Any] = {"samples_yielded": self.samples_yielded}
         if isinstance(self.sampler, Stateful):
             sd["sampler"] = self.sampler.state_dict()
         if isinstance(self.sampler_iter, Stateful):
@@ -108,5 +108,5 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
                 yield batch[:idx_in_batch]
 
 
-torch.utils.data.sampler.BatchSampler = BatchSampler
-torch.utils.data.dataloader.BatchSampler = BatchSampler
+torch.utils.data.sampler.BatchSampler = BatchSampler  # type: ignore[misc]
+torch.utils.data.dataloader.BatchSampler = BatchSampler  # type: ignore[misc]

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -29,15 +29,12 @@ class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
 
     def __iter__(self):
         super_iter = super().__iter__()
-        self.yielded = 0
-        if self.next_yielded is not None:
-            for _ in range(self.next_yielded):
-                next(super_iter)
-                self.yielded += 1
-            self.next_yielded = None
+        self.yielded = self.next_yielded or 0
         while True:
             try:
-                yield next(super_iter)
+                val = next(super_iter)
+                # print("yielding", val)
+                yield val
                 self.yielded += 1
             except StopIteration:
                 return
@@ -85,14 +82,6 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
             self.sampler_iter = iter(self.sampler)
             self.samples_yielded = 0
 
-        # while True:
-        #     try:
-        #         yield next(super_iter)
-        #         self.yielded += 1
-        #     except StopIteration:
-        #         return
-
-        ##########
         if self.drop_last:
             while True:
                 try:
@@ -116,6 +105,7 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
                     batch = [0] * self.batch_size
             if idx_in_batch > 0:
                 yield batch[:idx_in_batch]
+
 
 torch.utils.data.sampler.BatchSampler = BatchSampler
 torch.utils.data.dataloader.BatchSampler = BatchSampler

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -1,0 +1,121 @@
+from typing import Any, Dict, Optional, Sized
+import torch.utils.data.sampler
+from torch.utils.data.dataloader import _InfiniteConstantSampler
+from .stateful import Stateful
+
+
+class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
+    def __init__(self, data_source: Sized, replacement: bool = False,
+                 num_samples: Optional[int] = None, generator=None):
+
+        if generator is None:
+            # Ensure that underlying sampler has something repeatable
+            generator = torch.Generator()
+            generator.manual_seed(1)
+        super().__init__(data_source, replacement, num_samples, generator)
+        self.yielded = 0
+        self.next_yielded = None
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {
+            "generator": self.generator.get_state() if self.generator else None,
+            "yielded": self.yielded
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        if state_dict["generator"] is not None:
+            self.generator.set_state(state_dict["generator"])
+        self.next_yielded = state_dict["yielded"]
+
+    def __iter__(self):
+        super_iter = super().__iter__()
+        self.yielded = 0
+        if self.next_yielded is not None:
+            for _ in range(self.next_yielded):
+                next(super_iter)
+                self.yielded += 1
+            self.next_yielded = None
+        while True:
+            try:
+                yield next(super_iter)
+                self.yielded += 1
+            except StopIteration:
+                return
+
+
+torch.utils.data.sampler.RandomSampler = RandomSampler
+torch.utils.data.dataloader.RandomSampler = RandomSampler
+
+
+class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
+    def __init__(self, sampler, batch_size, drop_last):
+        super().__init__(sampler, batch_size, drop_last)
+        self.samples_yielded = 0
+        self.next_yielded = None
+        self.sampler_iter = iter(sampler)
+
+    def state_dict(self) -> Dict[str, Any]:
+        sd = {"samples_yielded": self.samples_yielded}
+        if isinstance(self.sampler, Stateful):
+            sd["sampler"] = self.sampler.state_dict()
+        if isinstance(self.sampler_iter, Stateful):
+            sd["sampler_iter"] = self.sampler_iter.state_dict()
+        return sd
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self.next_yielded = state_dict["samples_yielded"]
+        if "sampler" in state_dict:
+            assert isinstance(self.sampler, Stateful)
+            self.sampler.load_state_dict(state_dict["sampler"])
+        self.sampler_iter = iter(self.sampler)
+        if "sampler_iter" in state_dict:
+            assert isinstance(self.sampler_iter, Stateful)
+            self.sampler_iter.load_state_dict(state_dict["sampler"])
+
+    def __iter__(self):
+        if self.next_yielded is not None:
+            self.samples_yielded = self.next_yielded
+            if not (isinstance(self.sampler, Stateful) or isinstance(self.sampler_iter, Stateful)) and not isinstance(self.sampler, _InfiniteConstantSampler):
+                # We skip x samples if underlying sampler is not stateful
+                for _ in range(self.next_yielded):
+                    next(self.sampler_iter)
+            self.next_yielded = None
+        elif self.samples_yielded > 0:
+            # don't re-create sampler_iter unless necessary, we may already have one from init
+            self.sampler_iter = iter(self.sampler)
+            self.samples_yielded = 0
+
+        # while True:
+        #     try:
+        #         yield next(super_iter)
+        #         self.yielded += 1
+        #     except StopIteration:
+        #         return
+
+        ##########
+        if self.drop_last:
+            while True:
+                try:
+                    batch = []
+                    for _ in range(self.batch_size):
+                        batch.append(next(self.sampler_iter))
+                        self.samples_yielded += 1
+                    yield batch
+                except StopIteration:
+                    break
+        else:
+            batch = [0] * self.batch_size
+            idx_in_batch = 0
+            for idx in self.sampler_iter:
+                self.samples_yielded += 1
+                batch[idx_in_batch] = idx
+                idx_in_batch += 1
+                if idx_in_batch == self.batch_size:
+                    yield batch
+                    idx_in_batch = 0
+                    batch = [0] * self.batch_size
+            if idx_in_batch > 0:
+                yield batch[:idx_in_batch]
+
+torch.utils.data.sampler.BatchSampler = BatchSampler
+torch.utils.data.dataloader.BatchSampler = BatchSampler

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -1,12 +1,15 @@
 from typing import Any, Dict, Optional, Sized
+
 import torch.utils.data.sampler
 from torch.utils.data.dataloader import _InfiniteConstantSampler
+
 from .stateful import Stateful
 
 
 class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
-    def __init__(self, data_source: Sized, replacement: bool = False,
-                 num_samples: Optional[int] = None, generator=None):
+    def __init__(
+        self, data_source: Sized, replacement: bool = False, num_samples: Optional[int] = None, generator=None
+    ):
 
         if generator is None:
             # Ensure that underlying sampler has something repeatable
@@ -17,10 +20,7 @@ class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
         self.next_yielded = None
 
     def state_dict(self) -> Dict[str, Any]:
-        return {
-            "generator": self.generator.get_state() if self.generator else None,
-            "yielded": self.yielded
-        }
+        return {"generator": self.generator.get_state() if self.generator else None, "yielded": self.yielded}
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if state_dict["generator"] is not None:
@@ -33,7 +33,6 @@ class RandomSampler(torch.utils.data.sampler.RandomSampler, Stateful):
         while True:
             try:
                 val = next(super_iter)
-                # print("yielding", val)
                 yield val
                 self.yielded += 1
             except StopIteration:
@@ -72,7 +71,9 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
     def __iter__(self):
         if self.next_yielded is not None:
             self.samples_yielded = self.next_yielded
-            if not (isinstance(self.sampler, Stateful) or isinstance(self.sampler_iter, Stateful)) and not isinstance(self.sampler, _InfiniteConstantSampler):
+            if not (isinstance(self.sampler, Stateful) or isinstance(self.sampler_iter, Stateful)) and not isinstance(
+                self.sampler, _InfiniteConstantSampler
+            ):
                 # We skip x samples if underlying sampler is not stateful
                 for _ in range(self.next_yielded):
                     next(self.sampler_iter)

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Any, Dict, Iterator, Optional, Sized
 
 import torch.utils.data.sampler

--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -66,7 +66,7 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler, Stateful):
         self.sampler_iter = iter(self.sampler)
         if "sampler_iter" in state_dict:
             assert isinstance(self.sampler_iter, Stateful)
-            self.sampler_iter.load_state_dict(state_dict["sampler"])
+            self.sampler_iter.load_state_dict(state_dict["sampler_iter"])
 
     def __iter__(self):
         if self.next_yielded is not None:

--- a/torchdata/stateful_dataloader/stateful.py
+++ b/torchdata/stateful_dataloader/stateful.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class Stateful(Protocol):
-    def state_dict(self) -> Optional[Dict[str, Any]]:
+    def state_dict(self) -> Dict[str, Any]:
         ...
 
-    def load_state_dict(self, state_dict: Optional[Dict[str, Any]]) -> None:
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         ...

--- a/torchdata/stateful_dataloader/stateful.py
+++ b/torchdata/stateful_dataloader/stateful.py
@@ -1,0 +1,10 @@
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Stateful(Protocol):
+    def state_dict(self) -> Dict[str, Any]:
+        ...
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        ...

--- a/torchdata/stateful_dataloader/stateful.py
+++ b/torchdata/stateful_dataloader/stateful.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Any, Dict, Protocol, runtime_checkable
 
 

--- a/torchdata/stateful_dataloader/stateful.py
+++ b/torchdata/stateful_dataloader/stateful.py
@@ -1,10 +1,10 @@
-from typing import Any, Dict, Protocol, runtime_checkable
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class Stateful(Protocol):
-    def state_dict(self) -> Dict[str, Any]:
+    def state_dict(self) -> Optional[Dict[str, Any]]:
         ...
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(self, state_dict: Optional[Dict[str, Any]]) -> None:
         ...

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1369,6 +1369,3 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
 
     def __del__(self):
         self._shutdown_workers()
-
-
-torch.utils.data.DataLoader = StatefulDataLoader  # type: ignore[misc]

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1364,3 +1364,6 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
 
     def __del__(self):
         self._shutdown_workers()
+
+
+torch.utils.data.DataLoader = StatefulDataLoader

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 r"""Definition of the StatefulDataLoader and associated iterators.
 
 This file is a stand-in for torch.utils.data.dataloader, and includes a
@@ -886,7 +892,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
                 for _ in range(self._prefetch_factor * self._num_workers):
                     self._try_put_index()
 
-            for i in range(next_iter_state[self._STEPS_SINCE_SNAPSHOT]):
+            for _ in range(next_iter_state[self._STEPS_SINCE_SNAPSHOT]):
                 next(self)
             self._finished = next_iter_state[_ITERATOR_FINISHED]
 

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1,0 +1,1703 @@
+r"""Definition of the DataLoader and associated iterators that subclass _BaseDataLoaderIter.
+
+To support these two classes, in `./_utils` we define many utility methods and
+functions to be run in multiprocessing. E.g., the data loading worker loop is
+in `./_utils/worker.py`.
+"""
+
+import functools
+import itertools
+import logging
+import os
+import copy
+import collections
+import queue
+import random
+import threading
+import uuid
+import warnings
+
+from typing import Any, Callable, Iterable, TypeVar, Generic, List, Optional, Union
+
+import multiprocessing as python_multiprocessing
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as multiprocessing
+import torch.utils.data.graph_settings
+
+from torch._utils import ExceptionWrapper
+from .worker import try_to_deserialize, try_to_serialize
+
+try:
+    import numpy as np
+
+    HAS_NUMPY = True
+except ModuleNotFoundError:
+    HAS_NUMPY = False
+
+from torch.utils.data.datapipes.datapipe import (
+    _IterDataPipeSerializationWrapper,
+    _MapDataPipeSerializationWrapper,
+)
+
+from torch.utils.data import (
+    IterDataPipe,
+    MapDataPipe,
+    IterableDataset,
+    Sampler,
+    SequentialSampler,
+    RandomSampler,
+    BatchSampler,
+    Dataset,)
+
+from torch.utils.data.datapipes.datapipe import _IterDataPipeSerializationWrapper, _MapDataPipeSerializationWrapper
+
+from torch.utils.data import _utils
+
+__all__ = [
+    "StatefulDataLoader",
+    "get_worker_info",
+    "default_collate",
+    "default_convert",
+]
+
+T_co = TypeVar('T_co', covariant=True)
+T = TypeVar('T')
+_worker_init_fn_t = Callable[[int], None]
+
+# Ideally we would parameterize `DataLoader` by the return type of `collate_fn`, but there is currently no way to have that
+# type parameter set to a default value if the user doesn't pass in a custom 'collate_fn'.
+# See https://github.com/python/mypy/issues/3737.
+_collate_fn_t = Callable[[List[T]], Any]
+
+
+# These functions used to be defined in this file. However, it was moved to
+# _utils/collate.py. Although it is rather hard to access this from user land
+# (one has to explicitly directly `import torch.utils.data.dataloader`), there
+# probably is user code out there using it. This aliasing maintains BC in this
+# aspect.
+default_collate: _collate_fn_t = _utils.collate.default_collate
+default_convert = _utils.collate.default_convert
+
+get_worker_info = _utils.worker.get_worker_info
+
+logger = logging.getLogger(__name__)
+
+
+class _DatasetKind:
+    Map = 0
+    Iterable = 1
+
+    @staticmethod
+    def create_fetcher(kind, dataset, auto_collation, collate_fn, drop_last):
+        if kind == _DatasetKind.Map:
+            return _utils.fetch._MapDatasetFetcher(dataset, auto_collation, collate_fn, drop_last)
+        else:
+            return _utils.fetch._IterableDatasetFetcher(dataset, auto_collation, collate_fn, drop_last)
+
+
+class _InfiniteConstantSampler(Sampler):
+    r"""Analogous to ``itertools.repeat(None, None)``.
+
+    Used as sampler for :class:`~torch.utils.data.IterableDataset`.
+    """
+
+    def __iter__(self):
+        while True:
+            yield None
+
+
+def _get_distributed_settings():
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size(), dist.get_rank()
+    else:
+        return 1, 0
+
+
+def _sharding_worker_init_fn(worker_init_fn, world_size, rank_id, worker_id):
+    global_worker_id = worker_id
+    info = torch.utils.data.get_worker_info()
+    assert info is not None
+    total_workers = info.num_workers
+    datapipe = info.dataset
+    assert isinstance(datapipe, (IterDataPipe, MapDataPipe))
+    # To distribute elements across distributed process evenly, we should shard data on distributed
+    # processes first then shard on worker processes
+    total_workers *= world_size
+    global_worker_id = global_worker_id * world_size + rank_id
+    # For BC, use default SHARDING_PRIORITIES
+    torch.utils.data.graph_settings.apply_sharding(datapipe, total_workers, global_worker_id)
+    if worker_init_fn is not None:
+        worker_init_fn(worker_id)
+
+
+def _share_dist_seed(generator, pg):
+    _shared_seed = torch.empty((), dtype=torch.int64).random_(generator=generator)
+    if isinstance(pg, dist.ProcessGroup):
+        dist.broadcast(_shared_seed, src=0, group=pg)
+    return _shared_seed.item()
+
+
+class StatefulDataLoader(Generic[T_co]):
+    r"""
+    Data loader combines a dataset and a sampler, and provides an iterable over the given dataset.
+
+    The :class:`~torch.utils.data.DataLoader` supports both map-style and
+    iterable-style datasets with single- or multi-process loading, customizing
+    loading order and optional automatic batching (collation) and memory pinning.
+
+    See :py:mod:`torch.utils.data` documentation page for more details.
+
+    Args:
+        dataset (Dataset): dataset from which to load the data.
+        batch_size (int, optional): how many samples per batch to load
+            (default: ``1``).
+        shuffle (bool, optional): set to ``True`` to have the data reshuffled
+            at every epoch (default: ``False``).
+        sampler (Sampler or Iterable, optional): defines the strategy to draw
+            samples from the dataset. Can be any ``Iterable`` with ``__len__``
+            implemented. If specified, :attr:`shuffle` must not be specified.
+        batch_sampler (Sampler or Iterable, optional): like :attr:`sampler`, but
+            returns a batch of indices at a time. Mutually exclusive with
+            :attr:`batch_size`, :attr:`shuffle`, :attr:`sampler`,
+            and :attr:`drop_last`.
+        num_workers (int, optional): how many subprocesses to use for data
+            loading. ``0`` means that the data will be loaded in the main process.
+            (default: ``0``)
+        collate_fn (Callable, optional): merges a list of samples to form a
+            mini-batch of Tensor(s).  Used when using batched loading from a
+            map-style dataset.
+        pin_memory (bool, optional): If ``True``, the data loader will copy Tensors
+            into device/CUDA pinned memory before returning them.  If your data elements
+            are a custom type, or your :attr:`collate_fn` returns a batch that is a custom type,
+            see the example below.
+        drop_last (bool, optional): set to ``True`` to drop the last incomplete batch,
+            if the dataset size is not divisible by the batch size. If ``False`` and
+            the size of dataset is not divisible by the batch size, then the last batch
+            will be smaller. (default: ``False``)
+        timeout (numeric, optional): if positive, the timeout value for collecting a batch
+            from workers. Should always be non-negative. (default: ``0``)
+        worker_init_fn (Callable, optional): If not ``None``, this will be called on each
+            worker subprocess with the worker id (an int in ``[0, num_workers - 1]``) as
+            input, after seeding and before data loading. (default: ``None``)
+        multiprocessing_context (str or multiprocessing.context.BaseContext, optional): If
+            ``None``, the default `multiprocessing context`_ of your operating system will
+            be used. (default: ``None``)
+        generator (torch.Generator, optional): If not ``None``, this RNG will be used
+            by RandomSampler to generate random indexes and multiprocessing to generate
+            ``base_seed`` for workers. (default: ``None``)
+        prefetch_factor (int, optional, keyword-only arg): Number of batches loaded
+            in advance by each worker. ``2`` means there will be a total of
+            2 * num_workers batches prefetched across all workers. (default value depends
+            on the set value for num_workers. If value of num_workers=0 default is ``None``.
+            Otherwise, if value of ``num_workers > 0`` default is ``2``).
+        persistent_workers (bool, optional): If ``True``, the data loader will not shut down
+            the worker processes after a dataset has been consumed once. This allows to
+            maintain the workers `Dataset` instances alive. (default: ``False``)
+        pin_memory_device (str, optional): the device to :attr:`pin_memory` to if ``pin_memory`` is
+            ``True``.
+
+
+    .. warning:: If the ``spawn`` start method is used, :attr:`worker_init_fn`
+                 cannot be an unpicklable object, e.g., a lambda function. See
+                 :ref:`multiprocessing-best-practices` on more details related
+                 to multiprocessing in PyTorch.
+
+    .. warning:: ``len(dataloader)`` heuristic is based on the length of the sampler used.
+                 When :attr:`dataset` is an :class:`~torch.utils.data.IterableDataset`,
+                 it instead returns an estimate based on ``len(dataset) / batch_size``, with proper
+                 rounding depending on :attr:`drop_last`, regardless of multi-process loading
+                 configurations. This represents the best guess PyTorch can make because PyTorch
+                 trusts user :attr:`dataset` code in correctly handling multi-process
+                 loading to avoid duplicate data.
+
+                 However, if sharding results in multiple workers having incomplete last batches,
+                 this estimate can still be inaccurate, because (1) an otherwise complete batch can
+                 be broken into multiple ones and (2) more than one batch worth of samples can be
+                 dropped when :attr:`drop_last` is set. Unfortunately, PyTorch can not detect such
+                 cases in general.
+
+                 See `Dataset Types`_ for more details on these two types of datasets and how
+                 :class:`~torch.utils.data.IterableDataset` interacts with
+                 `Multi-process data loading`_.
+
+    .. warning:: See :ref:`reproducibility`, and :ref:`dataloader-workers-random-seed`, and
+                 :ref:`data-loading-randomness` notes for random seed related questions.
+
+    .. _multiprocessing context:
+        https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
+    """
+
+    dataset: Dataset[T_co]
+    batch_size: Optional[int]
+    num_workers: int
+    pin_memory: bool
+    drop_last: bool
+    timeout: float
+    sampler: Union[Sampler, Iterable]
+    pin_memory_device: str
+    prefetch_factor: Optional[int]
+    _iterator : Optional['_BaseDataLoaderIter']
+    __initialized = False
+
+    def __init__(self, dataset: Dataset[T_co], batch_size: Optional[int] = 1,
+                 shuffle: Optional[bool] = None, sampler: Union[Sampler, Iterable, None] = None,
+                 batch_sampler: Union[Sampler[List], Iterable[List], None] = None,
+                 num_workers: int = 0, collate_fn: Optional[_collate_fn_t] = None,
+                 pin_memory: bool = False, drop_last: bool = False,
+                 timeout: float = 0, worker_init_fn: Optional[_worker_init_fn_t] = None,
+                 multiprocessing_context=None, generator=None,
+                 *, prefetch_factor: Optional[int] = None,
+                 persistent_workers: bool = False,
+                 pin_memory_device: str = "",
+                 checkpoint_every_n_steps: Optional[int] = 1):
+        torch._C._log_api_usage_once("python.data_loader")
+
+        if num_workers < 0:
+            raise ValueError('num_workers option should be non-negative; '
+                             'use num_workers=0 to disable multiprocessing.')
+
+        if timeout < 0:
+            raise ValueError('timeout option should be non-negative')
+
+        if num_workers == 0 and prefetch_factor is not None:
+            raise ValueError('prefetch_factor option could only be specified in multiprocessing.'
+                             'let num_workers > 0 to enable multiprocessing, otherwise set prefetch_factor to None.')
+        elif num_workers > 0 and prefetch_factor is None:
+            prefetch_factor = 2
+        elif prefetch_factor is not None and prefetch_factor < 0:
+            raise ValueError('prefetch_factor option should be non-negative')
+
+        if persistent_workers and num_workers == 0:
+            raise ValueError('persistent_workers option needs num_workers > 0')
+
+        self.dataset = dataset
+        self.num_workers = num_workers
+        self.prefetch_factor = prefetch_factor
+        self.pin_memory = pin_memory
+        self.pin_memory_device = pin_memory_device
+        self.timeout = timeout
+        self.worker_init_fn = worker_init_fn
+        self.multiprocessing_context = multiprocessing_context
+        self.checkpoint_every_n_steps = checkpoint_every_n_steps
+
+        # Adds forward compatibilities so classic DataLoader can work with DataPipes:
+        #   _DataPipeSerializationWrapper container makes it easier to serialize without redefining pickler
+        if isinstance(self.dataset, IterDataPipe):
+            self.dataset = _IterDataPipeSerializationWrapper(self.dataset)
+        elif isinstance(self.dataset, MapDataPipe):
+            self.dataset = _MapDataPipeSerializationWrapper(self.dataset)
+
+        # Arg-check dataset related before checking samplers because we want to
+        # tell users that iterable-style datasets are incompatible with custom
+        # samplers first, so that they don't learn that this combo doesn't work
+        # after spending time fixing the custom sampler errors.
+        if isinstance(dataset, IterableDataset):
+            self._dataset_kind = _DatasetKind.Iterable
+            # NOTE [ Custom Samplers and IterableDataset ]
+            #
+            # `IterableDataset` does not support custom `batch_sampler` or
+            # `sampler` since the key is irrelevant (unless we support
+            # generator-style dataset one day...).
+            #
+            # For `sampler`, we always create a dummy sampler. This is an
+            # infinite sampler even when the dataset may have an implemented
+            # finite `__len__` because in multi-process data loading, naive
+            # settings will return duplicated data (which may be desired), and
+            # thus using a sampler with length matching that of dataset will
+            # cause data lost (you may have duplicates of the first couple
+            # batches, but never see anything afterwards). Therefore,
+            # `Iterabledataset` always uses an infinite sampler, an instance of
+            # `_InfiniteConstantSampler` defined above.
+            #
+            # A custom `batch_sampler` essentially only controls the batch size.
+            # However, it is unclear how useful it would be since an iterable-style
+            # dataset can handle that within itself. Moreover, it is pointless
+            # in multi-process data loading as the assignment order of batches
+            # to workers is an implementation detail so users can not control
+            # how to batchify each worker's iterable. Thus, we disable this
+            # option. If this turns out to be useful in future, we can re-enable
+            # this, and support custom samplers that specify the assignments to
+            # specific workers.
+            if isinstance(dataset, IterDataPipe):
+                if shuffle is not None:
+                    dataset = torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
+            # We cannot check `shuffle is not None` here, since previously `shuffle=False` was the default.
+            elif shuffle not in {False, None}:
+                raise ValueError(
+                    f"DataLoader with IterableDataset: expected unspecified shuffle option, but got shuffle={shuffle}")
+
+            if sampler is not None:
+                # See NOTE [ Custom Samplers and IterableDataset ]
+                raise ValueError(
+                    f"DataLoader with IterableDataset: expected unspecified sampler option, but got sampler={sampler}")
+            elif batch_sampler is not None:
+                # See NOTE [ Custom Samplers and IterableDataset ]
+                raise ValueError(
+                    "DataLoader with IterableDataset: expected unspecified "
+                    f"batch_sampler option, but got batch_sampler={batch_sampler}")
+        else:
+            shuffle = bool(shuffle)
+            self._dataset_kind = _DatasetKind.Map
+
+
+
+        if sampler is not None and shuffle:
+            raise ValueError('sampler option is mutually exclusive with '
+                             'shuffle')
+
+        if batch_sampler is not None:
+            # auto_collation with custom batch_sampler
+            if batch_size != 1 or shuffle or sampler is not None or drop_last:
+                raise ValueError('batch_sampler option is mutually exclusive '
+                                 'with batch_size, shuffle, sampler, and '
+                                 'drop_last')
+            batch_size = None
+            drop_last = False
+        elif batch_size is None:
+            # no auto_collation
+            if drop_last:
+                raise ValueError('batch_size=None option disables auto-batching '
+                                 'and is mutually exclusive with drop_last')
+
+        if sampler is None:  # give default samplers
+            if self._dataset_kind == _DatasetKind.Iterable:
+                # See NOTE [ Custom Samplers and IterableDataset ]
+                sampler = _InfiniteConstantSampler()
+            else:  # map-style
+                if shuffle:
+                    sampler = RandomSampler(dataset, generator=generator)  # type: ignore[arg-type]
+                else:
+                    sampler = SequentialSampler(dataset)  # type: ignore[arg-type]
+
+        if batch_size is not None and batch_sampler is None:
+            # auto_collation without custom batch_sampler
+            batch_sampler = BatchSampler(sampler, batch_size, drop_last)
+
+        self.batch_size = batch_size
+        self.drop_last = drop_last
+        self.sampler = sampler
+        self.batch_sampler = batch_sampler
+        self.generator = generator
+
+        if collate_fn is None:
+            if self._auto_collation:
+                collate_fn = _utils.collate.default_collate
+            else:
+                collate_fn = _utils.collate.default_convert
+
+        self.collate_fn = collate_fn
+        self.persistent_workers = persistent_workers
+
+        self.__initialized = True
+        self._IterableDataset_len_called = None  # See NOTE [ IterableDataset and __len__ ]
+
+        self._iterator = None
+
+        self.check_worker_number_rationality()
+
+        torch.set_vital('Dataloader', 'enabled', 'True')  # type: ignore[attr-defined]
+
+    def _get_iterator(self) -> '_BaseDataLoaderIter':
+        if self.num_workers == 0:
+            return _SingleProcessDataLoaderIter(self)
+        else:
+            self.check_worker_number_rationality()
+            return _MultiProcessingDataLoaderIter(self)
+
+    @property
+    def multiprocessing_context(self):
+        return self.__multiprocessing_context
+
+    @multiprocessing_context.setter
+    def multiprocessing_context(self, multiprocessing_context):
+        if multiprocessing_context is not None:
+            if self.num_workers > 0:
+                if isinstance(multiprocessing_context, str):
+                    valid_start_methods = multiprocessing.get_all_start_methods()
+                    if multiprocessing_context not in valid_start_methods:
+                        raise ValueError(
+                            'multiprocessing_context option '
+                            f'should specify a valid start method in {valid_start_methods!r}, but got '
+                            f'multiprocessing_context={multiprocessing_context!r}')
+                    multiprocessing_context = multiprocessing.get_context(multiprocessing_context)
+
+                if not isinstance(multiprocessing_context, python_multiprocessing.context.BaseContext):
+                    raise TypeError('multiprocessing_context option should be a valid context '
+                                    'object or a string specifying the start method, but got '
+                                    f'multiprocessing_context={multiprocessing_context}')
+            else:
+                raise ValueError('multiprocessing_context can only be used with '
+                                 'multi-process loading (num_workers > 0), but got '
+                                 f'num_workers={self.num_workers}')
+
+        self.__multiprocessing_context = multiprocessing_context
+
+    def __setattr__(self, attr, val):
+        if self.__initialized and attr in (
+                'batch_size', 'batch_sampler', 'sampler', 'drop_last', 'dataset', 'persistent_workers'):
+            raise ValueError(f'{attr} attribute should not be set after {self.__class__.__name__} is initialized')
+
+        super().__setattr__(attr, val)
+
+    # We quote '_BaseDataLoaderIter' since it isn't defined yet and the definition can't be moved up
+    # since '_BaseDataLoaderIter' references 'DataLoader'.
+    def __iter__(self) -> '_BaseDataLoaderIter':
+        # When using a single worker the returned iterator should be
+        # created everytime to avoid resetting its state
+        # However, in the case of a multiple workers iterator
+        # the iterator is only created once in the lifetime of the
+        # DataLoader object so that workers can be reused
+        if self.persistent_workers and self.num_workers > 0:
+            if self._iterator is None:
+                self._iterator = self._get_iterator()
+            else:
+                self._iterator._reset(self)
+            return self._iterator
+        else:
+            return self._get_iterator()
+
+    @property
+    def _auto_collation(self):
+        return self.batch_sampler is not None
+
+    @property
+    def _index_sampler(self):
+        # The actual sampler used for generating indices for `_DatasetFetcher`
+        # (see _utils/fetch.py) to read data at each time. This would be
+        # `.batch_sampler` if in auto-collation mode, and `.sampler` otherwise.
+        # We can't change `.sampler` and `.batch_sampler` attributes for BC
+        # reasons.
+        if self._auto_collation:
+            return self.batch_sampler
+        else:
+            return self.sampler
+
+    def __len__(self) -> int:
+        if self._dataset_kind == _DatasetKind.Iterable:
+            # NOTE [ IterableDataset and __len__ ]
+            #
+            # For `IterableDataset`, `__len__` could be inaccurate when one naively
+            # does multi-processing data loading, since the samples will be duplicated.
+            # However, no real use case should be actually using that behavior, so
+            # it should count as a user error. We should generally trust user
+            # code to do the proper thing (e.g., configure each replica differently
+            # in `__iter__`), and give us the correct `__len__` if they choose to
+            # implement it (this will still throw if the dataset does not implement
+            # a `__len__`).
+            #
+            # To provide a further warning, we track if `__len__` was called on the
+            # `DataLoader`, save the returned value in `self._len_called`, and warn
+            # if the iterator ends up yielding more than this number of samples.
+
+            # Cannot statically verify that dataset is Sized
+            length = self._IterableDataset_len_called = len(self.dataset)  # type: ignore[assignment, arg-type]
+            if self.batch_size is not None:  # IterableDataset doesn't allow custom sampler or batch_sampler
+                from math import ceil
+                if self.drop_last:
+                    length = length // self.batch_size
+                else:
+                    length = ceil(length / self.batch_size)
+            return length
+        else:
+            return len(self._index_sampler)
+
+    def check_worker_number_rationality(self):
+        # This function check whether the dataloader's worker number is rational based on
+        # current system's resource. Current rule is that if the number of workers this
+        # Dataloader will create is bigger than the number of logical cpus that is allowed to
+        # use, than we will pop up a warning to let user pay attention.
+        #
+        # eg. If current system has 2 physical CPUs with 16 cores each. And each core support 2
+        #     threads, then the total logical cpus here is 2 * 16 * 2 = 64. Let's say current
+        #     DataLoader process can use half of them which is 32, then the rational max number of
+        #     worker that initiated from this process is 32.
+        #     Now, let's say the created DataLoader has num_works = 40, which is bigger than 32.
+        #     So the warning message is triggered to notify the user to lower the worker number if
+        #     necessary.
+        #
+        #
+        # [Note] Please note that this function repects `cpuset` only when os.sched_getaffinity is
+        #        available (available in most of Linux system, but not OSX and Windows).
+        #        When os.sched_getaffinity is not available, os.cpu_count() is called instead, but
+        #        it doesn't repect cpuset.
+        #        We don't take threading into account since each worker process is single threaded
+        #        at this time.
+        #
+        #        We don't set any threading flags (eg. OMP_NUM_THREADS, MKL_NUM_THREADS, etc)
+        #        other than `torch.set_num_threads` to 1 in the worker process, if the passing
+        #        in functions use 3rd party modules that rely on those threading flags to determine
+        #        how many thread to create (eg. numpy, etc), then it is caller's responsibility to
+        #        set those flags correctly.
+        def _create_warning_msg(num_worker_suggest, num_worker_created, cpuset_checked):
+
+            suggested_max_worker_msg = ((
+                "Our suggested max number of worker in current system is {}{}, which is smaller "
+                "than what this DataLoader is going to create.").format(
+                    num_worker_suggest,
+                    ("" if cpuset_checked else " (`cpuset` is not taken into account)"))
+            ) if num_worker_suggest is not None else (
+                "DataLoader is not able to compute a suggested max number of worker in current system.")
+
+            warn_msg = (
+                "This DataLoader will create {} worker processes in total. {} "
+                "Please be aware that excessive worker creation might get DataLoader running slow or even freeze, "
+                "lower the worker number to avoid potential slowness/freeze if necessary.").format(
+                    num_worker_created,
+                    suggested_max_worker_msg)
+            return warn_msg
+
+        if not self.num_workers or self.num_workers == 0:
+            return
+
+        # try to compute a suggested max number of worker based on system's resource
+        max_num_worker_suggest = None
+        cpuset_checked = False
+        if hasattr(os, 'sched_getaffinity'):
+            try:
+                max_num_worker_suggest = len(os.sched_getaffinity(0))
+                cpuset_checked = True
+            except Exception:
+                pass
+        if max_num_worker_suggest is None:
+            # os.cpu_count() could return Optional[int]
+            # get cpu count first and check None in order to satisfy mypy check
+            cpu_count = os.cpu_count()
+            if cpu_count is not None:
+                max_num_worker_suggest = cpu_count
+
+        if max_num_worker_suggest is None:
+            warnings.warn(_create_warning_msg(
+                max_num_worker_suggest,
+                self.num_workers,
+                cpuset_checked))
+            return
+
+        if self.num_workers > max_num_worker_suggest:
+            warnings.warn(_create_warning_msg(
+                max_num_worker_suggest,
+                self.num_workers,
+                cpuset_checked))
+
+
+class _BaseDataLoaderIter:
+    def __init__(self, loader: StatefulDataLoader) -> None:
+        self._dataset = loader.dataset
+        self._shared_seed = None
+        self._pg = None
+        if isinstance(self._dataset, IterDataPipe):
+            if dist.is_available() and dist.is_initialized():
+                self._pg = dist.new_group(backend="gloo")
+            self._shared_seed = _share_dist_seed(loader.generator, self._pg)
+            shared_rng = torch.Generator()
+            shared_rng.manual_seed(self._shared_seed)
+            self._dataset = torch.utils.data.graph_settings.apply_random_seed(self._dataset, shared_rng)
+        self._dataset_kind = loader._dataset_kind
+        self._IterableDataset_len_called = loader._IterableDataset_len_called
+        self._auto_collation = loader._auto_collation
+        self._drop_last = loader.drop_last
+        self._index_sampler = loader._index_sampler
+        self._num_workers = loader.num_workers
+        ws, rank = _get_distributed_settings()
+        self._world_size = ws
+        self._rank = rank
+        # for other backends, pin_memory_device need to set. if not set
+        # default behaviour is CUDA device. if pin_memory_device is selected
+        # and pin_memory is not set, the default behaviour false.
+        if (len(loader.pin_memory_device) == 0):
+            self._pin_memory = loader.pin_memory and torch.cuda.is_available()
+            self._pin_memory_device = None
+        else:
+            if not loader.pin_memory:
+                warn_msg = ("pin memory device is set and pin_memory flag is not used then device pinned memory won't be used"
+                            "please set pin_memory to true, if you need to use the device pin memory")
+                warnings.warn(warn_msg)
+
+            self._pin_memory = loader.pin_memory
+            self._pin_memory_device = loader.pin_memory_device
+        self._timeout = loader.timeout
+        self._collate_fn = loader.collate_fn
+        self._sampler_iter = iter(self._index_sampler)
+        self._base_seed = torch.empty((), dtype=torch.int64).random_(generator=loader.generator).item()
+        self._persistent_workers = loader.persistent_workers
+        self._num_yielded = 0
+        self._sampler_iter_yielded = 0
+        self._profile_name = f"enumerate(DataLoader)#{self.__class__.__name__}.__next__"
+
+    def __iter__(self) -> '_BaseDataLoaderIter':
+        return self
+
+    def _reset(self, loader, first_iter=False):
+        self._sampler_iter = iter(self._index_sampler)
+        self._sampler_iter_yielded = 0
+        self._num_yielded = 0
+        self._IterableDataset_len_called = loader._IterableDataset_len_called
+        if isinstance(self._dataset, IterDataPipe):
+            self._shared_seed = _share_dist_seed(loader.generator, self._pg)
+            shared_rng = torch.Generator()
+            shared_rng.manual_seed(self._shared_seed)
+            self._dataset = torch.utils.data.graph_settings.apply_random_seed(self._dataset, shared_rng)
+
+    def _next_index(self):
+        idx = next(self._sampler_iter)  # may raise StopIteration
+        self._sampler_iter_yielded += 1
+        return idx
+
+    def _next_data(self):
+        raise NotImplementedError
+
+    def __next__(self) -> Any:
+        with torch.autograd.profiler.record_function(self._profile_name):
+            if self._sampler_iter is None:
+                # TODO(https://github.com/pytorch/pytorch/issues/76750)
+                self._reset()  # type: ignore[call-arg]
+            data = self._next_data()
+            self._num_yielded += 1
+            if self._dataset_kind == _DatasetKind.Iterable and \
+                    self._IterableDataset_len_called is not None and \
+                    self._num_yielded > self._IterableDataset_len_called:
+                warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
+                            "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
+                                                                  self._num_yielded)
+                if self._num_workers > 0:
+                    warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
+                                 "IterableDataset replica at each worker. Please see "
+                                 "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
+                warnings.warn(warn_msg)
+            return data
+
+    def __len__(self) -> int:
+        return len(self._index_sampler)
+
+    def __getstate__(self):
+        # TODO: add limited pickling support for sharing an iterator
+        # across multiple threads for HOGWILD.
+        # Probably the best way to do this is by moving the sample pushing
+        # to a separate thread and then just sharing the data queue
+        # but signalling the end is tricky without a non-blocking API
+        raise NotImplementedError("{} cannot be pickled", self.__class__.__name__)
+
+    def state_dict(self):
+        pass
+
+    def load_state_dict(self, state_dict):
+        pass
+
+
+class _SingleProcessDataLoaderIter(_BaseDataLoaderIter):
+    def __init__(self, loader):
+        super().__init__(loader)
+        assert self._timeout == 0
+        assert self._num_workers == 0
+
+        # Adds forward compatibilities so classic DataLoader can work with DataPipes:
+        #   Taking care of distributed sharding
+        if isinstance(self._dataset, (IterDataPipe, MapDataPipe)):
+            # For BC, use default SHARDING_PRIORITIES
+            torch.utils.data.graph_settings.apply_sharding(self._dataset, self._world_size, self._rank)
+
+        self._dataset_fetcher = _DatasetKind.create_fetcher(
+            self._dataset_kind, self._dataset, self._auto_collation, self._collate_fn, self._drop_last)
+
+    def _next_data(self):
+        index = self._next_index()  # may raise StopIteration
+        data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
+        if self._pin_memory:
+            data = _utils.pin_memory.pin_memory(data, self._pin_memory_device)
+        return data
+
+    def state_dict(self):
+        if self._dataset_kind == _DatasetKind.Iterable:
+            fetcher_state = {
+                "dataset_iter": try_to_serialize(
+                    self._dataset_fetcher.dataset_iter, False
+                ),
+                "ended": self._dataset_fetcher.ended,
+            }
+        else:
+            fetcher_state = None
+        state_dict = {
+            "_index_sampler": try_to_serialize(self._index_sampler, True),
+            "_sampler_iter": try_to_serialize(self._sampler_iter, True),
+            "_sampler_iter_yielded": self._sampler_iter_yielded,
+            "_num_yielded": self._num_yielded,
+            "_IterableDataset_len_called": self._IterableDataset_len_called,
+            "_shared_seed": self._shared_seed,
+            "fetcher_state": fetcher_state,
+        }
+
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        self._index_sampler = (
+            try_to_deserialize(self._index_sampler, state_dict["_index_sampler"])
+            or self._index_sampler
+        )
+        self._sampler_iter_yielded = state_dict["_sampler_iter_yielded"]
+        sampler_iter = try_to_deserialize(
+            self._sampler_iter, state_dict["_sampler_iter"]
+        )
+        if sampler_iter is None:
+            # Fallback to fastforward
+            sampler_iter = itertools.islice(
+                self._index_sampler, self._sampler_iter_yielded, None
+            )
+        self._sampler_iter = sampler_iter
+        self._num_yielded = state_dict["_num_yielded"]
+        self._IterableDataset_len_called = state_dict["_IterableDataset_len_called"]
+        self._shared_seed = state_dict["_shared_seed"]
+        if state_dict["fetcher_state"] is not None:
+            self._dataset_fetcher.dataset_iter = try_to_deserialize(
+                self._dataset_fetcher.dataset_iter,
+                state_dict["fetcher_state"]["dataset_iter"],
+            )
+            self._dataset_fetcher.ended = state_dict["fetcher_state"]["ended"]
+
+
+class _MultiProcessingDataLoaderIter(_BaseDataLoaderIter):
+    r"""Iterates once over the DataLoader's dataset, as specified by the sampler."""
+
+    # NOTE [ Data Loader Multiprocessing Shutdown Logic ]
+    #
+    # Preliminary:
+    #
+    # Our data model looks like this (queues are indicated with curly brackets):
+    #
+    #                main process                              ||
+    #                     |                                    ||
+    #               {index_queue}                              ||
+    #                     |                                    ||
+    #              worker processes                            ||     DATA
+    #                     |                                    ||
+    #            {worker_result_queue}                         ||     FLOW
+    #                     |                                    ||
+    #      pin_memory_thread of main process                   ||   DIRECTION
+    #                     |                                    ||
+    #               {data_queue}                               ||
+    #                     |                                    ||
+    #                data output                               \/
+    #
+    # P.S. `worker_result_queue` and `pin_memory_thread` part may be omitted if
+    #      `pin_memory=False`.
+    #
+    #
+    # Terminating multiprocessing logic requires very careful design. In
+    # particular, we need to make sure that
+    #
+    #   1. The iterator gracefully exits the workers when its last reference is
+    #      gone or it is depleted.
+    #
+    #      In this case, the workers should be gracefully exited because the
+    #      main process may still need to continue to run, and we want cleaning
+    #      up code in the workers to be executed (e.g., releasing GPU memory).
+    #      Naturally, we implement the shutdown logic in `__del__` of
+    #      DataLoaderIterator.
+    #
+    #      We delay the discussion on the logic in this case until later.
+    #
+    #   2. The iterator exits the workers when the loader process and/or worker
+    #      processes exits normally or with error.
+    #
+    #      We set all workers and `pin_memory_thread` to have `daemon=True`.
+    #
+    #      You may ask, why can't we make the workers non-daemonic, and
+    #      gracefully exit using the same logic as we have in `__del__` when the
+    #      iterator gets deleted (see 1 above)?
+    #
+    #      First of all, `__del__` is **not** guaranteed to be called when
+    #      interpreter exits. Even if it is called, by the time it executes,
+    #      many Python core library resources may already be freed, and even
+    #      simple things like acquiring an internal lock of a queue may hang.
+    #      Therefore, in this case, we actually need to prevent `__del__` from
+    #      being executed, and rely on the automatic termination of daemonic
+    #      children.
+    #
+    #      Thus, we register an `atexit` hook that sets a global flag
+    #      `_utils.python_exit_status`. Since `atexit` hooks are executed in the
+    #      reverse order of registration, we are guaranteed that this flag is
+    #      set before library resources we use are freed (which, at least in
+    #      CPython, is done via an `atexit` handler defined in
+    #      `multiprocessing/util.py`
+    #      https://github.com/python/cpython/blob/c606624af8d4cb3b4a052fb263bb983b3f87585b/Lib/multiprocessing/util.py#L320-L362
+    #      registered when an object requiring this mechanism is first
+    #      created, e.g., `mp.Queue`
+    #      https://github.com/python/cpython/blob/c606624af8d4cb3b4a052fb263bb983b3f87585b/Lib/multiprocessing/context.py#L100-L103
+    #      https://github.com/python/cpython/blob/c606624af8d4cb3b4a052fb263bb983b3f87585b/Lib/multiprocessing/queues.py#L29
+    #      )
+    #
+    #      So in `__del__`, we check if `_utils.python_exit_status` is set or
+    #      `None` (freed), and perform no-op if so.
+    #
+    #      However, simply letting library clean-up codes run can also be bad,
+    #      because such codes (i.e., `multiprocessing.util._exit_function()`)
+    #      include join putting threads for `mp.Queue`, which can be blocking.
+    #      Hence, the main process putting threads are called with
+    #      `cancel_join_thread` at creation.  See later section
+    #      [ 3b. A process won't hang when putting into a queue; ]
+    #      for more details.
+    #
+    #      Here are two example cases where library clean-up codes can run
+    #      before `__del__` is called:
+    #
+    #        1. If we hold onto a reference to the iterator, it more often
+    #           than not tries to do `multiprocessing` library cleaning before
+    #           clearing the alive referenced objects (https://github.com/pytorch/pytorch/issues/48666)
+    #           and thus prevents our cleaning-up code to run first.
+    #
+    #        2. A similar issue araises when a `DataLoader` is used in a subprocess.
+    #           When a process ends, it shuts the all its daemonic children
+    #           down with a SIGTERM (instead of joining them without a timeout).
+    #           Simiarly for threads, but by a different mechanism. This fact,
+    #           together with a few implementation details of multiprocessing, forces
+    #           us to make workers daemonic. All of our problems arise when a
+    #           DataLoader is used in a subprocess, and are caused by multiprocessing
+    #           code which looks more or less like this:
+    #
+    #               try:
+    #                   your_function_using_a_dataloader()
+    #               finally:
+    #                   multiprocessing.util._exit_function()
+    #
+    #           The joining/termination mentioned above happens inside
+    #           `_exit_function()`. Now, if `your_function_using_a_dataloader()`
+    #           throws, the stack trace stored in the exception will prevent the
+    #           frame which uses `DataLoaderIter` to be freed. If the frame has any
+    #           reference to the `DataLoaderIter` (e.g., in a method of the iter),
+    #           its  `__del__`, which starts the shutdown procedure, will not be
+    #           called. That, in turn, means that workers aren't notified. Attempting
+    #           to join in `_exit_function` will then result in a hang.
+    #
+    #           For context, `_exit_function` is also registered as an `atexit` call.
+    #           So it is unclear to me (@ssnl) why this is needed in a finally block.
+    #           The code dates back to 2008 and there is no comment on the original
+    #           PEP 371 or patch https://bugs.python.org/issue3050 (containing both
+    #           the finally block and the `atexit` registration) that explains this.
+    #
+    #
+    #      Finally, another choice is to just shutdown workers with logic in 1
+    #      above whenever we see an error in `next`. This isn't ideal because
+    #        a. It prevents users from using try-catch to resume data loading.
+    #        b. It doesn't prevent hanging if users have references to the
+    #           iterator.
+    #
+    #   3. All processes exit if any of them die unexpectedly by fatal signals.
+    #
+    #      As shown above, the workers are set as daemonic children of the main
+    #      process. However, automatic cleaning-up of such child processes only
+    #      happens if the parent process exits gracefully (e.g., not via fatal
+    #      signals like SIGKILL). So we must ensure that each process will exit
+    #      even the process that should send/receive data to/from it were
+    #      killed, i.e.,
+    #
+    #        a. A process won't hang when getting from a queue.
+    #
+    #           Even with carefully designed data dependencies (i.e., a `put()`
+    #           always corresponding to a `get()`), hanging on `get()` can still
+    #           happen when data in queue is corrupted (e.g., due to
+    #           `cancel_join_thread` or unexpected exit).
+    #
+    #           For child exit, we set a timeout whenever we try to get data
+    #           from `data_queue`, and check the workers' status on each timeout
+    #           and error.
+    #           See `_DataLoaderiter._get_batch()` and
+    #           `_DataLoaderiter._try_get_data()` for details.
+    #
+    #           Additionally, for child exit on non-Windows platforms, we also
+    #           register a SIGCHLD handler (which is supported on Windows) on
+    #           the main process, which checks if any of the workers fail in the
+    #           (Python) handler. This is more efficient and faster in detecting
+    #           worker failures, compared to only using the above mechanism.
+    #           See `DataLoader.cpp` and `_utils/signal_handling.py` for details.
+    #
+    #           For `.get()` calls where the sender(s) is not the workers, we
+    #           guard them with timeouts, and check the status of the sender
+    #           when timeout happens:
+    #             + in the workers, the `_utils.worker.ManagerWatchdog` class
+    #               checks the status of the main process.
+    #             + if `pin_memory=True`, when getting from `pin_memory_thread`,
+    #               check `pin_memory_thread` status periodically until `.get()`
+    #               returns or see that `pin_memory_thread` died.
+    #
+    #        b. A process won't hang when putting into a queue;
+    #
+    #           We use `mp.Queue` which has a separate background thread to put
+    #           objects from an unbounded buffer array. The background thread is
+    #           daemonic and usually automatically joined when the process
+    #           *exits*.
+    #
+    #           In case that the receiver has ended abruptly while
+    #           reading from the pipe, the join will hang forever.  The usual
+    #           solution for this in Python is calling  `q.cancel_join_thread`,
+    #           which prevents automatically joining it when finalizing
+    #           (exiting).
+    #
+    #           Nonetheless, `cancel_join_thread` must only be called when the
+    #           queue is **not** going to be read from or write into by another
+    #           process, because it may hold onto a lock or leave corrupted data
+    #           in the queue, leading other readers/writers to hang.
+    #
+    #           Hence,
+    #             + For worker processes, we only do so (for their output
+    #               queues, i.e., `worker_result_queue`) before exiting.
+    #             + For `pin_memory_thread`, its output queue `data_queue` is a
+    #               `queue.Queue` that does blocking `put` if the queue is full.
+    #               So there is no above problem, but as a result, in
+    #               `_pin_memory_loop`, we do need to  wrap the `put` in a loop
+    #               that breaks not only upon success, but also when the main
+    #               process stops reading, i.e., is shutting down.
+    #             + For loader process, we `cancel_join_thread()` for all
+    #               `_index_queues` because the whole purpose of workers and
+    #               `pin_memory_thread` is to serve the loader process.  If
+    #               loader process is already exiting, we don't really care if
+    #               the queues are corrupted.
+    #
+    #
+    # Now let's get back to 1:
+    #   how we gracefully exit the workers when the last reference to the
+    #   iterator is gone.
+    #
+    # To achieve this, we implement the following logic along with the design
+    # choices mentioned above:
+    #
+    # `workers_done_event`:
+    #   A `multiprocessing.Event` shared among the main process and all worker
+    #   processes. This is used to signal the workers that the iterator is
+    #   shutting down. After it is set, they will not send processed data to
+    #   queues anymore, and only wait for the final `None` before exiting.
+    #   `done_event` isn't strictly needed. I.e., we can just check for `None`
+    #   from the input queue, but it allows us to skip wasting resources
+    #   processing data if we are already shutting down.
+    #
+    # `pin_memory_thread_done_event`:
+    #   A `threading.Event` for a similar purpose to that of
+    #   `workers_done_event`, but is for the `pin_memory_thread`. The reason
+    #   that separate events are needed is that `pin_memory_thread` reads from
+    #   the output queue of the workers. But the workers, upon seeing that
+    #   `workers_done_event` is set, only wants to see the final `None`, and is
+    #   not required to flush all data in the output queue (e.g., it may call
+    #   `cancel_join_thread` on that queue if its `IterableDataset` iterator
+    #   happens to exhaust coincidentally, which is out of the control of the
+    #   main process). Thus, since we will exit `pin_memory_thread` before the
+    #   workers (see below), two separete events are used.
+    #
+    # NOTE: In short, the protocol is that the main process will set these
+    #       `done_event`s and then the corresponding processes/threads a `None`,
+    #       and that they may exit at any time after receiving the `None`.
+    #
+    # NOTE: Using `None` as the final signal is valid, since normal data will
+    #       always be a 2-tuple with the 1st element being the index of the data
+    #       transferred (different from dataset index/key), and the 2nd being
+    #       either the dataset key or the data sample (depending on which part
+    #       of the data model the queue is at).
+    #
+    # [ worker processes ]
+    #   While loader process is alive:
+    #     Get from `index_queue`.
+    #       If get anything else,
+    #          Check `workers_done_event`.
+    #            If set, continue to next iteration
+    #                    i.e., keep getting until see the `None`, then exit.
+    #            Otherwise, process data:
+    #                If is fetching from an `IterableDataset` and the iterator
+    #                    is exhausted, send an `_IterableDatasetStopIteration`
+    #                    object to signal iteration end. The main process, upon
+    #                    receiving such an object, will send `None` to this
+    #                    worker and not use the corresponding `index_queue`
+    #                    anymore.
+    #       If timed out,
+    #          No matter `workers_done_event` is set (still need to see `None`)
+    #          or not, must continue to next iteration.
+    #   (outside loop)
+    #   If `workers_done_event` is set,  (this can be False with `IterableDataset`)
+    #     `data_queue.cancel_join_thread()`.  (Everything is ending here:
+    #                                          main process won't read from it;
+    #                                          other workers will also call
+    #                                          `cancel_join_thread`.)
+    #
+    # [ pin_memory_thread ]
+    #   # No need to check main thread. If this thread is alive, the main loader
+    #   # thread must be alive, because this thread is set as daemonic.
+    #   While `pin_memory_thread_done_event` is not set:
+    #     Get from `worker_result_queue`.
+    #       If timed out, continue to get in the next iteration.
+    #       Otherwise, process data.
+    #       While `pin_memory_thread_done_event` is not set:
+    #         Put processed data to `data_queue` (a `queue.Queue` with blocking put)
+    #         If timed out, continue to put in the next iteration.
+    #         Otherwise, break, i.e., continuing to the out loop.
+    #
+    #   NOTE: we don't check the status of the main thread because
+    #           1. if the process is killed by fatal signal, `pin_memory_thread`
+    #              ends.
+    #           2. in other cases, either the cleaning-up in __del__ or the
+    #              automatic exit of daemonic thread will take care of it.
+    #              This won't busy-wait either because `.get(timeout)` does not
+    #              busy-wait.
+    #
+    # [ main process ]
+    #   In the DataLoader Iter's `__del__`
+    #     b. Exit `pin_memory_thread`
+    #          i.   Set `pin_memory_thread_done_event`.
+    #          ii   Put `None` in `worker_result_queue`.
+    #          iii. Join the `pin_memory_thread`.
+    #          iv.  `worker_result_queue.cancel_join_thread()`.
+    #
+    #     c. Exit the workers.
+    #          i.   Set `workers_done_event`.
+    #          ii.  Put `None` in each worker's `index_queue`.
+    #          iii. Join the workers.
+    #          iv.  Call `.cancel_join_thread()` on each worker's `index_queue`.
+    #
+    #        NOTE: (c) is better placed after (b) because it may leave corrupted
+    #              data in `worker_result_queue`, which `pin_memory_thread`
+    #              reads from, in which case the `pin_memory_thread` can only
+    #              happen at timing out, which is slow. Nonetheless, same thing
+    #              happens if a worker is killed by signal at unfortunate times,
+    #              but in other cases, we are better off having a non-corrupted
+    #              `worker_result_queue` for `pin_memory_thread`.
+    #
+    #   NOTE: If `pin_memory=False`, there is no `pin_memory_thread` and (b)
+    #         can be omitted
+    #
+    # NB: `done_event`s isn't strictly needed. E.g., we can just check for
+    #     `None` from `index_queue`, but it allows us to skip wasting resources
+    #     processing indices already in `index_queue` if we are already shutting
+    #     down.
+
+    def __init__(self, loader):
+        super().__init__(loader)
+        self._snapshot_interval = loader.checkpoint_every_n_steps
+        self._prefetch_factor = loader.prefetch_factor
+
+        assert self._num_workers > 0
+        assert self._prefetch_factor > 0
+
+        if loader.multiprocessing_context is None:
+            multiprocessing_context = multiprocessing
+        else:
+            multiprocessing_context = loader.multiprocessing_context
+
+        self._worker_init_fn = loader.worker_init_fn
+
+        # Adds forward compatibilities so classic DataLoader can work with DataPipes:
+        #   Additional worker init function will take care of sharding in MP and Distributed
+        if isinstance(self._dataset, (IterDataPipe, MapDataPipe)):
+            self._worker_init_fn = functools.partial(
+                _sharding_worker_init_fn, self._worker_init_fn, self._world_size, self._rank)
+
+        # No certainty which module multiprocessing_context is
+        self._worker_result_queue = multiprocessing_context.Queue()  # type: ignore[var-annotated]
+        self._worker_pids_set = False
+        self._shutdown = False
+        self._workers_done_event = multiprocessing_context.Event()
+
+        self._index_queues = []
+        self._workers = []
+        for i in range(self._num_workers):
+            # No certainty which module multiprocessing_context is
+            index_queue = multiprocessing_context.Queue()  # type: ignore[var-annotated]
+            # Need to `cancel_join_thread` here!
+            # See sections (2) and (3b) above.
+            index_queue.cancel_join_thread()
+            w = multiprocessing_context.Process(
+                target=_utils.worker._worker_loop,
+                args=(self._dataset_kind, self._dataset, index_queue,
+                      self._worker_result_queue, self._workers_done_event,
+                      self._auto_collation, self._collate_fn, self._drop_last,
+                      self._base_seed, self._worker_init_fn, i, self._num_workers,
+                      self._persistent_workers, self._shared_seed))
+            w.daemon = True
+            # NB: Process.start() actually take some time as it needs to
+            #     start a process and pass the arguments over via a pipe.
+            #     Therefore, we only add a worker to self._workers list after
+            #     it started, so that we do not call .join() if program dies
+            #     before it starts, and __del__ tries to join but will get:
+            #     AssertionError: can only join a started process.
+            w.start()
+            self._index_queues.append(index_queue)
+            self._workers.append(w)
+
+        if self._pin_memory:
+            self._pin_memory_thread_done_event = threading.Event()
+
+            # Queue is not type-annotated
+            self._data_queue = queue.Queue()  # type: ignore[var-annotated]
+            if self._pin_memory_device == "xpu":
+                current_device = torch.xpu.current_device()  # type: ignore[attr-defined]
+            elif self._pin_memory_device == torch._C._get_privateuse1_backend_name():
+                custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
+                current_device = custom_device_mod.current_device()
+            else:
+                current_device = torch.cuda.current_device()  # choose cuda for default
+            pin_memory_thread = threading.Thread(
+                target=_utils.pin_memory._pin_memory_loop,
+                args=(self._worker_result_queue, self._data_queue,
+                      current_device,
+                      self._pin_memory_thread_done_event, self._pin_memory_device))
+            pin_memory_thread.daemon = True
+            pin_memory_thread.start()
+            # Similar to workers (see comment above), we only register
+            # pin_memory_thread once it is started.
+            self._pin_memory_thread = pin_memory_thread
+        else:
+            self._data_queue = self._worker_result_queue  # type: ignore[assignment]
+
+        # In some rare cases, persistent workers (daemonic processes)
+        # would be terminated before `__del__` of iterator is invoked
+        # when main process exits
+        # It would cause failure when pin_memory_thread tries to read
+        # corrupted data from worker_result_queue
+        # atexit is used to shutdown thread and child processes in the
+        # right sequence before main process exits
+        if self._persistent_workers and self._pin_memory:
+            import atexit
+            for w in self._workers:
+                atexit.register(_MultiProcessingDataLoaderIter._clean_up_worker, w)
+
+        # .pid can be None only before process is spawned (not the case, so ignore)
+        _utils.signal_handling._set_worker_pids(id(self), tuple(w.pid for w in self._workers))  # type: ignore[misc]
+        _utils.signal_handling._set_SIGCHLD_handler()
+        self._worker_pids_set = True
+        self._snapshot, self._worker_snapshots, self._main_snapshots = {}, {}, collections.deque()
+        self._reset(loader, first_iter=True)
+
+    def _reset_state_vars(self):
+        self._snapshot = {
+            "snapshot_step": 0,
+            "num_workers": self._num_workers,
+            "last_yielded_worker_id": self._num_workers-1,
+        }
+        self._worker_snapshots = {}
+        self._main_snapshots = collections.deque()
+
+    def _reset(self, loader, first_iter=False):
+        super()._reset(loader, first_iter)
+        self._send_idx = 0  # idx of the next task to be sent to workers
+        self._rcvd_idx = 0  # idx of the next task to be returned in __next__
+        # information about data not yet yielded, i.e., tasks w/ indices in range [rcvd_idx, send_idx).
+        # map: task idx => - (worker_id,)        if data isn't fetched (outstanding)
+        #                  \ (worker_id, data)   if data is already fetched (out-of-order)
+        self._task_info = {}
+        self._tasks_outstanding = 0  # always equal to count(v for v in task_info.values() if len(v) == 1)
+        # A list of booleans representing whether each worker still has work to
+        # do, i.e., not having exhausted its iterable dataset object. It always
+        # contains all `True`s if not using an iterable-style dataset
+        # (i.e., if kind != Iterable).
+        # Not that this indicates that a worker still has work to do *for this epoch*.
+        # It does not mean that a worker is dead. In case of `_persistent_workers`,
+        # the worker will be reset to available in the next epoch.
+        self._workers_status = [True for i in range(self._num_workers)]
+        # Reset the worker queue cycle so it resumes next epoch at worker 0
+        self._worker_queue_idx_cycle = itertools.cycle(range(self._num_workers))
+        # We resume the prefetching in case it was enabled
+        if not first_iter:
+            for idx in range(self._num_workers):
+                self._index_queues[idx].put(_utils.worker._ResumeIteration(self._shared_seed))
+            resume_iteration_cnt = self._num_workers
+            while resume_iteration_cnt > 0:
+                return_idx, return_data = self._get_data()
+                if isinstance(return_idx, _utils.worker._ResumeIteration):
+                    assert return_data is None
+                    resume_iteration_cnt -= 1
+        self._reset_state_vars()
+        # prime the prefetch loop
+        for _ in range(self._prefetch_factor * self._num_workers):
+            self._try_put_index()
+
+    def state_dict(self):
+        steps_since_snapshot = self._num_yielded - self._snapshot["snapshot_step"]
+        state_dict = {
+            "snapshot": self._snapshot,
+            "steps_since_snapshot": steps_since_snapshot,
+        }
+
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        # Put load state request on worker index queues
+        worker_states = state_dict["snapshot"].get("worker_snapshots", {})
+        if worker_states:
+            assert set(range(len(worker_states))) == set(worker_states.keys())
+        request_uuid = uuid.uuid4()
+        for idx in range(self._num_workers):
+            if idx in worker_states:
+                ws = worker_states[idx]
+            else:
+                ws = "skip"
+            self._index_queues[idx].put(
+                _utils.worker._LoadStateRequest(request_uuid, idx, ws)
+            )
+        acks = [None] * self._num_workers
+        remaining = self._num_workers
+        # TODO: add timeout
+        while remaining > 0:
+            return_idx, return_data = self._get_data()
+            if isinstance(return_idx, _utils.worker._LoadStateRequestComplete):
+                if return_idx.uuid != request_uuid:
+                    continue
+                assert acks[return_idx.worker_id] is None
+                acks[return_idx.worker_id] = True
+                remaining -= 1
+
+        assert all(acks)
+
+        if "main_snapshot" in state_dict["snapshot"]:
+            self._restore_main_state(state_dict["snapshot"]["main_snapshot"])
+        self._num_yielded = state_dict["snapshot"]["snapshot_step"]
+        self._last_yielded_worker_id = state_dict["snapshot"]["last_yielded_worker_id"]
+        self._worker_queue_idx_cycle = itertools.cycle(range(self._num_workers))
+        for _ in range(self._last_yielded_worker_id + 1):
+            next(self._worker_queue_idx_cycle)
+
+        self._send_idx = 0  # idx of the next task to be sent to workers
+        self._rcvd_idx = 0  # idx of the next task to be returned in __next__
+        # information about data not yet yielded, i.e., tasks w/ indices in range [rcvd_idx, send_idx).
+        # map: task idx => - (worker_id,)        if data isn't fetched (outstanding)
+        #                  \ (worker_id, data)   if data is already fetched (out-of-order)
+        self._task_info = {}
+        self._tasks_outstanding = 0  # always equal to count(v for v in task_info.values() if len(v) == 1)
+
+        # prime the prefetch loop
+        for _ in range(self._prefetch_factor * self._num_workers):
+            self._try_put_index()
+
+        for i in range(state_dict["steps_since_snapshot"]):
+            next(self)
+
+    def _try_get_data(self, timeout=_utils.MP_STATUS_CHECK_INTERVAL):
+        # Tries to fetch data from `self._data_queue` once for a given timeout.
+        # This can also be used as inner loop of fetching without timeout, with
+        # the sender status as the loop condition.
+        #
+        # This raises a `RuntimeError` if any worker died expectedly. This error
+        # can come from either the SIGCHLD handler in `_utils/signal_handling.py`
+        # (only for non-Windows platforms), or the manual check below on errors
+        # and timeouts.
+        #
+        # Returns a 2-tuple:
+        #   (bool: whether successfully get data, any: data if successful else None)
+        try:
+            data = self._data_queue.get(timeout=timeout)
+            return (True, data)
+        except Exception as e:
+            # At timeout and error, we manually check whether any worker has
+            # failed. Note that this is the only mechanism for Windows to detect
+            # worker failures.
+            failed_workers = []
+            for worker_id, w in enumerate(self._workers):
+                if self._workers_status[worker_id] and not w.is_alive():
+                    failed_workers.append(w)
+                    self._mark_worker_as_unavailable(worker_id)
+            if len(failed_workers) > 0:
+                pids_str = ', '.join(str(w.pid) for w in failed_workers)
+                raise RuntimeError(f'DataLoader worker (pid(s) {pids_str}) exited unexpectedly') from e
+            if isinstance(e, queue.Empty):
+                return (False, None)
+            import tempfile
+            import errno
+            try:
+                # Raise an exception if we are this close to the FDs limit.
+                # Apparently, trying to open only one file is not a sufficient
+                # test.
+                # See NOTE [ DataLoader on Linux and open files limit ]
+                fds_limit_margin = 10
+                fs = [tempfile.NamedTemporaryFile() for i in range(fds_limit_margin)]
+            except OSError as e:
+                if e.errno == errno.EMFILE:
+                    raise RuntimeError(
+                        "Too many open files. Communication with the"
+                        " workers is no longer possible. Please increase the"
+                        " limit using `ulimit -n` in the shell or change the"
+                        " sharing strategy by calling"
+                        " `torch.multiprocessing.set_sharing_strategy('file_system')`"
+                        " at the beginning of your code") from None
+            raise
+
+# NOTE [ DataLoader on Linux and open files limit ]
+#
+# On Linux when DataLoader is used with multiprocessing we pass the data between
+# the root process and the workers through SHM files. We remove those files from
+# the filesystem as soon as they are created and keep them alive by
+# passing around their file descriptors through AF_UNIX sockets. (See
+# docs/source/multiprocessing.rst and 'Multiprocessing Technical Notes` in
+# the wiki (https://github.com/pytorch/pytorch/wiki).)
+#
+# This sometimes leads us to exceeding the open files limit. When that happens,
+# and the offending file descriptor is coming over a socket, the `socket` Python
+# package silently strips the file descriptor from the message, setting only the
+# `MSG_CTRUNC` flag (which might be a bit misleading since the manpage says that
+# it _indicates that some control data were discarded due to lack of space in
+# the buffer for ancillary data_). This might reflect the C implementation of
+# AF_UNIX sockets.
+#
+# This behaviour can be reproduced with the script and instructions at the
+# bottom of this note.
+#
+# When that happens, the standard Python `multiprocessing` (and not
+# `torch.multiprocessing`) raises a `RuntimeError: received 0 items of ancdata`
+#
+# Sometimes, instead of the FD being stripped, you may get an `OSError:
+# Too many open files`, both in the script below and in DataLoader. However,
+# this is rare and seems to be nondeterministic.
+#
+#
+#   #!/usr/bin/env python3
+#   import sys
+#   import socket
+#   import os
+#   import array
+#   import shutil
+#   import socket
+#
+#
+#   if len(sys.argv) != 4:
+#       print("Usage: ", sys.argv[0], " tmp_dirname iteration (send|recv)")
+#       sys.exit(1)
+#
+#   if __name__ == '__main__':
+#       dirname = sys.argv[1]
+#       sock_path = dirname + "/sock"
+#       iterations = int(sys.argv[2])
+#       def dummy_path(i):
+#           return dirname + "/" + str(i) + ".dummy"
+#
+#
+#       if sys.argv[3] == 'send':
+#           while not os.path.exists(sock_path):
+#               pass
+#           client = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+#           client.connect(sock_path)
+#           for i in range(iterations):
+#               fd = os.open(dummy_path(i), os.O_WRONLY | os.O_CREAT)
+#               ancdata = array.array('i', [fd])
+#               msg = bytes([i % 256])
+#               print("Sending fd ", fd, " (iteration #", i, ")")
+#               client.sendmsg([msg], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, ancdata)])
+#
+#
+#       else:
+#           assert sys.argv[3] == 'recv'
+#
+#           if os.path.exists(dirname):
+#               raise Exception("Directory exists")
+#
+#           os.mkdir(dirname)
+#
+#           print("Opening socket...")
+#           server = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+#           server.bind(sock_path)
+#
+#           print("Listening...")
+#           for i in range(iterations):
+#               a = array.array('i')
+#               msg, ancdata, flags, addr = server.recvmsg(1, socket.CMSG_SPACE(a.itemsize))
+#               assert(len(ancdata) == 1)
+#               cmsg_level, cmsg_type, cmsg_data = ancdata[0]
+#               a.frombytes(cmsg_data)
+#               print("Received fd ", a[0], " (iteration #", i, ")")
+#
+#           shutil.rmtree(dirname)
+#
+# Steps to reproduce:
+#
+# 1. Run two shells and set lower file descriptor limit in the receiving one:
+# (shell1) ulimit -n 1020
+# (shell2) ulimit -n 1022
+#
+# 2. Run the script above with the `recv` option in the first shell
+# (shell1) ./test_socket.py sock_tmp 1017 recv
+#
+# 3. Run the script with the `send` option in the second shell:
+# (shell2) ./test_socket.py sock_tmp 1017 send
+
+    def _get_data(self):
+        # Fetches data from `self._data_queue`.
+        #
+        # We check workers' status every `MP_STATUS_CHECK_INTERVAL` seconds,
+        # which we achieve by running `self._try_get_data(timeout=MP_STATUS_CHECK_INTERVAL)`
+        # in a loop. This is the only mechanism to detect worker failures for
+        # Windows. For other platforms, a SIGCHLD handler is also used for
+        # worker failure detection.
+        #
+        # If `pin_memory=True`, we also need check if `pin_memory_thread` had
+        # died at timeouts.
+        if self._timeout > 0:
+            success, data = self._try_get_data(self._timeout)
+            if success:
+                return data
+            else:
+                raise RuntimeError(f'DataLoader timed out after {self._timeout} seconds')
+        elif self._pin_memory:
+            while self._pin_memory_thread.is_alive():
+                success, data = self._try_get_data()
+                if success:
+                    return data
+            else:
+                # while condition is false, i.e., pin_memory_thread died.
+                raise RuntimeError('Pin memory thread exited unexpectedly')
+            # In this case, `self._data_queue` is a `queue.Queue`,. But we don't
+            # need to call `.task_done()` because we don't use `.join()`.
+        else:
+            while True:
+                success, data = self._try_get_data()
+                if success:
+                    return data
+
+    def _next_data(self):
+        while True:
+            # If the worker responsible for `self._rcvd_idx` has already ended
+            # and was unable to fulfill this task (due to exhausting an `IterableDataset`),
+            # we try to advance `self._rcvd_idx` to find the next valid index.
+            #
+            # This part needs to run in the loop because both the `self._get_data()`
+            # call and `_IterableDatasetStopIteration` check below can mark
+            # extra worker(s) as dead.
+            while self._rcvd_idx < self._send_idx:
+                info = self._task_info[self._rcvd_idx]
+                worker_id = info[0]
+                if len(info) == 2 or self._workers_status[worker_id]:  # has data or is still active
+                    break
+                del self._task_info[self._rcvd_idx]
+                self._rcvd_idx += 1
+            else:
+                # no valid `self._rcvd_idx` is found (i.e., didn't break)
+                if not self._persistent_workers:
+                    self._shutdown_workers()
+                raise StopIteration
+
+            # Now `self._rcvd_idx` is the batch index we want to fetch
+
+            # Check if the next sample has already been generated
+            if len(self._task_info[self._rcvd_idx]) == 2:
+                data, worker_id, state_dict = self._task_info.pop(self._rcvd_idx)[1]
+                return self._process_data(data, worker_id, state_dict)
+
+            assert not self._shutdown and self._tasks_outstanding > 0
+            idx, (data, worker_id, state_dict) = self._get_data()
+            self._tasks_outstanding -= 1
+            if self._dataset_kind == _DatasetKind.Iterable:
+                # Check for _IterableDatasetStopIteration
+                if isinstance(data, _utils.worker._IterableDatasetStopIteration):
+                    self._workers_status[data.worker_id] = False
+                    self._try_put_index()
+                    assert state_dict is not None, "StopIteration should always be accompanied by a state_dict"
+                    self._worker_snapshots[data.worker_id] = state_dict
+                    continue
+
+            if idx != self._rcvd_idx:
+                # store out-of-order samples
+                self._task_info[idx] += ((data, worker_id, state_dict),)
+            else:
+                del self._task_info[idx]
+                return self._process_data(data, worker_id, state_dict)
+
+    def _get_main_state(self):
+        return {
+            "_num_workers": self._num_workers,
+            "_sampler_iter": try_to_serialize(self._sampler_iter, pickle=True),
+            "_index_sampler": try_to_serialize(self._index_sampler, pickle=True),
+            "_sampler_iter_yielded": self._sampler_iter_yielded,
+            "random_rng_state": random.getstate(),
+            "torch_rng_state": torch.get_rng_state(),
+            "numpy_rng_state": np.random.get_state() if HAS_NUMPY else None,
+            "_workers_status": copy.deepcopy(self._workers_status),
+            "_IterableDataset_len_called": self._IterableDataset_len_called,
+            "_shared_seed": self._shared_seed,
+        }
+
+    def _restore_main_state(self, state_dict):
+        assert self._num_workers == state_dict["_num_workers"]
+        self._index_sampler = (
+            try_to_deserialize(self._index_sampler, state_dict["_index_sampler"])
+            or self._index_sampler
+        )
+        self._sampler_iter_yielded = state_dict["_sampler_iter_yielded"]
+        sampler_iter = try_to_deserialize(
+            self._sampler_iter, state_dict["_sampler_iter"]
+        )
+        if sampler_iter is None:
+            # Fallback to fastforward
+            sampler_iter = itertools.islice(
+                self._index_sampler, self._sampler_iter_yielded, None
+            )
+        self._workers_status = state_dict["_workers_status"]
+        self._sampler_iter = sampler_iter
+        self._IterableDataset_len_called = state_dict["_IterableDataset_len_called"]
+        self._shared_seed = state_dict["_shared_seed"]
+        random.setstate(state_dict["random_rng_state"])
+        torch.set_rng_state(state_dict["torch_rng_state"])
+        if HAS_NUMPY and state_dict["numpy_rng_state"] is not None:
+            np.random.set_state(state_dict["numpy_rng_state"])
+
+    def _try_put_index(self):
+        assert self._tasks_outstanding < self._prefetch_factor * self._num_workers
+
+        try:
+            index = self._next_index()
+            snapshot_main = False
+            snapshot = False
+            if self._dataset_kind == _DatasetKind.Iterable:
+                x = self._num_yielded % self._snapshot_interval
+                hi = x + 1 + self._num_workers * self._prefetch_factor
+                if hi >= self._snapshot_interval:
+                    snapshot_main = True
+                if hi + self._num_workers >= self._snapshot_interval:
+                    snapshot = True
+            else:
+                if self._sampler_iter_yielded % self._snapshot_interval == 0:
+                    # Snapshot sampler
+                    snapshot_main = True
+                if (
+                    (self._sampler_iter_yielded - 1) % self._snapshot_interval
+                ) + self._num_workers >= self._snapshot_interval:
+                    snapshot = True
+        except StopIteration:
+            return
+        for _ in range(self._num_workers):  # find the next active worker, if any
+            worker_queue_idx = next(self._worker_queue_idx_cycle)
+            if self._workers_status[worker_queue_idx]:
+                break
+        else:
+            # not found (i.e., didn't break)
+            return
+
+        if snapshot_main:
+            assert snapshot
+            self._main_snapshots.append((self._send_idx, self._get_main_state()))
+
+        self._index_queues[worker_queue_idx].put((self._send_idx, (index, snapshot)))  # type: ignore[possibly-undefined]
+        self._task_info[self._send_idx] = (worker_queue_idx,)
+        self._tasks_outstanding += 1
+        self._send_idx += 1
+
+    def _process_data(self, data, worker_id, state_dict):
+        self._rcvd_idx += 1
+        self._try_put_index()
+        if isinstance(data, ExceptionWrapper):
+            data.reraise()
+        self._last_yielded_worker_id = worker_id
+        # Update latest worker state
+        if state_dict is not None:
+            self._worker_snapshots[state_dict["worker_id"]] = state_dict
+        if (self._num_yielded + 1) % self._snapshot_interval == 0:
+            self._take_snapshot()
+        return data
+
+    def _take_snapshot(self):
+        while len(self._main_snapshots) and (self._main_snapshots[0][0] <= self._rcvd_idx - 1):
+            main_snapshot_idx, main_snapshot = self._main_snapshots.popleft()
+        assert main_snapshot_idx == self._rcvd_idx - 1, (main_snapshot_idx, self._rcvd_idx - 1)
+
+        self._snapshot = {
+            "snapshot_step": self._num_yielded + 1,
+            "last_yielded_worker_id": self._last_yielded_worker_id,
+            "num_workers": self._num_workers,
+            "main_snapshot": main_snapshot,
+            "worker_snapshots": dict(self._worker_snapshots),  # shallow copy
+        }
+
+    def _mark_worker_as_unavailable(self, worker_id, shutdown=False):
+        # Mark a worker as having finished its work e.g., due to
+        # exhausting an `IterableDataset`. This should be used only when this
+        # `_MultiProcessingDataLoaderIter` is going to continue running.
+
+        assert self._workers_status[worker_id] or self._persistent_workers or shutdown
+
+        # Signal termination to that specific worker.
+        q = self._index_queues[worker_id]
+        # Indicate that no more data will be put on this queue by the current
+        # process.
+        q.put(None)
+
+        # Note that we don't actually join the worker here, nor do we remove the
+        # worker's pid from C side struct because (1) joining may be slow, and
+        # (2) since we don't join, the worker may still raise error, and we
+        # prefer capturing those, rather than ignoring them, even though they
+        # are raised after the worker has finished its job.
+        # Joinning is deferred to `_shutdown_workers`, which it is called when
+        # all workers finish their jobs (e.g., `IterableDataset` replicas) or
+        # when this iterator is garbage collected.
+
+        self._workers_status[worker_id] = False
+
+        assert self._workers_done_event.is_set() == shutdown
+
+    def _shutdown_workers(self):
+        # Called when shutting down this `_MultiProcessingDataLoaderIter`.
+        # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on
+        # the logic of this function.
+        if _utils is None or _utils.python_exit_status is True or _utils.python_exit_status is None:
+            # See (2) of the note. If Python is shutting down, do no-op.
+            return
+        # Normal exit when last reference is gone / iterator is depleted.
+        # See (1) and the second half of the note.
+        if not self._shutdown:
+            self._shutdown = True
+            try:
+                # Normal exit when last reference is gone / iterator is depleted.
+                # See (1) and the second half of the note.
+
+                # Exit `pin_memory_thread` first because exiting workers may leave
+                # corrupted data in `worker_result_queue` which `pin_memory_thread`
+                # reads from.
+                if hasattr(self, '_pin_memory_thread'):
+                    # Use hasattr in case error happens before we set the attribute.
+                    self._pin_memory_thread_done_event.set()
+                    # Send something to pin_memory_thread in case it is waiting
+                    # so that it can wake up and check `pin_memory_thread_done_event`
+                    self._worker_result_queue.put((None, None))
+                    self._pin_memory_thread.join()
+                    self._worker_result_queue.cancel_join_thread()
+                    self._worker_result_queue.close()
+
+                # Exit workers now.
+                self._workers_done_event.set()
+                for worker_id in range(len(self._workers)):
+                    # Get number of workers from `len(self._workers)` instead of
+                    # `self._num_workers` in case we error before starting all
+                    # workers.
+                    # If we are using workers_status with persistent_workers
+                    # we have to shut it down because the worker is paused
+                    if self._persistent_workers or self._workers_status[worker_id]:
+                        self._mark_worker_as_unavailable(worker_id, shutdown=True)
+                for w in self._workers:
+                    # We should be able to join here, but in case anything went
+                    # wrong, we set a timeout and if the workers fail to join,
+                    # they are killed in the `finally` block.
+                    w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
+                for q in self._index_queues:
+                    q.cancel_join_thread()
+                    q.close()
+            finally:
+                # Even though all this function does is putting into queues that
+                # we have called `cancel_join_thread` on, weird things can
+                # happen when a worker is killed by a signal, e.g., hanging in
+                # `Event.set()`. So we need to guard this with SIGCHLD handler,
+                # and remove pids from the C side data structure only at the
+                # end.
+                #
+                # FIXME: Unfortunately, for Windows, we are missing a worker
+                #        error detection mechanism here in this function, as it
+                #        doesn't provide a SIGCHLD handler.
+                if self._worker_pids_set:
+                    _utils.signal_handling._remove_worker_pids(id(self))
+                    self._worker_pids_set = False
+                for w in self._workers:
+                    if w.is_alive():
+                        # Existing mechanisms try to make the workers exit
+                        # peacefully, but in case that we unfortunately reach
+                        # here, which we shouldn't, (e.g., pytorch/pytorch#39570),
+                        # we kill the worker.
+                        w.terminate()
+
+    # staticmethod is used to remove reference to `_MultiProcessingDataLoaderIter`
+    @staticmethod
+    def _clean_up_worker(w):
+        try:
+            w.join(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
+        finally:
+            if w.is_alive():
+                w.terminate()
+
+    def __del__(self):
+        self._shutdown_workers()

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -33,7 +33,7 @@ from torch._utils import ExceptionWrapper
 
 from .worker import try_to_deserialize, try_to_serialize
 from .stateful import Stateful
-from . import sampler
+from . import sampler  # noqa
 
 try:
     import numpy as np

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -233,7 +233,7 @@ class StatefulDataLoader(DataLoader[T_co]):
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         if self.iter_calls > 0:
             raise RuntimeError(
-                "Cannot restore state on DataLoader that has already had an iterator created!"
+                "Cannot restore state on DataLoader that has already created an iterator!"
             )
         self.next_iter_state = state_dict
 

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -723,6 +723,8 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             assert set(range(len(wstates))) == set(wstates.keys()), (len(wstates), wstates.keys())
             for wid, sd in wstates.items():
                 worker_states[wid] = sd
+            self._base_seed = next_iter_state["snapshot"]["main_snapshot"].get("_base_seed", self._base_seed)
+            self._shared_seed = next_iter_state["snapshot"]["main_snapshot"].get("_shared_seed", self._shared_seed)
 
         for i in range(self._num_workers):
             # No certainty which module multiprocessing_context is
@@ -1162,6 +1164,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             "_sampler_iter_yielded": self._sampler_iter_yielded,
             "_IterableDataset_len_called": self._IterableDataset_len_called,
             "_shared_seed": self._shared_seed,
+            "_base_seed": self._base_seed,
         }
 
     def _restore_main_state(self, state_dict):
@@ -1179,6 +1182,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
                 self._sampler_iter = itertools.islice(self._index_sampler, self._sampler_iter_yielded, None)
         self._IterableDataset_len_called = state_dict["_IterableDataset_len_called"]
         self._shared_seed = state_dict["_shared_seed"]
+        self._base_seed = state_dict["_base_seed"]
 
     def _try_put_index(self):
         assert self._tasks_outstanding < self._prefetch_factor * self._num_workers

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -103,9 +103,7 @@ def _worker_loop(
             if init_fn is not None:
                 init_fn(worker_id)
 
-            fetcher = _DatasetKind.create_fetcher(
-                dataset_kind, dataset, auto_collation, collate_fn, drop_last
-            )
+            fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
 
             # Restore worker state if provided
             if worker_state:
@@ -133,9 +131,7 @@ def _worker_loop(
 
                 del worker_state
         except Exception:
-            init_exception = ExceptionWrapper(
-                where=f"in DataLoader worker process {worker_id}"
-            )
+            init_exception = ExceptionWrapper(where=f"in DataLoader worker process {worker_id}")
 
         # When using Iterable mode, some worker can exit earlier than others due
         # to the IterableDataset behaving differently for different workers.
@@ -169,9 +165,7 @@ def _worker_loop(
                     dataset = apply_random_seed(dataset, shared_rng)
 
                 # Recreate the fetcher for worker-reuse policy
-                fetcher = _DatasetKind.create_fetcher(
-                    dataset_kind, dataset, auto_collation, collate_fn, drop_last
-                )
+                fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
                 continue
             elif r is None:
                 # Received the final signal
@@ -192,10 +186,7 @@ def _worker_loop(
                 try:
                     data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
                 except Exception as e:
-                    if (
-                        isinstance(e, StopIteration)
-                        and dataset_kind == _DatasetKind.Iterable
-                    ):
+                    if isinstance(e, StopIteration) and dataset_kind == _DatasetKind.Iterable:
                         data = _IterableDatasetStopIteration(worker_id)
                         # Set `iteration_end`
                         #   (1) to save future `next(...)` calls, and
@@ -205,16 +196,8 @@ def _worker_loop(
                         # It is important that we don't store exc_info in a variable.
                         # `ExceptionWrapper` does the correct thing.
                         # See NOTE [ Python Traceback Reference Cycle Problem ]
-                        data = ExceptionWrapper(
-                            where=f"in DataLoader worker process {worker_id}"
-                        )
+                        data = ExceptionWrapper(where=f"in DataLoader worker process {worker_id}")
                 if snapshot or iteration_end:
-                    # always generate snapshot when Iterable raises StopIteration.
-                    if HAS_NUMPY:
-                        numpy_state = np.random.get_state()
-                    else:
-                        numpy_state = None
-
                     if dataset_kind == _DatasetKind.Iterable:
                         fetcher_state = {
                             "dataset_iter": try_to_serialize(fetcher.dataset_iter),

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -185,7 +185,7 @@ def _worker_loop(
             else:
                 try:
                     try:
-                        data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
+                        data = fetcher.fetch(index)  # type: ignore[union-attr]
                     except StopIteration:
                         if not dataset_kind == _DatasetKind.Iterable:
                             raise
@@ -197,8 +197,8 @@ def _worker_loop(
                     if snapshot or iteration_end:
                         if dataset_kind == _DatasetKind.Iterable:
                             fetcher_state = {
-                                "dataset_iter": try_to_serialize(fetcher.dataset_iter),
-                                "ended": fetcher.ended,
+                                "dataset_iter": try_to_serialize(fetcher.dataset_iter),  # type: ignore[union-attr]
+                                "ended": fetcher.ended,  # type: ignore[union-attr]
                             }
                         else:
                             fetcher_state = None

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -36,7 +36,7 @@ def try_to_serialize(obj: Any) -> Union[dict, None]:
     return obj_state
 
 
-def try_to_deserialize(obj: T, state_dict: Union[dict, None]) -> Union[T, None]:
+def try_to_deserialize(obj: T, state_dict: dict) -> T:
     if isinstance(obj, Stateful):
         obj.load_state_dict(state_dict)
         return obj  # type: ignore[return-value]

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -189,8 +189,7 @@ def _worker_loop(
                 continue
             if isinstance(r, _LoadStateRequest):
                 # Restore state from r.state_dict
-                # index_buffer.clear()
-                if r.state_dict == "skip":  # TODO: is this used?
+                if r.state_dict == "skip":
                     state_dict = copy.deepcopy(initial_state_dict)
                 else:
                     state_dict = r.state_dict

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -1,0 +1,362 @@
+r""""Contains definitions of the methods used by the _BaseDataLoaderIter workers.
+
+These **needs** to be in global scope since Py2 doesn't support serializing
+static methods.
+"""
+
+import torch
+import random
+import copy
+import os
+import pickle
+import queue
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, TYPE_CHECKING, Union
+
+from torch._utils import ExceptionWrapper
+from typing import Optional, Union, TYPE_CHECKING
+from torch.utils.data._utils import signal_handling, MP_STATUS_CHECK_INTERVAL, IS_WINDOWS, HAS_NUMPY
+from torch.utils.data._utils.worker import WorkerInfo, _generate_state
+if TYPE_CHECKING:
+    from torch.utils.data import Dataset
+
+if IS_WINDOWS:
+    import ctypes
+    from ctypes.wintypes import DWORD, BOOL, HANDLE
+
+    # On Windows, the parent ID of the worker process remains unchanged when the manager process
+    # is gone, and the only way to check it through OS is to let the worker have a process handle
+    # of the manager and ask if the process status has changed.
+    class ManagerWatchdog:
+        def __init__(self):
+            self.manager_pid = os.getppid()
+
+            # mypy cannot detect this code is windows only
+            self.kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)  # type: ignore[attr-defined]
+            self.kernel32.OpenProcess.argtypes = (DWORD, BOOL, DWORD)
+            self.kernel32.OpenProcess.restype = HANDLE
+            self.kernel32.WaitForSingleObject.argtypes = (HANDLE, DWORD)
+            self.kernel32.WaitForSingleObject.restype = DWORD
+
+            # Value obtained from https://msdn.microsoft.com/en-us/library/ms684880.aspx
+            SYNCHRONIZE = 0x00100000
+            self.manager_handle = self.kernel32.OpenProcess(SYNCHRONIZE, 0, self.manager_pid)
+
+            if not self.manager_handle:
+                raise ctypes.WinError(ctypes.get_last_error())  # type: ignore[attr-defined]
+
+            self.manager_dead = False
+
+        def is_alive(self):
+            if not self.manager_dead:
+                # Value obtained from https://msdn.microsoft.com/en-us/library/windows/desktop/ms687032.aspx
+                self.manager_dead = self.kernel32.WaitForSingleObject(self.manager_handle, 0) == 0
+            return not self.manager_dead
+else:
+    class ManagerWatchdog:  # type: ignore[no-redef]
+        def __init__(self):
+            self.manager_pid = os.getppid()
+            self.manager_dead = False
+
+        def is_alive(self):
+            if not self.manager_dead:
+                self.manager_dead = os.getppid() != self.manager_pid
+            return not self.manager_dead
+
+
+# def get_worker_info() -> Optional[WorkerInfo]:
+#     r"""Returns the information about the current
+#     :class:`~torch.utils.data.DataLoader` iterator worker process.
+
+#     When called in a worker, this returns an object guaranteed to have the
+#     following attributes:
+
+#     * :attr:`id`: the current worker id.
+#     * :attr:`num_workers`: the total number of workers.
+#     * :attr:`seed`: the random seed set for the current worker. This value is
+#       determined by main process RNG and the worker id. See
+#       :class:`~torch.utils.data.DataLoader`'s documentation for more details.
+#     * :attr:`dataset`: the copy of the dataset object in **this** process. Note
+#       that this will be a different object in a different process than the one
+#       in the main process.
+
+#     When called in the main process, this returns ``None``.
+
+#     .. note::
+#        When used in a :attr:`worker_init_fn` passed over to
+#        :class:`~torch.utils.data.DataLoader`, this method can be useful to
+#        set up each worker process differently, for instance, using ``worker_id``
+#        to configure the ``dataset`` object to only read a specific fraction of a
+#        sharded dataset, or use ``seed`` to seed other libraries used in dataset
+#        code.
+#     """
+#     return _worker_info
+
+
+# r"""Dummy class used to signal the end of an IterableDataset"""
+# @dataclass(frozen=True)
+# class _IterableDatasetStopIteration:
+#     worker_id: int
+
+# r"""Dummy class used to resume the fetching when worker reuse is enabled"""
+# @dataclass(frozen=True)
+# class _ResumeIteration:
+#     seed: Optional[int] = None
+
+from torch.utils.data._utils.worker import _IterableDatasetStopIteration, _ResumeIteration
+
+r"""Dummy class used to signal StateRequest"""
+@dataclass(frozen=True)
+class _StateRequest:
+    uuid: str
+    worker_id: int
+
+r"""Dummy class used to signal StateRequestComplete"""
+@dataclass(frozen=True)
+class _StateRequestComplete:
+    uuid: str
+
+r"""Dummy class used to signal LoadStateRequest"""
+@dataclass(frozen=True)
+class _LoadStateRequest:
+    uuid: str
+    worker_id: int
+    state_dict: Dict[str, Any]
+
+r"""Dummy class used to signal LoadStateRequest"""
+@dataclass(frozen=True)
+class _LoadStateRequestComplete:
+    uuid: str
+    worker_id: int
+
+
+def try_to_serialize(obj: Any, pickle: bool) -> Union[dict, bytes, None]:
+    if hasattr(obj, "state_dict") and hasattr(obj, "load_state_dict"):
+        obj_state = obj.state_dict()
+    elif pickle:
+        try:
+            obj_state = pickle.dumps(obj)
+        except Exception:
+            # If pickle fails, we fall back to copying the state
+            # dict. This is not ideal, but it's better than
+            # failing entirely.
+            obj_state = None
+    else:
+        obj_state = None
+
+    return obj_state
+
+
+def try_to_deserialize(obj: Any, serialized: Union[dict, bytes, None]) -> Union[Any, None]:
+    if hasattr(obj, "load_state_dict"):
+        obj.load_state_dict(serialized)
+        return obj
+    else:
+        try:
+            obj = pickle.loads(serialized)
+        except:
+            obj = None
+    return obj
+
+
+def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
+                 auto_collation, collate_fn, drop_last, base_seed, init_fn, worker_id,
+                 num_workers, persistent_workers, shared_seed):
+    # See NOTE [ Data Loader Multiprocessing Shutdown Logic ] for details on the
+    # logic of this function.
+
+    try:
+        # Initialize C side signal handlers for SIGBUS and SIGSEGV. Python signal
+        # module's handlers are executed after Python returns from C low-level
+        # handlers, likely when the same fatal signal had already happened
+        # again.
+        # https://docs.python.org/3/library/signal.html#execution-of-python-signal-handlers
+        signal_handling._set_worker_signal_handlers()
+
+        torch.set_num_threads(1)
+        seed = base_seed + worker_id
+        random.seed(seed)
+        torch.manual_seed(seed)
+        if HAS_NUMPY:
+            np_seed = _generate_state(base_seed, worker_id)
+            import numpy as np
+            np.random.seed(np_seed)
+
+        from torch.utils.data import IterDataPipe
+        from torch.utils.data.graph_settings import apply_random_seed
+
+        shared_rng = torch.Generator()
+        if isinstance(dataset, IterDataPipe):
+            assert shared_seed is not None
+            shared_rng.manual_seed(shared_seed)
+            dataset = apply_random_seed(dataset, shared_rng)
+
+        # global _worker_info
+        torch.utils.data._utils.worker._worker_info = WorkerInfo(
+            id=worker_id, num_workers=num_workers, seed=seed, dataset=dataset)
+
+        from torch.utils.data import _DatasetKind
+
+        init_exception = None
+
+        fetcher = None
+        try:
+            if init_fn is not None:
+                init_fn(worker_id)
+
+            fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
+
+            if HAS_NUMPY:
+                numpy_state = np.random.get_state()
+            else:
+                numpy_state = None
+
+            if dataset_kind == _DatasetKind.Iterable:
+                fetcher_state = {
+                    "dataset_iter": try_to_serialize(fetcher.dataset_iter, False),
+                    "ended": fetcher.ended,
+                }
+            else:
+                fetcher_state = None
+            # Pick up any user-defined dataset state, for both map/iterable style datasets
+            dataset_state = try_to_serialize(dataset, False)
+            initial_state_dict = copy.deepcopy({
+                "worker_id": worker_id,
+                "fetcher_state": fetcher_state,
+                "dataset_state": dataset_state,
+                "shared_rng": shared_rng.get_state(),
+                "random_rng_state": random.getstate(),
+                "torch_rng_state": torch.get_rng_state(),
+                "numpy_rng_state": numpy_state,
+                "iteration_end": False,
+            })
+        except Exception:
+            init_exception = ExceptionWrapper(
+                where=f"in DataLoader worker process {worker_id}")
+
+        # When using Iterable mode, some worker can exit earlier than others due
+        # to the IterableDataset behaving differently for different workers.
+        # When such things happen, an `_IterableDatasetStopIteration` object is
+        # sent over to the main process with the ID of this worker, so that the
+        # main process won't send more tasks to this worker, and will send
+        # `None` to this worker to properly exit it.
+        #
+        # Note that we cannot set `done_event` from a worker as it is shared
+        # among all processes. Instead, we set the `iteration_end` flag to
+        # signify that the iterator is exhausted. When either `done_event` or
+        # `iteration_end` is set, we skip all processing step and just wait for
+        # `None`.
+        iteration_end = False
+
+        watchdog = ManagerWatchdog()
+
+        while watchdog.is_alive():
+            try:
+                r = index_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)
+            except queue.Empty:
+                continue
+            if isinstance(r, _LoadStateRequest):
+                # Restore state from r.state_dict
+                # index_buffer.clear()
+                if r.state_dict == "skip":  # TODO: is this used?
+                    state_dict = copy.deepcopy(initial_state_dict)
+                else:
+                    state_dict = r.state_dict
+
+                if state_dict["fetcher_state"] is not None:
+                    fetcher.dataset_iter = try_to_deserialize(fetcher.dataset_iter, state_dict["fetcher_state"]["dataset_iter"])
+                    fetcher.ended = state_dict["fetcher_state"]["ended"]
+                if state_dict["dataset_state"] is not None:
+                    dataset = try_to_deserialize(dataset, state_dict["dataset_state"])
+                shared_rng.set_state(state_dict["shared_rng"])
+                random.setstate(state_dict["random_rng_state"])
+                torch.set_rng_state(state_dict["torch_rng_state"])
+                if HAS_NUMPY:
+                    np.random.set_state(state_dict["numpy_rng_state"])
+                # iteration_end = state_dict["iteration_end"]
+                iteration_end = False
+
+                data_queue.put((_LoadStateRequestComplete(r.uuid, r.worker_id), None))
+                del state_dict
+                continue
+            elif isinstance(r, _ResumeIteration):
+                # Acknowledge the main process
+                data_queue.put((r, None))
+                iteration_end = False
+
+                if isinstance(dataset, IterDataPipe):
+                    assert r.seed is not None
+                    shared_rng.manual_seed(r.seed)
+                    dataset = apply_random_seed(dataset, shared_rng)
+
+                # Recreate the fetcher for worker-reuse policy
+                fetcher = _DatasetKind.create_fetcher(
+                    dataset_kind, dataset, auto_collation, collate_fn, drop_last)
+                continue
+            elif r is None:
+                # Received the final signal
+                assert done_event.is_set() or iteration_end
+                break
+            elif done_event.is_set() or iteration_end:
+                # `done_event` is set. But I haven't received the final signal
+                # (None) yet. I will keep continuing until get it, and skip the
+                # processing steps.
+                continue
+            idx, (index, snapshot) = r
+            data: Union[_IterableDatasetStopIteration, ExceptionWrapper]
+            state_dict = None
+            if init_exception is not None:
+                data = init_exception
+                # init_exception = None
+            else:
+                try:
+                    data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
+                except Exception as e:
+                    if isinstance(e, StopIteration) and dataset_kind == _DatasetKind.Iterable:
+                        data = _IterableDatasetStopIteration(worker_id)
+                        # Set `iteration_end`
+                        #   (1) to save future `next(...)` calls, and
+                        #   (2) to avoid sending multiple `_IterableDatasetStopIteration`s.
+                        iteration_end = True
+                    else:
+                        # It is important that we don't store exc_info in a variable.
+                        # `ExceptionWrapper` does the correct thing.
+                        # See NOTE [ Python Traceback Reference Cycle Problem ]
+                        data = ExceptionWrapper(
+                            where=f"in DataLoader worker process {worker_id}")
+                if snapshot or iteration_end:
+                    # always generate snapshot when Iterable raises StopIteration.
+                    if HAS_NUMPY:
+                        numpy_state = np.random.get_state()
+                    else:
+                        numpy_state = None
+
+                    if dataset_kind == _DatasetKind.Iterable:
+                        fetcher_state = {
+                            "dataset_iter": try_to_serialize(fetcher.dataset_iter, False),
+                            "ended": fetcher.ended,
+                        }
+                    else:
+                        fetcher_state = None
+                    # Pick up any user-defined dataset state, for both map/iterable style datasets
+                    dataset_state = try_to_serialize(dataset, False)
+                    state_dict = {
+                        "worker_id": worker_id,
+                        "fetcher_state": fetcher_state,
+                        "dataset_state": dataset_state,
+                        "shared_rng": shared_rng.get_state(),
+                        "random_rng_state": random.getstate(),
+                        "torch_rng_state": torch.get_rng_state(),
+                        "numpy_rng_state": numpy_state,
+                    }
+            data_queue.put((idx, (data, worker_id, state_dict)))
+            del data, idx, index, r, state_dict  # save memory
+    except KeyboardInterrupt:
+        # Main process will raise KeyboardInterrupt anyways.
+        pass
+    if done_event.is_set():
+        data_queue.cancel_join_thread()
+        data_queue.close()
+
+
+torch.utils.data._utils.worker._worker_loop = _worker_loop

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 r""""Contains definitions of the methods used by the _BaseDataLoaderIter workers.
 
 These **needs** to be in global scope since Py2 doesn't support serializing

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -39,7 +39,7 @@ def try_to_serialize(obj: Any) -> Union[dict, None]:
 def try_to_deserialize(obj: T, state_dict: Union[dict, None]) -> Union[T, None]:
     if isinstance(obj, Stateful):
         obj.load_state_dict(state_dict)
-        return obj
+        return obj  # type: ignore[return-value]
     return obj
 
 
@@ -181,8 +181,9 @@ def _worker_loop(
             state_dict = None
             if init_exception is not None:
                 data = init_exception
-                # init_exception = None
+                init_exception = None
             else:
+                assert fetcher is not None
                 try:
                     data = fetcher.fetch(index)  # type: ignore[possibly-undefined]
                 except Exception as e:
@@ -222,4 +223,4 @@ def _worker_loop(
         data_queue.close()
 
 
-torch.utils.data._utils.worker._worker_loop = _worker_loop
+torch.utils.data._utils.worker._worker_loop = _worker_loop  # type: ignore[assignment]

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -7,7 +7,6 @@ static methods.
 import torch
 import random
 import copy
-import os
 import pickle
 import queue
 from dataclasses import dataclass
@@ -105,7 +104,6 @@ def _worker_loop(dataset_kind, dataset, index_queue, data_queue, done_event,
             shared_rng.manual_seed(shared_seed)
             dataset = apply_random_seed(dataset, shared_rng)
 
-        # global _worker_info
         torch.utils.data._utils.worker._worker_info = WorkerInfo(
             id=worker_id, num_workers=num_workers, seed=seed, dataset=dataset)
 


### PR DESCRIPTION
Adds a StatefulDataLoader - drop in replacement for torch.utils.data.DataLoader - that offers state_dict/load_state_dict for mid-epoch checkpointing.

please see [RFC] Stateful DataLoader (TODO: link)

Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #{issue number}

### Changes
- Add torchdata.stateful_dataloader.StatefulDataLoader class
- copy test_dataloader unit-tests from pytorch/torch/utils/data for regressions
- adds test_state_dict unit-tests testing stateful functionality.
