### PR TITLE
make torchdata default imports lazy

### DIFF
--- a/test/stateful_dataloader/test_dataloader.py
+++ b/test/stateful_dataloader/test_dataloader.py
@@ -1638,6 +1638,7 @@ except RuntimeError as e:
                     list(self._get_data_loader(ds_cls(counting_ds_n), multiprocessing_context=ctx, **dl_common_args)),
                 )
 
+    @unittest.skipIf(IS_MACOS, "Not working on macos")
     def _test_multiprocessing_iterdatapipe(self, with_dill):
         # Testing to make sure that function from global scope (e.g. imported from library) can be serialized
         # and used with multiprocess DataLoader

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -784,7 +784,7 @@ class TestTorchDataLazyImport(unittest.TestCase):
 
         self.assertFalse("datapipes" in torchdata.__dict__)
 
-        from torchdata import _extension, datapipes as dp, janitor  # noqa  # noqa
+        from torchdata import datapipes as dp, janitor  # noqa  # noqa
 
         self.assertTrue("datapipes" in torchdata.__dict__)
         dp.iter.IterableWrapper([1, 2])

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -784,7 +784,7 @@ class TestTorchDataLazyImport(unittest.TestCase):
 
         self.assertFalse("datapipes" in torchdata.__dict__)
 
-        from torchdata import datapipes as dp, janitor  # noqa  # noqa
+        from torchdata import datapipes as dp, janitor  # noqa
 
         self.assertTrue("datapipes" in torchdata.__dict__)
         dp.iter.IterableWrapper([1, 2])

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -778,5 +778,17 @@ class TestNumWorkersMismatch(unittest.TestCase):
             self.assertTrue(False, "Error should be of type AssertionError")
 
 
+class TestTorchDataLazyImport(unittest.TestCase):
+    def test_lazy_imports(self) -> None:
+        import torchdata
+
+        self.assertFalse("datapipes" in torchdata.__dict__)
+
+        from torchdata import _extension, datapipes as dp, janitor  # noqa  # noqa
+
+        self.assertTrue("datapipes" in torchdata.__dict__)
+        dp.iter.IterableWrapper([1, 2])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -4,11 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torchdata import _extension  # noqa: F401
-
-from . import datapipes
-
-janitor = datapipes.utils.janitor
+import importlib
 
 try:
     from .version import __version__  # noqa: F401
@@ -22,3 +18,17 @@ __all__ = [
 
 # Please keep this list sorted
 assert __all__ == sorted(__all__)
+
+
+# Lazy import these modules
+def __getattr__(name):
+    if name == "janitor":
+        return importlib.import_module(".datapipes.utils." + name, __name__)
+    else:
+        try:
+            return importlib.import_module("." + name, __name__)
+        except ModuleNotFoundError:
+            if name in globals():
+                return globals()[name]
+            else:
+                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
 assert __all__ == sorted(__all__)
 
 
-# Lazy import these modules
+# Lazy import all modules
 def __getattr__(name):
     if name == "janitor":
         return importlib.import_module(".datapipes.utils." + name, __name__)

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -4,13 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# import importlib
-
-from torchdata import _extension  # noqa: F401
-
-from . import datapipes
-
-janitor = datapipes.utils.janitor
+import importlib
 
 try:
     from .version import __version__  # noqa: F401
@@ -26,15 +20,18 @@ __all__ = [
 assert __all__ == sorted(__all__)
 
 
-# # Lazy import all modules
-# def __getattr__(name):
-#     if name == "janitor":
-#         return importlib.import_module(".datapipes.utils." + name, __name__)
-#     else:
-#         try:
-#             return importlib.import_module("." + name, __name__)
-#         except ModuleNotFoundError:
-#             if name in globals():
-#                 return globals()[name]
-#             else:
-#                 raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+# Lazy import all modules
+def __getattr__(name):
+    if name in ("janitor", "datapipes"):
+        from torchdata import _extension  # noqa: F401
+
+    if name == "janitor":
+        return importlib.import_module(".datapipes.utils." + name, __name__)
+    else:
+        try:
+            return importlib.import_module("." + name, __name__)
+        except ModuleNotFoundError:
+            if name in globals():
+                return globals()[name]
+            else:
+                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -22,8 +22,8 @@ assert __all__ == sorted(__all__)
 
 # Lazy import all modules
 def __getattr__(name):
-    if name in ("janitor", "datapipes"):
-        from torchdata import _extension  # noqa: F401
+    if not name.startswith("stateful_dataloader"):
+        importlib.import_module("._extension", __name__)
 
     if name == "janitor":
         return importlib.import_module(".datapipes.utils." + name, __name__)

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -31,4 +31,4 @@ def __getattr__(name):
             if name in globals():
                 return globals()[name]
             else:
-                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+                raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -31,4 +31,4 @@ def __getattr__(name):
             if name in globals():
                 return globals()[name]
             else:
-                raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -22,9 +22,6 @@ assert __all__ == sorted(__all__)
 
 # Lazy import all modules
 def __getattr__(name):
-    if not name.startswith("stateful_dataloader"):
-        importlib.import_module("._extension", __name__)
-
     if name == "janitor":
         return importlib.import_module(".datapipes.utils." + name, __name__)
     else:

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -4,7 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib
+# import importlib
+
+from torchdata import _extension  # noqa: F401
+
+from . import datapipes
+
+janitor = datapipes.utils.janitor
 
 try:
     from .version import __version__  # noqa: F401
@@ -20,15 +26,15 @@ __all__ = [
 assert __all__ == sorted(__all__)
 
 
-# Lazy import all modules
-def __getattr__(name):
-    if name == "janitor":
-        return importlib.import_module(".datapipes.utils." + name, __name__)
-    else:
-        try:
-            return importlib.import_module("." + name, __name__)
-        except ModuleNotFoundError:
-            if name in globals():
-                return globals()[name]
-            else:
-                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+# # Lazy import all modules
+# def __getattr__(name):
+#     if name == "janitor":
+#         return importlib.import_module(".datapipes.utils." + name, __name__)
+#     else:
+#         try:
+#             return importlib.import_module("." + name, __name__)
+#         except ModuleNotFoundError:
+#             if name in globals():
+#                 return globals()[name]
+#             else:
+#                 raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None

--- a/torchdata/_torchdata/__init__.pyi
+++ b/torchdata/_torchdata/__init__.pyi
@@ -6,6 +6,8 @@
 
 from typing import List
 
+from torchdata import _extension  # noqa: F401
+
 # TODO: Add pyi generate script
 class S3Handler:
     def __init__(self, request_timeout_ms: int, region: str) -> None: ...

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+from torchdata import _extension  # noqa: F401
 from torchdata.dataloader2.dataloader2 import DataLoader2, DataLoader2Iterator
 from torchdata.dataloader2.error import PauseIteration
 from torchdata.dataloader2.reading_service import (

--- a/torchdata/datapipes/__init__.py
+++ b/torchdata/datapipes/__init__.py
@@ -6,6 +6,8 @@
 
 from torch.utils.data import DataChunk, functional_datapipe
 
+from torchdata import _extension  # noqa: F401
+
 from . import iter, map, utils
 
 __all__ = ["DataChunk", "functional_datapipe", "iter", "map", "utils"]


### PR DESCRIPTION
Summary: Push all imports in torchdata/__init__.py to be lazy by default so they don't interfere with new development (eg stateful_dataloader)

Test Plan: 
New unit test, CI for the rest

Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #{issue number}

### Changes

Makes imports lazy, should be no-op for downstream users 
-
-
