### PR TITLE
Don't patch _worker_loop

### DIFF
--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -10,7 +10,7 @@ import unittest
 from typing import Iterator
 
 import torch
-
+import torch.utils.data
 from torchdata.stateful_dataloader import Stateful, StatefulDataLoader
 
 
@@ -788,6 +788,25 @@ class TestTorchDataLazyImport(unittest.TestCase):
 
         self.assertTrue("datapipes" in torchdata.__dict__)
         dp.iter.IterableWrapper([1, 2])
+
+
+class TestConcurrentDataLoaders(unittest.TestCase):
+    def test_two_dataloaders(self) -> None:
+        dataset = DummyMapDataset(100, shuffle=False)
+        sdl = StatefulDataLoader(
+            dataset=dataset,
+            num_workers=2,
+            collate_fn=identity,
+        )
+        exp = list(sdl)
+
+        dl = torch.utils.data.DataLoader(
+            dataset=dataset,
+            num_workers=2,
+            collate_fn=identity,
+        )
+        data = list(dl)
+        self.assertEqual(data, exp)
 
 
 if __name__ == "__main__":

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -47,6 +47,7 @@ from .worker import (
     _FETCHER_ENDED,
     _FETCHER_STATE,
     _WORKER_ID,
+    _worker_loop,
     try_to_deserialize,
     try_to_serialize,
 )
@@ -774,7 +775,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             index_queue.cancel_join_thread()
 
             w = multiprocessing_context.Process(
-                target=_utils.worker._worker_loop,
+                target=_worker_loop,
                 args=(
                     self._dataset_kind,
                     self._dataset,

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -235,6 +235,3 @@ def _worker_loop(
     if done_event.is_set():
         data_queue.cancel_join_thread()
         data_queue.close()
-
-
-torch.utils.data._utils.worker._worker_loop = _worker_loop  # type: ignore[assignment]


### PR DESCRIPTION
Summary: We originally patched the _worker_loop function in torch.utils.data._utils.worker.py in order to make sure `torch.utils.data.get_worker_info()` worked correctly, but at some point this must have become unnecessary. This currently causes issues where importing StatefulDataLoader will break other usages of `torch.utils.data.DataLoader` with multiprocessing because the two _worker_loop's have different APIs. In this PR we drop the patching and add a small test that confirms that there is no conflict when using both non-stateful and StatefulDataLoader.

Test Plan: New unit test which used to fail but now passes. 

Fixes #{issue number}

### Changes

-
-
