### PR TITLE
Update actions/setup-python from v4 -> v5

### DIFF
--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -48,7 +48,7 @@ jobs:
           sudo apt update
           sudo apt install rar unrar libssl-dev libcurl4-openssl-dev zlib1g-dev
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup msbuild on Windows

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           arch: x64
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies


### PR DESCRIPTION
MacOS continues to fail during intermittently during shutdown step. Before creating an issue in actions/setup-python let's try upgrading this to V5 

Fixes #{issue number}

### Changes

-
-
