### PR TITLE
update worker keys and add test

### DIFF
--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1308,7 +1308,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         last_yielded_worker_id: int,
         num_workers: int,
         main_snapshot: Dict[str, Any],
-        worker_snapshots: Dict[int, Any],
+        worker_snapshots: Dict[str, Any],
     ):
         self._snapshot = {
             self._SNAPSHOT_STEP: snapshot_step,


### PR DESCRIPTION
Users [internal] are occasionally using json.dumps to serialize the state_dict when they know the state_dicts are JSON serializable. Ignoring the fact this won't work in general, this fails because json spec does not allow int properties (string required) which we're using for _worker_states in the state dict. This PR changes the format of the state_dict to use strings instead, ie `_worker_states: {0: ..., 1: ...}` -> `_worker_states: {"worker_0": ..., "worker_1": ...}`

### Changes

* Adds json serde test which fails before fix
* Sets worker state keys to explicitly be strings for zero ambiguity

-
-
