### PR TITLE
fix an edge case bug where state is incomplete if request checkpoint after resume

### DIFF
--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -841,8 +841,8 @@ class TestConcurrentDataLoaders(unittest.TestCase):
         self.assertEqual(data, exp)
 
 
-class TestFailAfterResume(unittest.TestCase):
-    def test_fail_after_resume(self) -> None:
+class TestFastStateDictRequest(unittest.TestCase):
+    def test_fast_state_dict_request(self) -> None:
         num_workers = 4
         interrupt = 11  # because of round robin, this should stop after worker 2
         dataset = DummyIterableDataset([25, 25, 25, 25], shuffle=True)
@@ -865,7 +865,8 @@ class TestFailAfterResume(unittest.TestCase):
         exp = list(it)
 
         dl.load_state_dict(state_dict)
-        # new iter after load_state_dict, try to fail fast
+        # new iter after load_state_dict, ask for state dict before num_workers batches
+        # are yielded to ensure old worker states are stored properly
         it = iter(dl)
         for _ in range(2):
             next(it)

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -862,6 +862,9 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             self._restore_main_state(next_iter_state[self._SNAPSHOT][self._MAIN_SNAPSHOT])
             self._num_yielded = next_iter_state[self._SNAPSHOT][self._SNAPSHOT_STEP]
 
+            # Back-fill the worker snapshots before starting, in case of failure before a full cycle
+            self._worker_snapshots = {i: state for i, state in enumerate(worker_states)}
+
             fast_forward = False
             if self._dataset_kind == _DatasetKind.Iterable:
                 for state in worker_states:


### PR DESCRIPTION
StatefulDataLoader may return incomplete checkpoints if a state_dict is requested soon after a resume.

Consider a multiprocess dataloader with num_workers = 4. When we resume this dataloader, assuming we make it through 4 batches before the next state_dict is requested, we should have fresh snapshots for all 4 workers again. However in the case where we only make it through say 2, then we are missing state for the other 2 workers. 

Test plan:
Wrote a new unit-test to capture this, which fails with below error before the fix:
```
        worker_states = [None] * self._num_workers
        if next_iter_state is not None:
            assert (
                self._SNAPSHOT in next_iter_state
            ), f"State doesn't contain key '{self._SNAPSHOT}' expected for multiprocess dataloader"
            wstates = next_iter_state[self._SNAPSHOT].get(self._WORKER_SNAPSHOTS, {})
>           assert set(range(len(wstates))) == set(wstates.keys()), (len(wstates), wstates.keys())
E           AssertionError: (2, dict_keys([3, 0]))
```

### Changes
* Fixes edge-case bug where StatefulDataLoader.state_dict() may return an incomplete state after a resume if a request is made before num_workers steps.

-
-
