### PR TITLE
Add message about s3 iterdata pipes deprecation

### DIFF
--- a/test/test_remote_io.py
+++ b/test/test_remote_io.py
@@ -300,6 +300,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
         self.assertEqual(res_abfs, res_az, f"{input} failed")
 
     @skipIfAWS
+    @unittest.skip("S3 IterDataPipes are deprecated")
     def test_disabled_s3_io_iterdatapipe(self):
         file_urls = ["s3://ai2-public-datasets"]
         with self.assertRaisesRegex(ModuleNotFoundError, "TorchData must be built with"):
@@ -308,6 +309,7 @@ class TestDataPipeRemoteIO(expecttest.TestCase):
             _ = S3FileLoader(IterableWrapper(file_urls))
 
     @skipIfNoAWS
+    @unittest.skip("S3 IterDataPipes are deprecated")
     @unittest.skipIf(IS_M1, "PyTorch M1 CI Machine doesn't allow accessing")
     def test_s3_io_iterdatapipe(self):
         # S3FileLister: different inputs

--- a/test/test_s3io.py
+++ b/test/test_s3io.py
@@ -15,6 +15,7 @@ skipIfSandcastle = unittest.skipIf(IS_SANDCASTLE, "Skip for internal testing")
 
 
 @skipIfSandcastle
+@unittest.skip("S3 IterDataPipes are deprecated")
 @patch("torchdata._torchdata")
 class TestS3FileListerIterDataPipe(expecttest.TestCase):
     def test_list_files(self, mock_torchdata):

--- a/torchdata/datapipes/iter/load/README.md
+++ b/torchdata/datapipes/iter/load/README.md
@@ -2,6 +2,8 @@
 
 ## S3 IO Datapipe Documentation
 
+**WARNING**: S3 IO Datapipes have been deprecated. Consider using [S3 Connector for PyTorch](https://github.com/awslabs/s3-connector-for-pytorch).
+
 ### Build from Source
 
 `ninja` is required to link PyThon implementation to C++ source code.

--- a/torchdata/datapipes/iter/load/README.md
+++ b/torchdata/datapipes/iter/load/README.md
@@ -2,7 +2,8 @@
 
 ## S3 IO Datapipe Documentation
 
-**WARNING**: S3 IO Datapipes have been deprecated. Consider using [S3 Connector for PyTorch](https://github.com/awslabs/s3-connector-for-pytorch).
+**WARNING**: S3 IO Datapipes have been deprecated. Consider using
+[S3 Connector for PyTorch](https://github.com/awslabs/s3-connector-for-pytorch).
 
 ### Build from Source
 

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -17,7 +17,8 @@ from torchdata.datapipes.utils import StreamWrapper
 
 @functional_datapipe("list_files_by_s3")
 class S3FileListerIterDataPipe(IterDataPipe[str]):
-    r"""
+    r"""[DEPRECATED] Use https://github.com/awslabs/s3-connector-for-pytorch instead.
+
     Iterable DataPipe that lists Amazon S3 file URLs with the given prefixes (functional name: ``list_files_by_s3``).
     Acceptable prefixes include ``s3://bucket-name``, ``s3://bucket-name/``, ``s3://bucket-name/folder``.
 
@@ -104,7 +105,8 @@ class S3FileListerIterDataPipe(IterDataPipe[str]):
 
 @functional_datapipe("load_files_by_s3")
 class S3FileLoaderIterDataPipe(IterDataPipe[Tuple[str, StreamWrapper]]):
-    r"""
+    r"""[DEPRECATED] Use https://github.com/awslabs/s3-connector-for-pytorch instead.
+
     Iterable DataPipe that loads Amazon S3 files from the given S3 URLs (functional name: ``load_files_by_s3``).
     ``S3FileLoader`` iterates all given S3 URLs in ``BytesIO`` format with ``(url, BytesIO)`` tuples.
 


### PR DESCRIPTION
Adding deprecation message about S3 IterDataPipes and pointing to https://github.com/awslabs/s3-connector-for-pytorch.

Cc @jamesbornholt, @dnauti 
