### PR TITLE
remove label filters for test ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,7 @@ on:
 
 jobs:
   test:
-    if:
-      ${{ github.repository_owner == 'pytorch' && (github.event.action != 'labeled' ||
-      startsWith(github.event.label.name, 'ciflow')) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt update
           sudo apt install rar unrar libssl-dev libcurl4-openssl-dev zlib1g-dev
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup msbuild on Windows
@@ -58,7 +58,7 @@ jobs:
         with:
           arch: x64
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -15,9 +15,7 @@ on:
 
 jobs:
   test:
-    if:
-      ${{ github.repository_owner == 'pytorch' && (github.event.action != 'labeled' ||
-      startsWith(github.event.label.name, 'ciflow')) }}
+    if: ${{ github.repository_owner == 'pytorch' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt update
           sudo apt install rar unrar libssl-dev libcurl4-openssl-dev zlib1g-dev
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup msbuild on Windows
@@ -58,7 +58,7 @@ jobs:
         with:
           arch: x64
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies


### PR DESCRIPTION
Our tests are not being shown on PR creation because something in the filters disables them when facebook-github-bot adds the CLA Signed tag. Just disable the filters to match pytorch/pytorch repo setup

### Changes
- Remove label filters on CI 
- Bump actions/setup-python from v4 -> v5
- Bump actions/checkout from v3 -> v4
