### PR TITLE
Update state_dict() request at time 0 to include worker state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Install test requirements
         run: pip3 install -r test/requirements.txt
       - name: Test documentation examples
+        if: matrix.os != 'windows-latest'
         run: |
           cd ./docs
           pip3 install -r requirements.txt

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -72,15 +72,9 @@ jobs:
         run: |
           pip3 install .
         env:
-          BUILD_S3: 1
+          BUILD_S3: 0
       - name: Install test requirements
         run: pip3 install -r test/requirements.txt
-      - name: Test documentation examples
-        run: |
-          cd ./docs
-          pip3 install -r requirements.txt
-          make doctest
-          cd ..
       - name: Run StatefulDataLoader tests with pytest - dataloader
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
         run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_dataloader.py

--- a/test/stateful_dataloader/test_incremental_state.py
+++ b/test/stateful_dataloader/test_incremental_state.py
@@ -10,7 +10,7 @@ from typing import Dict
 import torch
 
 from torch.testing._internal.common_utils import TestCase
-from torchdata.stateful_dataloader import (
+from torchdata.stateful_dataloader.incremental_state import (
     _DATASET_ITER_STATE,
     _DATASET_STATE,
     _FETCHER_ENDED,

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1228,7 +1228,7 @@ class TestInitialState_shard0(TestCase):
             next(it)
 
     def test_load_then_state(self):
-        for pw, interrupt in itertools.product([False, True], [2, 9]):
+        for pw in itertools.product([False, True]):
             num_workers = 4
             dataset = DummyMapDataset(100, shuffle=True)
             dl = StatefulDataLoader(

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -986,6 +986,14 @@ class TestJsonSerDe_shard3(TestCase):
         self._run_test_map(3)
 
 
+class ErrorDataset(torch.utils.data.Dataset):
+    def __getitem__(self, index: int):
+        raise ValueError("Iteration error")
+
+    def __len__(self):
+        return 10
+
+
 class TestInitialState_shard0(TestCase):
     def test_initial_state(self):
         for pw in [False, True]:
@@ -1097,13 +1105,6 @@ class TestInitialState_shard0(TestCase):
             iter(dl)
 
     def test_iteration_error(self):
-        class ErrorDataset(torch.utils.data.Dataset):
-            def __getitem__(self, index: int):
-                raise ValueError("Iteration error")
-
-            def __len__(self):
-                return 10
-
         num_workers = 4
         dataset = ErrorDataset()
         dl = StatefulDataLoader(

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1124,8 +1124,6 @@ class TestInitialState_shard0(TestCase):
             )
             dl.load_state_dict(state)
             state0 = dl.state_dict()
-            print(state0)
-            print(state)
             self.assertEqual(state0, state)
             data = list(dl)
             self.assertEqual(data, exp)
@@ -1156,6 +1154,7 @@ class TestInitialState_shard0(TestCase):
         with self.assertRaisesRegex(ValueError, "Iteration error"):
             next(it)
 
+
 class TestStatefulDataLoaderIterable2_shard3(TestStatefulDataLoaderIterable_shard0):
     # Perform sanity test checks with the iterable dataset that is also an iterator
     def _get_dataset(self, shuffle):
@@ -1177,7 +1176,6 @@ class TestDatasetIteratorStateDuplication_shard3(TestCase):
             for _ in range(num_workers + 1):
                 next(it)
             state_dict = dl.state_dict()
-            print(state_dict)
 
             if num_workers > 0:
                 for i in range(num_workers):

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -412,7 +412,7 @@ class GeneratorIterable(torch.utils.data.IterableDataset):
             self.i += 1
             yield (i, self.epoch)
 
-        # To resume from next epoch properly, reset variables here so loading
+        # To save end-of-epoch state properly, reset variables here so loading
         # will begin from the correct position and epoch
         self.i = 0
         if self.increment_epoch:

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -39,15 +39,15 @@ class DummyIterator(Iterator, Stateful):
         return sample
 
     def state_dict(self):
-        sd = {"i": self.i}
+        sd = {"nest": {"i": self.i}}
         if self.include_generator:
-            sd["g"] = torch.get_rng_state()
+            sd["nest"]["g"] = torch.get_rng_state()
         return sd
 
     def load_state_dict(self, state_dict):
-        self.i = state_dict["i"]
+        self.i = state_dict["nest"]["i"]
         if self.include_generator:
-            torch.set_rng_state(state_dict["g"])
+            torch.set_rng_state(state_dict["nest"]["g"])
 
 
 class DummySamplerIterator(Iterator, Stateful):
@@ -1185,13 +1185,13 @@ class TestInitialState_shard0(TestCase):
             next(it)
 
 
-class TestStatefulDataLoaderIterable2_shard3(TestStatefulDataLoaderIterable_shard0):
+class TestStatefulDataLoaderIterable2_shard0(TestStatefulDataLoaderIterable_shard0):
     # Perform sanity test checks with the iterable dataset that is also an iterator
     def _get_dataset(self, shuffle):
         return DummyIteratorIterableDataset(list(range(100)), shuffle=shuffle, include_generator=True)
 
 
-class TestDynamicStateIterableDataset(TestCase):
+class TestDynamicStateIterableDataset_shard0(TestCase):
     def test(self):
         dataset = DynamicStateIterableDataset(list(range(100)))
         num_workers = 2
@@ -1238,7 +1238,7 @@ class TestDynamicStateIterableDataset(TestCase):
         self.assertEqual(len(worker_state), 9)
 
 
-class TestDatasetIteratorStateDuplication_shard3(TestCase):
+class TestDatasetIteratorStateDuplication_shard0(TestCase):
     def test(self):
         dataset = DummyIteratorIterableDataset(list(range(100)), shuffle=True, include_generator=True)
         for num_workers in (0, 2):

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -12,7 +12,7 @@ from typing import Iterator
 
 import torch
 import torch.utils.data
-from torch.testing._internal.common_utils import IS_MACOS, TestCase
+from torch.testing._internal.common_utils import IS_MACOS, TEST_CUDA, TestCase
 from torchdata.stateful_dataloader import Stateful, StatefulDataLoader
 
 
@@ -1115,6 +1115,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
             state = dl.state_dict()
             self.assertEqual(len(state["_snapshot"]["_worker_snapshots"]), num_workers)
@@ -1142,6 +1143,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
 
             it = iter(dl)
@@ -1156,6 +1158,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
             state0 = dl.state_dict()
             self.assertEqual(len(state0["_snapshot"]["_worker_snapshots"]), num_workers)
@@ -1173,6 +1176,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
 
             it = iter(dl)
@@ -1187,6 +1191,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
             dl.load_state_dict(state)
             state0 = dl.state_dict()
@@ -1203,6 +1208,7 @@ class TestInitialState_shard0(TestCase):
             collate_fn=identity,
             multiprocessing_context="forkserver" if IS_MACOS else None,
             worker_init_fn=error_worker_init_fn,
+            pin_memory=TEST_CUDA,
         )
         with self.assertRaisesRegex(ValueError, ERROR_MSG):
             iter(dl)
@@ -1215,6 +1221,7 @@ class TestInitialState_shard0(TestCase):
             num_workers=num_workers,
             collate_fn=identity,
             multiprocessing_context="forkserver" if IS_MACOS else None,
+            pin_memory=TEST_CUDA,
         )
         it = iter(dl)
         with self.assertRaisesRegex(ValueError, "Iteration error"):
@@ -1230,6 +1237,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
 
             state0 = dl.state_dict()
@@ -1241,6 +1249,7 @@ class TestInitialState_shard0(TestCase):
                 persistent_workers=pw,
                 collate_fn=identity,
                 multiprocessing_context="forkserver" if IS_MACOS else None,
+                pin_memory=TEST_CUDA,
             )
             it = iter(dl)
             for _ in range(3):

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1461,7 +1461,7 @@ class TestMultiEpochState_shard0(TestCase):
             num_workers=num_workers,
             persistent_workers=pw,
             collate_fn=identity,
-            multiprocessing_context="forkserver" if IS_MACOS else None,
+            multiprocessing_context=("forkserver" if IS_MACOS and num_workers else None),
         )
 
     def _run(self, pw: bool, num_workers: int):

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -43,6 +43,7 @@ class S3FileListerIterDataPipe(IterDataPipe[str]):
     Example:
 
     .. testsetup::
+
         from unittest import mock
         from torchdata.datapipes.iter import IterableWrapper, S3FileLister
 

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -43,31 +43,43 @@ class S3FileListerIterDataPipe(IterDataPipe[str]):
     Example:
 
     .. testsetup::
+        print("setup")
 
         from unittest import mock
         from torchdata.datapipes.iter import IterableWrapper, S3FileLister
+        print("import done")
 
         file_lister_patch = mock.patch.object(S3FileLister, "__iter__", return_value=iter([]))
         file_lister_patch.start()
+        print("patch done")
 
     .. testcode::
+        print("test code")
 
         from torchdata.datapipes.iter import IterableWrapper, S3FileLister
+        print("import done")
 
         s3_prefixes = IterableWrapper(['s3://bucket-name/folder/', ...])
+        print("iterablewrapper")
 
         dp_s3_urls = S3FileLister(s3_prefixes)
+        print("s3filelister done")
         for d in dp_s3_urls:
             pass
+        print("for loop done")
 
         # Functional API
         dp_s3_urls = s3_prefixes.list_files_by_s3(request_timeout_ms=100)
+        print("list files done")
         for d in dp_s3_urls:
             pass
+        print("s3 urls done")
 
     .. testcleanup::
+        print("cleanup start")
 
         file_lister_patch.stop()
+        print("cleanup end")
     """
 
     def __init__(

--- a/torchdata/datapipes/iter/load/s3io.py
+++ b/torchdata/datapipes/iter/load/s3io.py
@@ -43,43 +43,30 @@ class S3FileListerIterDataPipe(IterDataPipe[str]):
     Example:
 
     .. testsetup::
-        print("setup")
-
         from unittest import mock
         from torchdata.datapipes.iter import IterableWrapper, S3FileLister
-        print("import done")
 
         file_lister_patch = mock.patch.object(S3FileLister, "__iter__", return_value=iter([]))
         file_lister_patch.start()
-        print("patch done")
 
     .. testcode::
-        print("test code")
 
         from torchdata.datapipes.iter import IterableWrapper, S3FileLister
-        print("import done")
 
         s3_prefixes = IterableWrapper(['s3://bucket-name/folder/', ...])
-        print("iterablewrapper")
 
         dp_s3_urls = S3FileLister(s3_prefixes)
-        print("s3filelister done")
         for d in dp_s3_urls:
             pass
-        print("for loop done")
 
         # Functional API
         dp_s3_urls = s3_prefixes.list_files_by_s3(request_timeout_ms=100)
-        print("list files done")
         for d in dp_s3_urls:
             pass
-        print("s3 urls done")
 
     .. testcleanup::
-        print("cleanup start")
 
         file_lister_patch.stop()
-        print("cleanup end")
     """
 
     def __init__(

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -4,18 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .incremental_state import (
-    _DATASET_ITER_STATE,
-    _DATASET_STATE,
-    _FETCHER_ENDED,
-    _FETCHER_STATE,
-    _flatten,
-    _IncrementalState,
-    _IncrementalWorkerState,
-    _Tombstone,
-    _unflatten,
-    _WORKER_ID,
-)
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -4,8 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .sampler import BatchSampler, RandomSampler
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 
-__all__ = ["Stateful", "StatefulDataLoader", "RandomSampler", "BatchSampler"]
+__all__ = ["Stateful", "StatefulDataLoader"]

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -4,7 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .sampler import BatchSampler, RandomSampler
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 
-__all__ = ["Stateful", "StatefulDataLoader"]
+__all__ = ["Stateful", "StatefulDataLoader", "RandomSampler", "BatchSampler"]

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -47,7 +47,6 @@ from .incremental_state import (
     _WORKER_ID,
 )
 
-from .sampler import BatchSampler, RandomSampler  # noqa  # noqa
 from .stateful import Stateful
 
 from .worker import _AckStartup, _worker_loop, try_to_deserialize, try_to_serialize
@@ -215,6 +214,10 @@ class StatefulDataLoader(DataLoader[T_co]):
         self.snapshot_every_n_steps = snapshot_every_n_steps
         self.next_iter_state: Optional[Dict[str, Any]] = None
         self.iter_calls = 0
+        # When a state_dict is requested before __iter__ is called,
+        # we create the __iter__ so we can get a copy of the initial state from
+        # its workers. In those cases, we can avoid creating a new multiprocessing
+        # iterator on the next __iter__ call, and this flag is used for those cases.
         self._initial_iter_for_state_dict = False
 
     def _get_iterator(self) -> "_StatefulBaseDataLoaderIter":

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -880,6 +880,8 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             if not all(self._workers_status):
                 raise ValueError(f"A worker has failed during startup! {self._workers_status}")
             elif isinstance(data, _AckStartup):
+                if isinstance(data.initial_state, ExceptionWrapper):
+                    data.initial_state.reraise()
                 assert data.initial_state is not None, data
                 self._worker_snapshots_0[self._worker_key(data.worker_id)] = data.initial_state
             else:

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -46,7 +46,7 @@ from .incremental_state import (
     _IncrementalWorkerState,
     _WORKER_ID,
 )
-
+from .sampler import BatchSampler, RandomSampler  # noqa
 from .stateful import Stateful
 
 from .worker import _AckStartup, _worker_loop, try_to_deserialize, try_to_serialize

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -963,7 +963,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._workers_status = [True for i in range(self._num_workers)]
         # Reset the worker queue cycle so it resumes next epoch at worker 0
         self._worker_queue_idx_cycle = itertools.cycle(range(self._num_workers))
-        worker_states = {}
+        worker_states: Dict[str, Any] = {}
         if first_iter:
             # Request the initial state_dict
             for i in range(self._num_workers):

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -871,7 +871,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._main_state_0 = self._get_main_state()
         self._worker_snapshots_0: Dict[str, Any] = {}
         while len(self._worker_snapshots_0) < self._num_workers:
-            data = self._data_queue.get(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
+            data = self._get_data()
             if isinstance(data, _AckStartup):
                 self._worker_snapshots_0[self._worker_key(data.worker_id)] = data.initial_state
             elif isinstance(data, ExceptionWrapper):

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -868,7 +868,9 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._worker_snapshots_0: Dict[str, Any] = {}
         while len(self._worker_snapshots_0) < self._num_workers:
             data = self._get_data()
-            if isinstance(data, _AckStartup):
+            if not all(self._workers_status):
+                raise ValueError(f"A worker has failed during startup! {self._workers_status}")
+            elif isinstance(data, _AckStartup):
                 self._worker_snapshots_0[self._worker_key(data.worker_id)] = data.initial_state
             elif isinstance(data, ExceptionWrapper):
                 data.reraise()

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -880,7 +880,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         for i in range(self._num_workers):
             self._index_queues[i].put(_AckStartup(i, None))  # type: ignore[arg-type]
         while len(self._worker_states_0) < self._num_workers:
-            data = self._get_data()
+            _, data = self._get_data()
             if not all(self._workers_status):
                 raise ValueError(f"A worker has failed during startup! {self._workers_status}")
             elif isinstance(data, _AckStartup):

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -868,6 +868,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._worker_pids_set = True
         self._snapshot, self._worker_snapshots, self._main_snapshots = {}, {}, collections.deque()  # type: ignore[var-annotated]
 
+        self._workers_status = [True for i in range(self._num_workers)]
         self._main_state_0 = self._get_main_state()
         self._worker_snapshots_0: Dict[str, Any] = {}
         while len(self._worker_snapshots_0) < self._num_workers:

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -236,6 +236,7 @@ class StatefulDataLoader(DataLoader[T_co]):
         # DataLoader object so that workers can be reused
         if self._initial_iter_for_state_dict:
             self._initial_iter_for_state_dict = False
+            assert self._iterator is not None
         elif self.persistent_workers and self.num_workers > 0:
             # @@@@ Andrewkh
             # Cases to check:
@@ -256,8 +257,7 @@ class StatefulDataLoader(DataLoader[T_co]):
 
     def state_dict(self) -> Dict[str, Any]:
         if self._iterator is None:
-            self._initial_iter_for_state_dict = False
-            iter(self)
+            self._iterator = self._get_iterator()
             self._initial_iter_for_state_dict = True
         return self._iterator.state_dict()
 
@@ -869,7 +869,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._snapshot, self._worker_snapshots, self._main_snapshots = {}, {}, collections.deque()  # type: ignore[var-annotated]
 
         self._main_state_0 = self._get_main_state()
-        self._worker_snapshots_0 = {}
+        self._worker_snapshots_0: Dict[str, Any] = {}
         while len(self._worker_snapshots_0) < self._num_workers:
             data = self._data_queue.get(timeout=_utils.MP_STATUS_CHECK_INTERVAL)
             if isinstance(data, _AckStartup):

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -241,14 +241,16 @@ class StatefulDataLoader(DataLoader[T_co]):
         elif self.persistent_workers and self.num_workers > 0:
             if self._iterator is None:
                 self._iterator = self._get_iterator()
-                if self._iterator._finished:
-                    self._iterator._reset(self)
             else:
                 self._iterator._reset(self)
         else:
             self._iterator = self._get_iterator()
-            if self._iterator._finished:
+        if self._iterator._finished:
+            if self.persistent_workers:
+                self._iterator._reset(self)
+            else:
                 self._iterator = self._get_iterator()
+
         return self._iterator
 
     def state_dict(self) -> Dict[str, Any]:

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -886,6 +886,7 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         if next_iter_state is not None:
             self._restore_main_state(next_iter_state[self._SNAPSHOT][self._MAIN_SNAPSHOT])
             self._num_yielded = next_iter_state[self._SNAPSHOT][self._SNAPSHOT_STEP]
+            self._worker_snapshots = {key: _IncrementalWorkerState(state) for key, state in worker_states.items()}
 
             self._update_snapshot(
                 snapshot_step=next_iter_state[self._SNAPSHOT][self._SNAPSHOT_STEP],
@@ -975,7 +976,6 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
                 elif isinstance(data, _AckStartup):
                     if isinstance(data.initial_state, ExceptionWrapper):
                         data.initial_state.reraise()
-                    assert data.initial_state is not None, data
                     worker_states[self._worker_key(data.worker_id)] = data.initial_state
                 else:
                     raise ValueError(f"Invalid response from worker after startup: {data}")

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -238,11 +238,6 @@ class StatefulDataLoader(DataLoader[T_co]):
             self._initial_iter_for_state_dict = False
             assert self._iterator is not None
         elif self.persistent_workers and self.num_workers > 0:
-            # @@@@ Andrewkh
-            # Cases to check:
-            #   * new dl, state_dict, iter
-            #   * new dl, state_dict, load_state_dict, iter
-            #   * new dl, load_state_dict, state_dict, iter
             if self._iterator is None:
                 self._iterator = self._get_iterator()
             else:

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -188,7 +188,7 @@ def _worker_loop(
                 continue
             if isinstance(r, _AckStartup):
                 # Send ack and initial state to the main process
-                data_queue.put(_AckStartup(worker_id=worker_id, initial_state=initial_state or init_exception))
+                data_queue.put((r, _AckStartup(worker_id=worker_id, initial_state=initial_state or init_exception)))
                 del initial_state
                 continue
             elif isinstance(r, _ResumeIteration):

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -133,6 +133,8 @@ def _worker_loop(
             # See NOTE [ Incremental worker state ]
             initial_state = worker_state or _make_state_dict(worker_id, dataset_kind, fetcher, dataset)
             incremental_worker_state = _IncrementalWorkerState(initial_state)
+            if initial_state is worker_state:
+                initial_state = None
 
             # Restore worker state if provided
             if worker_state:

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -131,6 +131,10 @@ def _worker_loop(
             fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
 
             initial_state = _make_state_dict(worker_id, dataset_kind, fetcher, dataset)
+            # The main-process instantiates its IncrementalWorkerState with worker_state if present
+            # else initial_state. We can't always start with initial_state because of the case
+            # where we load a state_dict, call next for n < num_worker steps (ie do not receive updates)
+            # and then request another state_dict.
             incremental_worker_state = _IncrementalWorkerState(worker_state or initial_state)
 
             # Restore worker state if provided

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -181,7 +181,7 @@ def _worker_loop(
                 continue
             if isinstance(r, _AckStartup):
                 # Send ack and initial state to the main process
-                data_queue.put(_AckStartup(worker_id=worker_id, initial_state=initial_state))
+                data_queue.put(_AckStartup(worker_id=worker_id, initial_state=initial_state or init_exception))
                 del initial_state
                 continue
             elif isinstance(r, _ResumeIteration):

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -120,7 +120,7 @@ def _worker_loop(
 
         from torch.utils.data import _DatasetKind
 
-        incremental_worker_state = _IncrementalWorkerState(worker_state)
+        incremental_worker_state: _IncrementalWorkerState
         init_exception = None
         fetcher = None
         initial_state = None
@@ -131,6 +131,7 @@ def _worker_loop(
             fetcher = _DatasetKind.create_fetcher(dataset_kind, dataset, auto_collation, collate_fn, drop_last)
 
             initial_state = _make_state_dict(worker_id, dataset_kind, fetcher, dataset)
+            incremental_worker_state = _IncrementalWorkerState(worker_state or initial_state)
 
             # Restore worker state if provided
             if worker_state:
@@ -227,9 +228,8 @@ def _worker_loop(
                         #   (2) to avoid sending multiple `_IterableDatasetStopIteration`s.
                         iteration_end = True
                     if snapshot or iteration_end:
-                        state_dict = _make_state_dict(worker_id, dataset_kind, fetcher, dataset)
-
                         # Generate incremental diff from prev_state_dict and current_state_dict
+                        state_dict = _make_state_dict(worker_id, dataset_kind, fetcher, dataset)
                         delta_state_dict = incremental_worker_state.generate_delta(state_dict)
                         del state_dict
                 except Exception:

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -13,7 +13,7 @@ static methods.
 import queue
 import random
 from dataclasses import dataclass
-from typing import Any, Dict, TypeVar, Union
+from typing import Any, Dict, Optional, TypeVar, Union
 
 import torch
 
@@ -55,7 +55,7 @@ class _AckStartup:
     """Dummy class used to ack startup and return state at time 0"""
 
     worker_id: int
-    initial_state: Dict[str, Any]
+    initial_state: Optional[Union[Dict[str, Any], ExceptionWrapper]]
 
 
 _WORKER_ID = "worker_id"


### PR DESCRIPTION
Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

When state_dict is requested before an iterator is created, we currently return an empty dict. This does not reflect a true initial state of the workers, and may break assumptions made by DCP.

This update will guarantee that anytime state_dict is requested, you will get a "full" state_dict that includes main state, and all worker initial states, including dataset/iterator states. We achieve this by including an ack signal from the workers which includes an initial state_dict. The main process now waits for these acks and stores the initial states for any subsequent state_dict requests, as well as for resetting the iterator.

Fixes #{issue number}

### Changes
* Changes the way state_dict is handled before iterator is generated, and before any iteration begins. 
-
-
