### PR TITLE
Implement incremental state transfer from worker to dataloader process #1262

### DIFF
--- a/test/stateful_dataloader/test_incremental_state.py
+++ b/test/stateful_dataloader/test_incremental_state.py
@@ -1,0 +1,100 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import unittest
+from typing import Dict
+
+import torch
+
+from torch.testing._internal.common_utils import TestCase
+from torchdata.stateful_dataloader import (
+    _DATASET_ITER_STATE,
+    _DATASET_STATE,
+    _FETCHER_ENDED,
+    _FETCHER_STATE,
+    _WORKER_ID,
+    DeletionTombStone,
+    Flattener,
+    IncrementalState,
+    IncrementalWorkerState,
+)
+
+
+class TestFlattener(TestCase):
+    def test(self):
+        test_dict_pairs = [
+            (None, 0),
+            ({}, 0),
+            ({"kt": torch.rand(2, 2)}, 1),
+            ({"k1": "v1"}, 1),
+            ({"k2": ["v1", "v2"]}, 1),
+            ({"k1": {"k2": "v2"}}, 1),
+            ({"k1": {"k2": "v2"}, "k2": {"k2": "v2"}}, 2),
+        ]
+
+        for kv, flat_key_count in test_dict_pairs:
+            flat_dict = Flattener.flatten(kv)
+            nest_dict = Flattener.unflatten(flat_dict)
+            self.assertEqual(kv, nest_dict)
+            if kv is None:
+                continue
+            self.assertEqual(len(flat_dict), flat_key_count)
+            for _, val in flat_dict.items():
+                self.assertFalse(isinstance(val, Dict))
+
+
+class TestIncrementalState(TestCase):
+    def test_basic(self):
+        incr_state = IncrementalState({"a": 4})
+        delta = incr_state.generate_delta({"a": 4, "b": 3})
+        self.assertEqual(delta, {"b": 3})
+        incr_state.apply_delta({"a": 5})
+        self.assertEqual(incr_state.get_state(), {"a": 5, "b": 3})
+
+    def test_removal(self):
+        incr_state = IncrementalState({"a": 4})
+        delta = incr_state.generate_delta({"b": {"x": "y"}})
+        self.assertEqual(len(delta), 2)
+        self.assertEqual(delta["b/x"], "y")
+        self.assertTrue(isinstance(delta["a"], DeletionTombStone))
+        incr_state.apply_delta({"c": 5})
+        self.assertEqual(incr_state.get_state(), {"b": {"x": "y"}, "c": 5})
+
+    def test_none(self):
+        incr_state = IncrementalState(None)
+        self.assertEqual(incr_state.get_state(), None)
+        delta = incr_state.generate_delta({"a": 1})
+        self.assertEqual(delta, {"a": 1})
+        delta = incr_state.generate_delta({})
+        self.assertEqual(len(delta), 1)
+        self.assertTrue(delta["a"], DeletionTombStone)
+        self.assertEqual(incr_state.get_state(), {})
+
+
+class TestIncrementalWorkerState(TestCase):
+    def test_basic(self):
+        worker_state = IncrementalWorkerState(None)
+        state = {
+            _WORKER_ID: 0,
+            _DATASET_STATE: {"abc": "xyz"},
+            _FETCHER_STATE: {
+                _DATASET_ITER_STATE: {"def": 123},
+                _FETCHER_ENDED: False,
+            },
+        }
+        delta = worker_state.generate_delta(state)
+        # No nested dicts, so state should be same as delta
+        self.assertEqual(state, delta)
+        state[_DATASET_STATE]["abc"] = "tuv"
+        delta = worker_state.generate_delta(state)
+        self.assertEqual(delta[_DATASET_STATE], {"abc": "tuv"})
+        self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], {})
+        final_state = worker_state.get_state()
+        self.assertEqual(state, final_state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -512,8 +512,6 @@ class TestStatefulDataLoaderGeneratorNoState_shard2(TestStatefulDataLoaderIterab
         for _ in range(interrupt):
             batches.append(next(it))
         state_dict = dl.state_dict()
-        print("Got sd: ", state_dict)
-
         self.assertEqual(batches, exp[:interrupt])
 
         # Restore new instance from state

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -9,11 +9,12 @@ from .incremental_state import (
     _DATASET_STATE,
     _FETCHER_ENDED,
     _FETCHER_STATE,
+    _flatten,
+    _IncrementalState,
+    _IncrementalWorkerState,
+    _Tombstone,
+    _unflatten,
     _WORKER_ID,
-    DeletionTombStone,
-    Flattener,
-    IncrementalState,
-    IncrementalWorkerState,
 )
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader

--- a/torchdata/stateful_dataloader/__init__.py
+++ b/torchdata/stateful_dataloader/__init__.py
@@ -4,6 +4,17 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from .incremental_state import (
+    _DATASET_ITER_STATE,
+    _DATASET_STATE,
+    _FETCHER_ENDED,
+    _FETCHER_STATE,
+    _WORKER_ID,
+    DeletionTombStone,
+    Flattener,
+    IncrementalState,
+    IncrementalWorkerState,
+)
 from .stateful import Stateful
 from .stateful_dataloader import StatefulDataLoader
 

--- a/torchdata/stateful_dataloader/incremental_state.py
+++ b/torchdata/stateful_dataloader/incremental_state.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
+
 from typing import Any, Dict, Optional, Tuple
 
 import torch

--- a/torchdata/stateful_dataloader/incremental_state.py
+++ b/torchdata/stateful_dataloader/incremental_state.py
@@ -3,7 +3,7 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 
@@ -14,7 +14,7 @@ _DATASET_STATE = "dataset_state"
 _DATASET_ITER_STATE = "dataset_iter_state"
 
 
-def _flatten(nested_data, key_lineage=()):
+def _flatten(nested_data: Any, key_lineage: Tuple = ()):
     if nested_data is None:
         return None
     data = {}
@@ -27,7 +27,7 @@ def _flatten(nested_data, key_lineage=()):
     return data
 
 
-def _unflatten(flat_data):
+def _unflatten(flat_data: Optional[Dict[Tuple, Any]]):
     if flat_data is None:
         return None
     nested_data = {}

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -1297,7 +1297,6 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
             data.reraise()
         self._last_yielded_worker_id = worker_id
         # Update latest worker state
-        # print("Received state_dict : ", state_dict)
         if state_dict is not None:
             self._update_worker_snapshot(self._worker_key(state_dict[_WORKER_ID]), state_dict)
         if self._snapshot_interval and ((self._num_yielded + 1) % self._snapshot_interval == 0):

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -167,8 +167,9 @@ def _worker_loop(
         from torch.utils.data import _DatasetKind
 
         init_exception = None
-
         fetcher = None
+        previous_state_dict = None
+
         try:
             if init_fn is not None:
                 init_fn(worker_id)
@@ -177,6 +178,7 @@ def _worker_loop(
 
             # Restore worker state if provided
             if worker_state:
+                previous_state_dict = worker_state
                 # Always restore in this order:
                 #  1. try to restore dataset state
                 #  2. generate dataset iterator
@@ -219,7 +221,6 @@ def _worker_loop(
 
         watchdog = ManagerWatchdog()
 
-        previous_state_dict = None
         while watchdog.is_alive():
             try:
                 r = index_queue.get(timeout=MP_STATUS_CHECK_INTERVAL)

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -32,8 +32,8 @@ from .incremental_state import (
     _DATASET_STATE,
     _FETCHER_ENDED,
     _FETCHER_STATE,
+    _IncrementalWorkerState,
     _WORKER_ID,
-    IncrementalWorkerState,
 )
 
 from .stateful import Stateful
@@ -111,7 +111,7 @@ def _worker_loop(
 
         from torch.utils.data import _DatasetKind
 
-        incremental_worker_state = IncrementalWorkerState(worker_state)
+        incremental_worker_state = _IncrementalWorkerState(worker_state)
         init_exception = None
         fetcher = None
 


### PR DESCRIPTION
Summary: Transfer of full state from worker to main process can be expensive if the state is very large. In order to alleviate the cost of state transfer, maintain a flattened state map in the worker process and send only the key/value that have changed to the main dataloader process where the full state is reconstructed with the changes received from the workers.

Test Plan: Unit tests

Reviewers:

Subscribers:

Tasks:

Tags:Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- Note that there is a section on requirements related to adding a new DataPipe.

Fixes #{issue number}

### Changes

-
-
