### PR TITLE
Incremental state: fix flatten None handling

### DIFF
--- a/test/stateful_dataloader/test_incremental_state.py
+++ b/test/stateful_dataloader/test_incremental_state.py
@@ -27,24 +27,34 @@ from torchdata.stateful_dataloader import (
 class TestFlattener(TestCase):
     def test(self):
         test_dict_pairs = [
-            (None, 0),
-            ({}, 0),
+            (None, 1),
+            ({}, 1),
             ({"kt": torch.rand(2, 2)}, 1),
             ({"k1": "v1"}, 1),
             ({"k2": ["v1", "v2"]}, 1),
             ({"k1": {"k2": "v2"}}, 1),
             ({"k1": {"k2": "v2"}, "k2": {"k2": "v2"}}, 2),
+            ({"k1": None}, 1),
+            ({"k1": {"k2": None}}, 1),
+            ("abcd", 1),
+            ({"k1": {"k2": {}, "k3": None}}, 2),
         ]
 
         for kv, flat_key_count in test_dict_pairs:
             flat_dict = _flatten(kv)
             nest_dict = _unflatten(flat_dict)
+            print(flat_dict)
+            print(nest_dict)
             self.assertEqual(kv, nest_dict)
             if kv is None:
                 continue
+            self.assertTrue(isinstance(flat_dict, dict))
+            self.assertTrue(len(flat_dict) > 0)
             self.assertEqual(len(flat_dict), flat_key_count)
             for _, val in flat_dict.items():
-                self.assertFalse(isinstance(val, Dict))
+                # Only empty dicts are allowed in flattened dict
+                if isinstance(val, Dict):
+                    self.assertFalse(len(val))
 
 
 class TestIncrementalState(TestCase):
@@ -55,23 +65,47 @@ class TestIncrementalState(TestCase):
         incr_state.apply_delta({("a",): 5})
         self.assertEqual(incr_state.get_state(), {"a": 5, "b": 3})
 
+    def test_non_dict(self):
+        incr_state = _IncrementalState("5")
+        self.assertEqual(incr_state.get_state(), "5")
+        delta = incr_state.generate_delta("4")
+        self.assertEqual(delta, {(): "4"})
+        self.assertEqual(incr_state.get_state(), "4")
+
     def test_removal(self):
         incr_state = _IncrementalState({"a": 4})
+        recv_state = _IncrementalState({"a": 4})
         delta = incr_state.generate_delta({"b": {"x": "y"}})
         self.assertEqual(len(delta), 2)
         self.assertEqual(delta[("b", "x")], "y")
         self.assertTrue(isinstance(delta[("a",)], _Tombstone))
-        incr_state.apply_delta({("c",): 5})
+        recv_state.apply_delta(delta)
+        self.assertEqual(recv_state.get_state(), incr_state.get_state())
+        delta = {("c",): 5}
+        incr_state.apply_delta(delta)
+        recv_state.apply_delta(delta)
         self.assertEqual(incr_state.get_state(), {"b": {"x": "y"}, "c": 5})
+        self.assertEqual(incr_state.get_state(), recv_state.get_state())
 
     def test_none(self):
         incr_state = _IncrementalState(None)
+        recv_state = _IncrementalState(None)
         self.assertEqual(incr_state.get_state(), None)
+
         delta = incr_state.generate_delta({"a": 1})
-        self.assertEqual(delta, {("a",): 1})
+        self.assertEqual(len(delta), 2)
+        self.assertEqual(delta[("a",)], 1)
+        self.assertTrue(isinstance(delta[()], _Tombstone))
+        recv_state.apply_delta(delta)
+        self.assertEqual(recv_state.get_state(), {"a": 1})
+        self.assertEqual(incr_state.get_state(), {"a": 1})
+
         delta = incr_state.generate_delta({})
-        self.assertEqual(len(delta), 1)
-        self.assertTrue(delta[("a",)], _Tombstone)
+        recv_state.apply_delta(delta)
+        self.assertEqual(len(delta), 2)
+        self.assertTrue(isinstance(delta[("a",)], _Tombstone))
+        self.assertEqual(delta[()], {})
+        self.assertEqual(recv_state.get_state(), {})
         self.assertEqual(incr_state.get_state(), {})
 
 
@@ -91,6 +125,62 @@ class TestIncrementalWorkerState(TestCase):
         delta = worker_state.generate_delta(state)
         self.assertEqual(delta[_DATASET_STATE], {("abc",): "tuv"})
         self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], {})
+        final_state = worker_state.get_state()
+        self.assertEqual(state, final_state)
+
+    def test_nested_state(self):
+        worker_state = _IncrementalWorkerState(None)
+        state = {
+            _WORKER_ID: 0,
+            _DATASET_STATE: {"z": {"a1": "b1"}},
+            _FETCHER_STATE: {
+                _DATASET_ITER_STATE: {"a": {"b": "c"}},
+                _FETCHER_ENDED: False,
+            },
+        }
+        delta = worker_state.generate_delta(state)
+        state[_DATASET_STATE]["z"]["a1"] = "z1"
+        delta = worker_state.generate_delta(state)
+        self.assertEqual(delta[_DATASET_STATE], {("z", "a1"): "z1"})
+        self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], {})
+        final_state = worker_state.get_state()
+        self.assertEqual(state, final_state)
+
+    def test_none_state(self):
+        worker_state = _IncrementalWorkerState(None)
+        state = {
+            _WORKER_ID: 0,
+            _DATASET_STATE: {"z": {"a1": None}},
+            _FETCHER_STATE: {
+                _DATASET_ITER_STATE: None,
+                _FETCHER_ENDED: False,
+            },
+        }
+        delta = worker_state.generate_delta(state)
+        state[_DATASET_STATE]["z"]["a1"] = 1
+        delta = worker_state.generate_delta(state)
+        self.assertEqual(delta[_DATASET_STATE], {("z", "a1"): 1})
+        self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], None)
+        final_state = worker_state.get_state()
+        self.assertEqual(state, final_state)
+
+    def test_none_replacement(self):
+        worker_state = _IncrementalWorkerState(None)
+        state = {
+            _WORKER_ID: 0,
+            _DATASET_STATE: {"z": None},
+            _FETCHER_STATE: {
+                _DATASET_ITER_STATE: {"a": None},
+                _FETCHER_ENDED: False,
+            },
+        }
+        delta = worker_state.generate_delta(state)
+        state[_DATASET_STATE]["z"] = "abc"
+        state[_FETCHER_STATE][_DATASET_ITER_STATE]["a"] = {"b": None}
+        delta = worker_state.generate_delta(state)
+        self.assertEqual(delta[_DATASET_STATE], {("z",): "abc"})
+        self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE][("a", "b")], None)
+        self.assertTrue(isinstance(delta[_FETCHER_STATE][_DATASET_ITER_STATE][("a",)], _Tombstone))
         final_state = worker_state.get_state()
         self.assertEqual(state, final_state)
 

--- a/torchdata/stateful_dataloader/incremental_state.py
+++ b/torchdata/stateful_dataloader/incremental_state.py
@@ -15,24 +15,27 @@ _DATASET_STATE = "dataset_state"
 _DATASET_ITER_STATE = "dataset_iter_state"
 
 
-def _flatten(nested_data: Any, key_lineage: Tuple = ()):
-    if nested_data is None:
-        return None
-    data = {}
-    if isinstance(nested_data, dict):
-        for key, value in nested_data.items():
+def _flatten(data: Any, key_lineage: Tuple = ()) -> Dict[Tuple, Any]:
+    # Always return a dict as the result
+    # If data is not a dict or if it is an empty dict, then return a dict with key as key_lineage and data as the value
+    # If data is a dict with entries, then iterate through it and flatten the keys
+    flat_data = {}
+    if isinstance(data, dict) and len(data) > 0:
+        for key, value in data.items():
             flat = _flatten(value, key_lineage + (key,))
-            data.update(flat)
+            flat_data.update(flat)
     else:
-        data[key_lineage] = nested_data
-    return data
+        flat_data[key_lineage] = data
+    return flat_data
 
 
-def _unflatten(flat_data: Optional[Dict[Tuple, Any]]):
-    if flat_data is None:
-        return None
+def _unflatten(flat_data: Dict[Tuple, Any]):
     nested_data = {}
     for key, value in flat_data.items():
+        # Consider case where key is empty tuple, this is the case where original data was not a dict
+        if len(key) == 0:
+            return value
+
         prefix = key[0]
         if len(key) == 1:
             nested_data[prefix] = value
@@ -42,7 +45,8 @@ def _unflatten(flat_data: Optional[Dict[Tuple, Any]]):
         if prefix not in nested_data:
             nested_data[prefix] = {}
         nested_data[prefix][suffix] = value
-    # now go through nested_data and unflatten next depth dicts
+
+    # now go through nested_data and unflatten next level of dicts
     for k, v in nested_data.items():
         if isinstance(v, dict):
             nested_data[k] = _unflatten(v)

--- a/torchdata/stateful_dataloader/incremental_state.py
+++ b/torchdata/stateful_dataloader/incremental_state.py
@@ -95,7 +95,7 @@ class _IncrementalState:
         self.flat_state = new_flat_state
         return delta_flat_state
 
-    def apply_delta(self, flat_delta_state: Dict[str, Any]) -> None:
+    def apply_delta(self, flat_delta_state: Dict[Tuple, Any]) -> None:
         for key, update in flat_delta_state.items():
             if self.flat_state is None:
                 self.flat_state = {}


### PR DESCRIPTION
Flatten could return None but result of flatten was recursively used for updating the flatten map. This caused an error when the value of the dict is None. Handling that case now and also added unit tests to capture that scenario

Fixes #{issue number}

### Changes

-
-
