### PR TITLE
Handle case where state is a tensor

### DIFF
--- a/test/stateful_dataloader/test_incremental_state.py
+++ b/test/stateful_dataloader/test_incremental_state.py
@@ -43,8 +43,6 @@ class TestFlattener(TestCase):
         for kv, flat_key_count in test_dict_pairs:
             flat_dict = _flatten(kv)
             nest_dict = _unflatten(flat_dict)
-            print(flat_dict)
-            print(nest_dict)
             self.assertEqual(kv, nest_dict)
             if kv is None:
                 continue
@@ -71,6 +69,14 @@ class TestIncrementalState(TestCase):
         delta = incr_state.generate_delta("4")
         self.assertEqual(delta, {(): "4"})
         self.assertEqual(incr_state.get_state(), "4")
+
+    def test_tensor_state(self):
+        incr_state = _IncrementalState(torch.rand(5))
+        ns = torch.rand(5)
+        delta = incr_state.generate_delta(ns)
+        self.assertEqual(len(delta), 1)
+        self.assertTrue(torch.equal(delta[()], ns))
+        self.assertTrue(torch.equal(incr_state.get_state(), ns))
 
     def test_removal(self):
         incr_state = _IncrementalState({"a": 4})
@@ -125,6 +131,24 @@ class TestIncrementalWorkerState(TestCase):
         delta = worker_state.generate_delta(state)
         self.assertEqual(delta[_DATASET_STATE], {("abc",): "tuv"})
         self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], {})
+        final_state = worker_state.get_state()
+        self.assertEqual(state, final_state)
+
+    def test_tensor_state(self):
+        worker_state = _IncrementalWorkerState(None)
+        state = {
+            _WORKER_ID: 0,
+            _DATASET_STATE: None,
+            _FETCHER_STATE: {
+                _DATASET_ITER_STATE: None,
+                _FETCHER_ENDED: False,
+            },
+        }
+        delta = worker_state.generate_delta(state)
+        ts = torch.rand(5)
+        state[_DATASET_STATE] = ts
+        delta = worker_state.generate_delta(state)
+        self.assertEqual(delta[_FETCHER_STATE][_DATASET_ITER_STATE], None)
         final_state = worker_state.get_state()
         self.assertEqual(state, final_state)
 

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1481,17 +1481,18 @@ class TestFastStateDictRequestRoundRobin_shard3(TestCase):
 class TestNonDictState_shard0(TestCase):
     def test(self):
         for state_type in StateType:
-            ds = TensorStateIterableDataset(5, state_type)
-            dl = StatefulDataLoader(
-                dataset=ds,
-                num_workers=2,
-                collate_fn=identity,
-                multiprocessing_context=("forkserver" if IS_MACOS and num_workers else None),
-            )
-            it = iter(dl)
-            next(it)
-            sd = dl.state_dict()
-            self.assertTrue(sd)
+            for num_workers in [0, 2]:
+                ds = TensorStateIterableDataset(5, state_type)
+                dl = StatefulDataLoader(
+                    dataset=ds,
+                    num_workers=num_workers,
+                    collate_fn=identity,
+                    multiprocessing_context=("forkserver" if IS_MACOS and num_workers else None),
+                )
+                it = iter(dl)
+                next(it)
+                sd = dl.state_dict()
+                self.assertTrue(sd)
 
 
 class TestMultiEpochState_shard0(TestCase):

--- a/torchdata/stateful_dataloader/incremental_state.py
+++ b/torchdata/stateful_dataloader/incremental_state.py
@@ -120,7 +120,8 @@ class _IncrementalWorkerState:
         if initial_worker_state_dict:
             self._worker_id = initial_worker_state_dict[_WORKER_ID]
             dataset_state = initial_worker_state_dict.get(_DATASET_STATE, None)
-            if fetcher_state := initial_worker_state_dict.get(_FETCHER_STATE, None):
+            fetcher_state = initial_worker_state_dict.get(_FETCHER_STATE, None)
+            if fetcher_state is not None:
                 self._fetcher_ended = fetcher_state[_FETCHER_ENDED]
                 fetcher_iter_state = fetcher_state.get(_DATASET_ITER_STATE, None)
 
@@ -132,14 +133,17 @@ class _IncrementalWorkerState:
         self._worker_id = new_state_dict[_WORKER_ID]
         incr_state_dict = {_WORKER_ID: self._worker_id, _FETCHER_STATE: None}
 
-        if ds_state := new_state_dict.get(_DATASET_STATE, None):
+        ds_state = new_state_dict.get(_DATASET_STATE, None)
+        if ds_state is not None:
             incr_state_dict[_DATASET_STATE] = self._incr_dataset_state.generate_delta(ds_state)
 
-        if fetcher_state := new_state_dict.get(_FETCHER_STATE, None):
+        fetcher_state = new_state_dict.get(_FETCHER_STATE, None)
+        if fetcher_state is not None:
             self._fetcher_ended = fetcher_state[_FETCHER_ENDED]
 
             delta_iter_state = None
-            if iter_state := fetcher_state.get(_DATASET_ITER_STATE, None):
+            iter_state = fetcher_state.get(_DATASET_ITER_STATE, None)
+            if iter_state is not None:
                 delta_iter_state = self._incr_fetcher_iter_state.generate_delta(iter_state)
 
             incr_state_dict[_FETCHER_STATE] = {
@@ -150,12 +154,15 @@ class _IncrementalWorkerState:
 
     def apply_delta(self, delta_state_dict: Dict[str, Any]) -> None:
         self._worker_id = delta_state_dict[_WORKER_ID]
-        if ds_state := delta_state_dict.get(_DATASET_STATE, None):
+        ds_state = delta_state_dict.get(_DATASET_STATE, None)
+        if ds_state is not None:
             self._incr_dataset_state.apply_delta(ds_state)
 
-        if fetcher_state := delta_state_dict.get(_FETCHER_STATE, None):
+        fetcher_state = delta_state_dict.get(_FETCHER_STATE, None)
+        if fetcher_state is not None:
             self._fetcher_ended = fetcher_state[_FETCHER_ENDED]
-            if iter_state := fetcher_state.get(_DATASET_ITER_STATE, None):
+            iter_state = fetcher_state.get(_DATASET_ITER_STATE, None)
+            if iter_state is not None:
                 self._incr_fetcher_iter_state.apply_delta(iter_state)
 
     def get_state(self) -> Dict[str, Any]:


### PR DESCRIPTION
Fixes the case where tensor is returned as the state instead of a dict. This was failing because the tensor object was being used as a bool check for the walrus operator and that failed. Instead just do regular fetch and not None comparison.

Added unit tests in all the layers to cover this

Fixes #{1271}

### Changes

-
-
