### PR TITLE
add deprecation warning for deprecated modules

### DIFF
--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -34,7 +34,7 @@ def __getattr__(name):
                 raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-_DEPRECATED = _warning_shown = False
+_warning_shown = False
 
 
 def deprecation_warning():

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -34,8 +34,7 @@ def __getattr__(name):
                 raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-_DEPRECATED = ["janitor", "datapipes", "dataloader2"]
-_warning_shown = False
+_DEPRECATED = _warning_shown = False
 
 
 def deprecation_warning():
@@ -45,11 +44,11 @@ def deprecation_warning():
         import warnings
 
         warnings.warn(
-            f"\n############################################################################\n"
-            f"   WARNING!\n"
-            f"The {_DEPRECATED} modules are deprecated and will be removed in a future \n"
-            f"torchdata release! Please see https://github.com/pytorch/data/issues/1196 \n"
-            f"to learn more and leave feedback.\n"
-            f"############################################################################\n",
+            "\n################################################################################\n"
+            "WARNING!\n"
+            "The 'datapipes', 'dataloader2' modules are deprecated and will be removed in a\n"
+            "future torchdata release! Please see https://github.com/pytorch/data/issues/1196\n"
+            "to learn more and leave feedback.\n"
+            "################################################################################\n",
             stacklevel=2,
         )

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -20,24 +20,8 @@ __all__ = [
 assert __all__ == sorted(__all__)
 
 
-_DEPRECATED = ["janitor", "datapipes", "dataloader2"]
-_warning_shown = False
-
-
 # Lazy import all modules
 def __getattr__(name):
-    if name in _DEPRECATED and not _warning_shown:
-        global _warning_shown
-        _warning_shown = True
-
-        import warnings
-
-        warnings.warn(
-            f"The {_DEPRECATED} modules are deprecated and will be removed in a future "
-            f"torchdata release! Please see https://github.com/pytorch/data/issues/1196 "
-            f"to learn more and leave feedback.",
-            stacklevel=2,
-        )
     if name == "janitor":
         return importlib.import_module(".datapipes.utils." + name, __name__)
     else:
@@ -48,3 +32,24 @@ def __getattr__(name):
                 return globals()[name]
             else:
                 raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+_DEPRECATED = ["janitor", "datapipes", "dataloader2"]
+_warning_shown = False
+
+
+def deprecation_warning():
+    global _warning_shown
+    if not _warning_shown:
+        _warning_shown = True
+        import warnings
+
+        warnings.warn(
+            f"\n############################################################################\n"
+            f"   WARNING!\n"
+            f"The {_DEPRECATED} modules are deprecated and will be removed in a future \n"
+            f"torchdata release! Please see https://github.com/pytorch/data/issues/1196 \n"
+            f"to learn more and leave feedback.\n"
+            f"############################################################################\n",
+            stacklevel=2,
+        )

--- a/torchdata/__init__.py
+++ b/torchdata/__init__.py
@@ -20,8 +20,24 @@ __all__ = [
 assert __all__ == sorted(__all__)
 
 
+_DEPRECATED = ["janitor", "datapipes", "dataloader2"]
+_warning_shown = False
+
+
 # Lazy import all modules
 def __getattr__(name):
+    if name in _DEPRECATED and not _warning_shown:
+        global _warning_shown
+        _warning_shown = True
+
+        import warnings
+
+        warnings.warn(
+            f"The {_DEPRECATED} modules are deprecated and will be removed in a future "
+            f"torchdata release! Please see https://github.com/pytorch/data/issues/1196 "
+            f"to learn more and leave feedback.",
+            stacklevel=2,
+        )
     if name == "janitor":
         return importlib.import_module(".datapipes.utils." + name, __name__)
     else:

--- a/torchdata/dataloader2/__init__.py
+++ b/torchdata/dataloader2/__init__.py
@@ -34,3 +34,8 @@ __all__ = [
 ]
 
 assert __all__ == sorted(__all__)
+
+
+from torchdata import deprecation_warning
+
+deprecation_warning()

--- a/torchdata/datapipes/__init__.py
+++ b/torchdata/datapipes/__init__.py
@@ -11,3 +11,8 @@ from torchdata import _extension  # noqa: F401
 from . import iter, map, utils
 
 __all__ = ["DataChunk", "functional_datapipe", "iter", "map", "utils"]
+
+
+from torchdata import deprecation_warning
+
+deprecation_warning()


### PR DESCRIPTION
See https://github.com/pytorch/data/issues/1196 

### Changes
Adds deprecation warning for datapipes, dataloader2, and janitor imports from torchdata

Some quick tests:

<img width="625" alt="image" src="https://github.com/pytorch/data/assets/5349063/fffea75b-9d77-4bd2-aad8-f280c7a3b5e4">


-
-
