### PR TITLE
Save state in dataset_iter_state when dataset is also an iterator

### DIFF
--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1295,7 +1295,9 @@ class TestDynamicStateIterableDataset_shard0(TestCase):
         next_state_dict = dl.state_dict()
         self.assertEqual(state_dict, deep_copy_state_dict)
         self.assertFalse(state_dict == next_state_dict)
-        worker_state = next_state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["fetcher_state"]["dataset_iter_state"]
+        worker_state = next_state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["fetcher_state"][
+            "dataset_iter_state"
+        ]
         self.assertEqual(len(worker_state), 11)
 
         dl = StatefulDataLoader(
@@ -1539,7 +1541,7 @@ class TestSingleIterCalled_shard0(TestCase):
             w_states = [state]
         else:
             w_states = list(state["_snapshot"]["_worker_snapshots"].values())
-        
+ 
         if w_states[0]["dataset_state"] is not None:
             return [x["dataset_state"]["iter_calls"] for x in w_states]
         return [x["fetcher_state"]["dataset_iter_state"]["iter_calls"] for x in w_states]

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1285,7 +1285,7 @@ class TestDynamicStateIterableDataset_shard0(TestCase):
         for _ in range((num_workers + 1) * 2):
             next(it)
         state_dict = dl.state_dict()
-        worker_state = state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["dataset_state"]
+        worker_state = state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["fetcher_state"]["dataset_iter_state"]
         self.assertEqual(len(worker_state), 7)
         deep_copy_state_dict = deepcopy(state_dict)
 
@@ -1295,7 +1295,7 @@ class TestDynamicStateIterableDataset_shard0(TestCase):
         next_state_dict = dl.state_dict()
         self.assertEqual(state_dict, deep_copy_state_dict)
         self.assertFalse(state_dict == next_state_dict)
-        worker_state = next_state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["dataset_state"]
+        worker_state = next_state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["fetcher_state"]["dataset_iter_state"]
         self.assertEqual(len(worker_state), 11)
 
         dl = StatefulDataLoader(
@@ -1311,7 +1311,7 @@ class TestDynamicStateIterableDataset_shard0(TestCase):
             exp.extend(next(it))
         state_dict = dl.state_dict()
         self.assertEqual(exp, [3, 3])
-        worker_state = state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["dataset_state"]
+        worker_state = state_dict["_snapshot"]["_worker_snapshots"]["worker_0"]["fetcher_state"]["dataset_iter_state"]
         self.assertEqual(len(worker_state), 9)
 
 
@@ -1334,16 +1334,15 @@ class TestDatasetIteratorStateDuplication_shard0(TestCase):
             if num_workers > 0:
                 for i in range(num_workers):
                     # Ensure worker state is stored only once if the dataset is also the iterator
-                    self.assertTrue(state_dict["_snapshot"]["_worker_snapshots"][f"worker_{i}"]["dataset_state"])
-                    self.assertEqual(
+                    self.assertEqual(state_dict["_snapshot"]["_worker_snapshots"][f"worker_{i}"]["dataset_state"], None)
+                    self.assertTrue(
                         state_dict["_snapshot"]["_worker_snapshots"][f"worker_{i}"]["fetcher_state"][
                             "dataset_iter_state"
-                        ],
-                        None,
+                        ]
                     )
             else:
-                self.assertTrue(state_dict["dataset_state"])
-                self.assertEqual(state_dict["fetcher_state"]["dataset_iter_state"], None)
+                self.assertEqual(state_dict["dataset_state"], None)
+                self.assertTrue(state_dict["fetcher_state"]["dataset_iter_state"])
 
 
 class PeriodicStateIterableDataset(torch.utils.data.IterableDataset):
@@ -1529,7 +1528,8 @@ class CountIterCallsIter(torch.utils.data.IterableDataset):
         return {"iter_calls": self.iter_calls, "items": deepcopy(self.items)}
 
     def load_state_dict(self, state_dict):
-        self.iter_calls = state_dict["iter_calls"]
+        # sequence of calls for this : iter is called first and then load_state_dict is called and thus we don't want state to override calls to iter that has happened before load_state_dict was called
+        self.iter_calls += state_dict["iter_calls"]
         self.items = state_dict["items"]
 
 
@@ -1539,10 +1539,14 @@ class TestSingleIterCalled_shard0(TestCase):
             w_states = [state]
         else:
             w_states = list(state["_snapshot"]["_worker_snapshots"].values())
-
-        return [x["dataset_state"]["iter_calls"] for x in w_states]
+        
+        if w_states[0]["dataset_state"] is not None:
+            return [x["dataset_state"]["iter_calls"] for x in w_states]
+        return [x["fetcher_state"]["dataset_iter_state"]["iter_calls"] for x in w_states]
 
     def _run_test(self, num_workers, dataset):
+        # Need to make a copy here as iter calls is tracked and its count is stored in dataset state which persists across calls for single process runs.
+        dataset_copy = deepcopy(dataset) if num_workers == 0 else dataset
         dl = StatefulDataLoader(
             dataset=dataset,
             num_workers=num_workers,
@@ -1552,7 +1556,7 @@ class TestSingleIterCalled_shard0(TestCase):
         state = dl.state_dict()
         self.assertEqual(self._get_iter_calls(state), [1] * max(1, num_workers))
         dl2 = StatefulDataLoader(
-            dataset=dataset,
+            dataset=dataset_copy,
             num_workers=num_workers,
             multiprocessing_context=("forkserver" if IS_MACOS and num_workers else None),
         )

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1507,7 +1507,7 @@ class CountIterCalls(torch.utils.data.IterableDataset):
 
     def load_state_dict(self, state_dict):
         self.iter_calls = state_dict["iter_calls"]
-        
+
 
 class CountIterCallsIter(torch.utils.data.IterableDataset):
     def __init__(self, length):
@@ -1570,7 +1570,7 @@ class TestSingleIterCalled_shard0(TestCase):
         iter(dl)
         state = dl.state_dict()
         self.assertEqual(self._get_iter_calls(state), [2] * max(1, num_workers))
-        
+
         dl2 = StatefulDataLoader(
             dataset=dataset_copy,
             num_workers=num_workers,
@@ -1589,7 +1589,6 @@ class TestSingleIterCalled_shard0(TestCase):
         # Ensure that iter has not been invoked again
         self.assertEqual(self._get_iter_calls(state2), [3] * max(1, num_workers))
 
-
     def test_inline(self):
         self._run_test(0, CountIterCalls(100))
 
@@ -1603,11 +1602,11 @@ class TestSingleIterCalled_shard0(TestCase):
         self._run_test(2, CountIterCallsIter(100))
 
 
-class IterationState():
+class IterationState:
     def __init__(self, start, end):
         self.curr = start
         self.end = end
-    
+
     def set_state(self, state):
         self.curr = state["curr"]
         self.end = state["end"]
@@ -1625,9 +1624,9 @@ class StatesInitializationDataset(torch.utils.data.IterableDataset):
         if torch.utils.data.get_worker_info() is not None:
             worker_id = torch.utils.data.get_worker_info().id
         num_workers = 1
-        if torch.utils.data.get_worker_info() is not None: 
+        if torch.utils.data.get_worker_info() is not None:
             num_workers = torch.utils.data.get_worker_info().num_workers
-        
+
         num_samples = (int)(self.length / num_workers)
         self.iter_state = IterationState(num_samples * worker_id, num_samples * (worker_id + 1))
         return self
@@ -1681,7 +1680,7 @@ class TestStateInitializationDataset(TestCase):
 
         for _ in range(30):
             data.extend(next(it))
-        
+
         # Order could be different for multiworker case as the data comes from different workers, so use set to check equality instead of list
         self.assertEqual(set(data), set(range(length)))
 

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1541,7 +1541,7 @@ class TestSingleIterCalled_shard0(TestCase):
             w_states = [state]
         else:
             w_states = list(state["_snapshot"]["_worker_snapshots"].values())
- 
+
         if w_states[0]["dataset_state"] is not None:
             return [x["dataset_state"]["iter_calls"] for x in w_states]
         return [x["fetcher_state"]["dataset_iter_state"]["iter_calls"] for x in w_states]

--- a/test/stateful_dataloader/test_state_dict.py
+++ b/test/stateful_dataloader/test_state_dict.py
@@ -1649,6 +1649,12 @@ class StatesInitializationDataset(torch.utils.data.IterableDataset):
 class TestStateInitializationDataset(TestCase):
     def _run_test(self, num_workers, dataset):
         length = dataset.length
+
+        # Ensure test is run with compatible parameters as the test and dataset used in the test doesn't cover all the corner cases
+        if num_workers > 0:
+            self.assertTrue(length % num_workers == 0)
+        self.assertTrue(length > 30)
+
         dl = StatefulDataLoader(
             dataset=dataset,
             num_workers=num_workers,
@@ -1676,6 +1682,7 @@ class TestStateInitializationDataset(TestCase):
         for _ in range(30):
             data.extend(next(it))
         
+        # Order could be different for multiworker case as the data comes from different workers, so use set to check equality instead of list
         self.assertEqual(set(data), set(range(length)))
 
     def test_inline(self):

--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -332,14 +332,13 @@ class _StatefulSingleProcessDataLoaderIter(_StatefulBaseDataLoaderIter):
 
     def state_dict(self):
         if self._dataset_kind == _DatasetKind.Iterable:
-            iter_state = None
-            if self._dataset_fetcher.dataset_iter is not self._dataset_fetcher.dataset:
-                iter_state = try_to_serialize(self._dataset_fetcher.dataset_iter)
             fetcher_state = {
-                _DATASET_ITER_STATE: iter_state,
+                _DATASET_ITER_STATE: try_to_serialize(self._dataset_fetcher.dataset_iter),
                 _FETCHER_ENDED: self._dataset_fetcher.ended,
             }
-            dataset_state = try_to_serialize(self._dataset_fetcher.dataset)
+            dataset_state = None
+            if self._dataset_fetcher.dataset_iter is not self._dataset_fetcher.dataset:
+                dataset_state = try_to_serialize(self._dataset_fetcher.dataset)
         else:
             fetcher_state = None
             dataset_state = try_to_serialize(self._dataset_fetcher.dataset)

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -273,7 +273,6 @@ def _make_state_dict(worker_id, dataset_kind, fetcher, dataset) -> Dict[str, Any
     from torch.utils.data import _DatasetKind
 
     if dataset_kind == _DatasetKind.Iterable:
-        iter_state = None
         fetcher_state = {
             _DATASET_ITER_STATE: try_to_serialize(fetcher.dataset_iter),
             _FETCHER_ENDED: fetcher.ended,

--- a/torchdata/stateful_dataloader/worker.py
+++ b/torchdata/stateful_dataloader/worker.py
@@ -274,13 +274,13 @@ def _make_state_dict(worker_id, dataset_kind, fetcher, dataset) -> Dict[str, Any
 
     if dataset_kind == _DatasetKind.Iterable:
         iter_state = None
-        if fetcher.dataset_iter is not fetcher.dataset:
-            iter_state = try_to_serialize(fetcher.dataset_iter)
         fetcher_state = {
-            _DATASET_ITER_STATE: iter_state,
+            _DATASET_ITER_STATE: try_to_serialize(fetcher.dataset_iter),
             _FETCHER_ENDED: fetcher.ended,
         }
-        dataset_state = try_to_serialize(fetcher.dataset)
+        dataset_state = None
+        if fetcher.dataset_iter is not fetcher.dataset:
+            dataset_state = try_to_serialize(fetcher.dataset)
     else:
         fetcher_state = None
         # Pick up any user-defined dataset state


### PR DESCRIPTION
Context:

For iterable datasets, state can be defined both at dataset level and also in the iterator. In the state_dict that is vended, this dataset_state is stored in dataset_state and iterator state is stored in fetcher_state::dataset_iter_state.

For a dataset which also acts as an iterator, initially the identical state was saved in both places which was wasteful. This was fixed in https://github.com/pytorch/data/pull/1258 where the state was saved only once in fetcher_state::dataset_iter_state.

But this was swapped in https://github.com/pytorch/data/pull/1273.

This is being swapped back to its original state to make sure the state variables can be initialized even in the iter method (which is the only place where it can access variables such as [WorkerInfo](https://github.com/pytorch/pytorch/blob/9d1b65b569a304032776375c24aa6babbf576c30/torch/utils/data/_utils/worker.py#L66)). 

Fixes #{issue number}

### Changes

-
-
