### PR TITLE
Add datapipes deprecation warning banner to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -160,3 +160,16 @@ def setup(app):
 intersphinx_mapping = {
     "graphviz": ("https://graphviz.readthedocs.io/en/stable/", None),
 }
+
+rst_prolog = """.. attention::
+   **June 2024 Status Update: Removing DataPipes and DataLoader V2**
+
+   We are re-focusing the torchdata repo to be an iterative enhancement of torch.utils.data.DataLoader. We do not plan on
+   continuing development or maintaining the [`DataPipes`] and [`DataLoaderV2`] solutions, and they will be removed from
+   the torchdata repo. We'll also be revisiting the `DataPipes` references in pytorch/pytorch. In release
+   `torchdata==0.8.0` (July 2024) they will be marked as deprecated, and in 0.9.0 (Oct 2024) they will be deleted. Existing
+   users are advised to pin to `torchdata==0.8.0` or an older version until they are able to migrate away. Subsequent
+   releases will not include DataPipes or DataLoaderV2.
+   Please reach out if you suggestions or comments (please use `this issue <https://github.com/pytorch/data/issues/1196>`_ for feedback)
+
+"""


### PR DESCRIPTION
### Changes
* add deprecation banner to sphinx docs. Adding this in rst_prolog pre-pends it to every page
-
-

Tested by building locally
<img width="1399" alt="image" src="https://github.com/user-attachments/assets/96746c59-32a1-417d-9587-6d2e663272c7">

