### PR TITLE
Fix nightly build. They've been failing due to missing secrets

### DIFF
--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -15,6 +15,4 @@ jobs:
       pre_dev_release: true
       pytorch_version: ""
     secrets:
-      PYTORCH_BINARY_AWS_ACCESS_KEY_ID: ${{ secrets.PYTORCH_BINARY_AWS_ACCESS_KEY_ID }}
-      PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY: ${{ secrets.PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY }}
       CONDA_NIGHTLY_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_NIGHTLY_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -31,8 +31,8 @@ jobs:
     if: github.repository == 'pytorch/data' && startsWith(github.ref_name, 'release/')
     uses: ./.github/workflows/_build_test_upload.yml
     with:
-      branch: "release/0.9"
+      branch: "release/0.8"
       pre_dev_release: true
-      pytorch_version: "2.5.0"
+      pytorch_version: "2.4.0"
     secrets:
       CONDA_TEST_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_TEST_PYTORCHBOT_TOKEN }}

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -31,8 +31,8 @@ jobs:
     if: github.repository == 'pytorch/data' && startsWith(github.ref_name, 'release/')
     uses: ./.github/workflows/_build_test_upload.yml
     with:
-      branch: "release/0.8"
+      branch: "release/0.9"
       pre_dev_release: true
-      pytorch_version: "2.4.0"
+      pytorch_version: "2.5.0"
     secrets:
       CONDA_TEST_PYTORCHBOT_TOKEN: ${{ secrets.CONDA_TEST_PYTORCHBOT_TOKEN }}


### PR DESCRIPTION
Unsure if CI will succeed without this, I don't see it referenced in many other pytorch repos though, and none of our tests which build seem to include it either. 

From this workflow:
https://github.com/pytorch/data/actions/workflows/nightly_release.yml 

[Invalid workflow file: .github/workflows/nightly_release.yml#L18](https://github.com/pytorch/data/actions/runs/11031708385/workflow)
The workflow is not valid. .github/workflows/nightly_release.yml (Line: 18, Col: 41): Invalid secret, PYTORCH_BINARY_AWS_ACCESS_KEY_ID is not defined in the referenced workflow. .github/workflows/nightly_release.yml (Line: 19, Col: 45): Invalid secret, PYTORCH_BINARY_AWS_SECRET_ACCESS_KEY is not defined in the referenced workflow.

Update digging through blame, I can see that test_release and pull_release had these keys dropped as part of this PR, probably just missed the nightly_release update: https://github.com/pytorch/data/commit/de5791bec43b8f72460baa6cf89bac5cf8c63a7b 
-
-
