### PR TITLE
fix test install path

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -395,7 +395,7 @@ jobs:
           if [[ $PIP_CHANNEL == 'official' ]]; then
             pip3 install "$PYTORCH_VERSION" -f https://download.pytorch.org/whl/torch_stable.html
           else
-            pip3 install --pre "$PYTORCH_VERSION" -f "https://download.pytorch.org/whl/$PIP_CHANNEL"
+            pip3 install --pre "$PYTORCH_VERSION" --index-url "https://download.pytorch.org/whl/$PIP_CHANNEL/cpu"
           fi
 
           pip3 install -r requirements.txt


### PR DESCRIPTION
https://github.com/pytorch/data/actions/runs/11357418885/job/31590502866 
Test Release run is failing to get pytorch 2.5.0 due to pip command. Tested locally:

With current command:
```
pip install --pre torch==2.5.0 -f https://download.pytorch.org/whl/test
...
Looking in links: https://download.pytorch.org/whl/test
ERROR: Could not find a version that satisfies the requirement torch==2.5.0 (from versions: 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.4.0, 2.4.1)
ERROR: No matching distribution found for torch==2.5.0
```

With updated command:
```
pip install --pre torch==2.5.0 --index-url https://download.pytorch.org/whl/test/cpu
...
Looking in indexes: https://download.pytorch.org/whl/test/cpu
Collecting torch==2.5.0
  Using cached https://download.pytorch.org/whl/test/cpu/torch-2.5.0%2Bcpu-cp312-cp312-linux_x86_64.whl (174.6 MB)
...
```
-
-
