### PR TITLE
Fix windows wheel build

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -107,7 +107,7 @@ jobs:
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
           PYTORCH_VERSION: ${{ inputs.pytorch_version }}
-          BUILD_S3: ${{ matrix.python-version != 'pure' }}
+          BUILD_S3: 0
         run: |
           set -ex
           packaging/build_wheel.sh

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build_test_upload:
     if: |
-      github.repository == 'pytorch/data' && github.ref_name == 'main'
+      (github.repository == 'pytorch/data' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: "main"

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build_test_upload:
     if: |
-      github.repository == 'pytorch/data' && (github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+      github.repository == 'pytorch/data' && (github.ref_name == 'main' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: "main"

--- a/.github/workflows/nightly_release.yml
+++ b/.github/workflows/nightly_release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   build_test_upload:
     if: |
-      (github.repository == 'pytorch/data' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
+      github.repository == 'pytorch/data' && (github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/_build_test_upload.yml
     with:
       branch: "main"


### PR DESCRIPTION
Current windows wheel build is failing on Nightly because it's trying to build S3 binaries, but we don't have any native extensions anymore. This leaves most of the code intact but just disables the envvar.

Example failing nightly:
https://github.com/pytorch/data/actions/runs/11438773492 

<img width="1702" alt="image" src="https://github.com/user-attachments/assets/61cf34af-f46f-4c3e-af7a-34b14e3d32f1">


Example passing job build step (upload fails because of branch protection, but that's fine)

https://github.com/pytorch/data/actions/runs/11444540802/job/31839644282

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/b66d8650-a976-465c-a12a-173cf4d7dfda">

