### PR TITLE
Add state management to torchdata.nodes

### DIFF
--- a/.github/workflows/nodes_ci.yml
+++ b/.github/workflows/nodes_ci.yml
@@ -78,4 +78,4 @@ jobs:
         run: pip3 install -r test/requirements.txt
       - name: Run Node tests with pytest - dataloader
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/nodes/
+        run: pytest --durations=0 --no-header -v test/nodes/ --full-trace

--- a/.github/workflows/nodes_ci.yml
+++ b/.github/workflows/nodes_ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         os:
           - macos-latest
-          # - ubuntu-latest
-          # - windows-latest
+          - ubuntu-latest
+          - windows-latest
         python-version:
           - 3.9
           - "3.10"
           - "3.11"
-          # - "3.12"
+          - "3.12"
     steps:
       - name: Get PyTorch Channel
         shell: bash

--- a/.github/workflows/nodes_ci.yml
+++ b/.github/workflows/nodes_ci.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
-          - windows-latest
+          # - ubuntu-latest
+          # - windows-latest
         python-version:
           - 3.9
           - "3.10"
           - "3.11"
-          - "3.12"
+          # - "3.12"
     steps:
       - name: Get PyTorch Channel
         shell: bash

--- a/.github/workflows/nodes_ci.yml
+++ b/.github/workflows/nodes_ci.yml
@@ -78,4 +78,4 @@ jobs:
         run: pip3 install -r test/requirements.txt
       - name: Run Node tests with pytest - dataloader
         if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/nodes/ --full-trace
+        run: pytest --durations=0 --no-header -v test/nodes/

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -76,24 +76,24 @@ jobs:
           BUILD_S3: 0
       - name: Install test requirements
         run: pip3 install -r test/requirements.txt
-      - name: Run StatefulDataLoader tests with pytest - dataloader
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_dataloader.py
-      - name: Run StatefulDataSampler tests with pytest - datasampler
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_sampler.py
-      - name: Run StatefulDataLoader tests with pytest - state_dict 0
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard0
-      - name: Run StatefulDataLoader tests with pytest - state_dict 1
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard1
-      - name: Run StatefulDataLoader tests with pytest - state_dict 2
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard2
-      - name: Run StatefulDataLoader tests with pytest - state_dict 3
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard3
-      - name: Run StatefulDataLoader HuggingFace tests
-        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_hugging_face.py
+      # - name: Run StatefulDataLoader tests with pytest - dataloader
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_dataloader.py
+      # - name: Run StatefulDataSampler tests with pytest - datasampler
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_sampler.py
+      # - name: Run StatefulDataLoader tests with pytest - state_dict 0
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard0
+      # - name: Run StatefulDataLoader tests with pytest - state_dict 1
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard1
+      # - name: Run StatefulDataLoader tests with pytest - state_dict 2
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard2
+      # - name: Run StatefulDataLoader tests with pytest - state_dict 3
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard3
+      # - name: Run StatefulDataLoader HuggingFace tests
+      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_hugging_face.py

--- a/.github/workflows/stateful_dataloader_ci.yml
+++ b/.github/workflows/stateful_dataloader_ci.yml
@@ -76,24 +76,24 @@ jobs:
           BUILD_S3: 0
       - name: Install test requirements
         run: pip3 install -r test/requirements.txt
-      # - name: Run StatefulDataLoader tests with pytest - dataloader
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_dataloader.py
-      # - name: Run StatefulDataSampler tests with pytest - datasampler
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_sampler.py
-      # - name: Run StatefulDataLoader tests with pytest - state_dict 0
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard0
-      # - name: Run StatefulDataLoader tests with pytest - state_dict 1
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard1
-      # - name: Run StatefulDataLoader tests with pytest - state_dict 2
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard2
-      # - name: Run StatefulDataLoader tests with pytest - state_dict 3
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard3
-      # - name: Run StatefulDataLoader HuggingFace tests
-      #   if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
-      #   run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_hugging_face.py
+      - name: Run StatefulDataLoader tests with pytest - dataloader
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_dataloader.py
+      - name: Run StatefulDataSampler tests with pytest - datasampler
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_sampler.py
+      - name: Run StatefulDataLoader tests with pytest - state_dict 0
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard0
+      - name: Run StatefulDataLoader tests with pytest - state_dict 1
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard1
+      - name: Run StatefulDataLoader tests with pytest - state_dict 2
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard2
+      - name: Run StatefulDataLoader tests with pytest - state_dict 3
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_state_dict.py -k _shard3
+      - name: Run StatefulDataLoader HuggingFace tests
+        if: ${{ ! contains(github.event.pull_request.labels.*.name, 'ciflow/slow') }}
+        run: pytest --durations=0 --no-header -v test/stateful_dataloader/test_hugging_face.py

--- a/test/nodes/test_adapters.py
+++ b/test/nodes/test_adapters.py
@@ -4,11 +4,38 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import testslide
-from torch.utils.data import IterableDataset, RandomSampler
-from torchdata.nodes.adapters import IterableWrapper, MapStyleWrapper, ToIterableDataset
+from typing import Any, Dict, Iterator
 
-from .utils import DummyIterableDataset, DummyMapDataset, MockSource
+import testslide
+
+from parameterized import parameterized
+
+from torch.utils.data import RandomSampler
+from torchdata.nodes.adapters import IterableWrapper, MapStyleWrapper
+
+from torchdata.nodes.types import Stateful
+
+from .utils import DummyIterableDataset, DummyMapDataset, run_test_save_load_state
+
+
+class _StatefulRange(Stateful):
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self._num_yielded = 0
+        self._next_start = 0
+
+    def __iter__(self) -> Iterator[int]:
+        self._num_yielded = self._next_start  # Reset for next iter call
+        self._next_start = 0
+        for i in range(self._num_yielded, self.n):
+            self._num_yielded += 1
+            yield i
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {"_num_yielded": self._num_yielded}
+
+    def load_state_dict(self, state_dict: Dict[str, Any]):
+        self._next_start = state_dict["_num_yielded"]
 
 
 class TestIterableWrapper(testslide.TestCase):
@@ -44,11 +71,19 @@ class TestIterableWrapper(testslide.TestCase):
                 self.assertEqual(row["test_tensor"].item(), i)
                 self.assertEqual(row["test_str"], f"str_{i}")
 
+    @parameterized.expand([0, 5, 10])
+    def test_save_load_state_fast_forward(self, midpoint: int):
+        run_test_save_load_state(self, IterableWrapper(range(10)), midpoint)
+
+    @parameterized.expand([0, 5, 10])
+    def test_save_load_state_stateful(self, midpoint: int):
+        run_test_save_load_state(self, IterableWrapper(_StatefulRange(10)), midpoint)
+
 
 class TestMapStyle(testslide.TestCase):
     def test_default_sampler(self):
         n = 20
-        node = MapStyleWrapper(DummyMapDataset(n))
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n))
         for epoch in range(2):
             result = list(node)
             self.assertEqual(len(result), n)
@@ -89,17 +124,14 @@ class TestMapStyle(testslide.TestCase):
                 self.assertEqual(row["test_tensor"].item(), i)
                 self.assertEqual(row["test_str"], f"str_{i}")
 
-
-class TestToIterableDataset(testslide.TestCase):
-    def test_to_iterable_dataset(self):
+    @parameterized.expand([0, 7, 20])
+    def test_save_load_state_fast_forward(self, midpoint: int):
         n = 20
-        node = MockSource(n)
-        iterable_ds = ToIterableDataset(node)
-        self.assertIsInstance(iterable_ds, IterableDataset)
-        for epoch in range(2):
-            result = list(iterable_ds)
-            self.assertEqual(len(result), n)
-            for i, row in enumerate(result):
-                self.assertEqual(row["step"], i)
-                self.assertEqual(row["test_tensor"].item(), i)
-                self.assertEqual(row["test_str"], f"str_{i}")
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n))
+        run_test_save_load_state(self, node, midpoint)
+
+    @parameterized.expand([0, 7, 20])
+    def test_save_load_state_stateful(self, midpoint: int):
+        n = 20
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=_StatefulRange(n))
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_adapters.py
+++ b/test/nodes/test_adapters.py
@@ -6,9 +6,8 @@
 
 from typing import Any, Dict, Iterator
 
-import testslide
-
 from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase
 
 from torch.utils.data import RandomSampler
 from torchdata.nodes.adapters import IterableWrapper, MapStyleWrapper
@@ -38,7 +37,7 @@ class _StatefulRange(Stateful):
         self._next_start = state_dict["_num_yielded"]
 
 
-class TestIterableWrapper(testslide.TestCase):
+class TestIterableWrapper(TestCase):
     def test_iterable(self):
         n = 20
         node = IterableWrapper(range(n))
@@ -80,7 +79,7 @@ class TestIterableWrapper(testslide.TestCase):
         run_test_save_load_state(self, IterableWrapper(_StatefulRange(10)), midpoint)
 
 
-class TestMapStyle(testslide.TestCase):
+class TestMapStyle(TestCase):
     def test_default_sampler(self):
         n = 20
         node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n))

--- a/test/nodes/test_adapters.py
+++ b/test/nodes/test_adapters.py
@@ -70,11 +70,11 @@ class TestIterableWrapper(TestCase):
                 self.assertEqual(row["test_tensor"].item(), i)
                 self.assertEqual(row["test_str"], f"str_{i}")
 
-    @parameterized.expand([0, 5, 10])
+    @parameterized.expand([0, 5])
     def test_save_load_state_fast_forward(self, midpoint: int):
         run_test_save_load_state(self, IterableWrapper(range(10)), midpoint)
 
-    @parameterized.expand([0, 5, 10])
+    @parameterized.expand([0, 5])
     def test_save_load_state_stateful(self, midpoint: int):
         run_test_save_load_state(self, IterableWrapper(_StatefulRange(10)), midpoint)
 

--- a/test/nodes/test_adapters.py
+++ b/test/nodes/test_adapters.py
@@ -123,13 +123,13 @@ class TestMapStyle(TestCase):
                 self.assertEqual(row["test_tensor"].item(), i)
                 self.assertEqual(row["test_str"], f"str_{i}")
 
-    @parameterized.expand([0, 7, 20])
+    @parameterized.expand([0, 7])
     def test_save_load_state_fast_forward(self, midpoint: int):
         n = 20
         node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n))
         run_test_save_load_state(self, node, midpoint)
 
-    @parameterized.expand([0, 7, 20])
+    @parameterized.expand([0, 7])
     def test_save_load_state_stateful(self, midpoint: int):
         n = 20
         node = MapStyleWrapper(DummyMapDataset(n), sampler=_StatefulRange(n))

--- a/test/nodes/test_base_node.py
+++ b/test/nodes/test_base_node.py
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import testslide
+from torchdata.nodes.adapters import IterableWrapper
+from torchdata.nodes.base_node import BaseNodeIterator
+
+
+class TestBaseNode(testslide.TestCase):
+    def test_started_finished(self) -> None:
+        x = IterableWrapper(range(10))
+        for _ in range(3):  # test multi-epoch
+            it: BaseNodeIterator = iter(x)
+            self.assertIsInstance(it, BaseNodeIterator)
+            self.assertFalse(it.started())
+            self.assertFalse(it.finished())
+
+            for _ in it:
+                self.assertTrue(it.started())
+                self.assertFalse(it.finished())
+
+            self.assertTrue(it.started())
+            self.assertTrue(it.finished())

--- a/test/nodes/test_base_node.py
+++ b/test/nodes/test_base_node.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-import testslide
+from torch.testing._internal.common_utils import TestCase
 from torchdata.nodes.adapters import IterableWrapper
 from torchdata.nodes.base_node import BaseNodeIterator
 
 from .utils import run_test_save_load_state
 
 
-class TestBaseNode(testslide.TestCase):
+class TestBaseNode(TestCase):
     def test_started_finished(self) -> None:
         x = IterableWrapper(range(10))
         for _ in range(3):  # test multi-epoch

--- a/test/nodes/test_base_node.py
+++ b/test/nodes/test_base_node.py
@@ -13,7 +13,7 @@ class TestBaseNode(testslide.TestCase):
     def test_started_finished(self) -> None:
         x = IterableWrapper(range(10))
         for _ in range(3):  # test multi-epoch
-            it: BaseNodeIterator = iter(x)
+            it = iter(x)
             self.assertIsInstance(it, BaseNodeIterator)
             self.assertFalse(it.started())
             self.assertFalse(it.finished())

--- a/test/nodes/test_base_node.py
+++ b/test/nodes/test_base_node.py
@@ -8,6 +8,8 @@ import testslide
 from torchdata.nodes.adapters import IterableWrapper
 from torchdata.nodes.base_node import BaseNodeIterator
 
+from .utils import run_test_save_load_state
+
 
 class TestBaseNode(testslide.TestCase):
     def test_started_finished(self) -> None:
@@ -26,19 +28,4 @@ class TestBaseNode(testslide.TestCase):
             self.assertTrue(it.finished())
 
     def test_save_load_state(self):
-        x = IterableWrapper(range(10))
-        it = iter(x)
-        results = []
-        for _ in range(5):
-            results.append(next(it))
-        state_dict = x.state_dict()
-        for val in it:
-            results.append(val)
-
-        x.load_state_dict(state_dict)
-        results_after = list(x)
-
-        self.assertEqual(results_after, results[5:])
-
-        full_results = list(x)
-        self.assertEqual(full_results, results)
+        run_test_save_load_state(self, IterableWrapper(range(10)), 5)

--- a/test/nodes/test_base_node.py
+++ b/test/nodes/test_base_node.py
@@ -24,3 +24,21 @@ class TestBaseNode(testslide.TestCase):
 
             self.assertTrue(it.started())
             self.assertTrue(it.finished())
+
+    def test_save_load_state(self):
+        x = IterableWrapper(range(10))
+        it = iter(x)
+        results = []
+        for _ in range(5):
+            results.append(next(it))
+        state_dict = x.state_dict()
+        for val in it:
+            results.append(val)
+
+        x.load_state_dict(state_dict)
+        results_after = list(x)
+
+        self.assertEqual(results_after, results[5:])
+
+        full_results = list(x)
+        self.assertEqual(full_results, results)

--- a/test/nodes/test_batch.py
+++ b/test/nodes/test_batch.py
@@ -4,11 +4,14 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
+
 import testslide
 import torch
+from parameterized import parameterized
 from torchdata.nodes.batch import Batcher
 
-from .utils import MockSource
+from .utils import MockSource, run_test_save_load_state
 
 
 class TestBatcher(testslide.TestCase):
@@ -38,3 +41,10 @@ class TestBatcher(testslide.TestCase):
                 self.assertEqual(results[i][j]["step"], i * batch_size + j)
                 self.assertEqual(results[i][j]["test_tensor"], torch.tensor([i * batch_size + j]))
                 self.assertEqual(results[i][j]["test_str"], f"str_{i * batch_size + j}")
+
+    @parameterized.expand(itertools.product([0, 1, 3], [True, False]))
+    def test_save_load_state_fast_forward(self, midpoint: int, drop_last: bool):
+        batch_size = 6
+        src = MockSource(num_samples=20)
+        node = Batcher(src, batch_size=batch_size, drop_last=drop_last)
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_batch.py
+++ b/test/nodes/test_batch.py
@@ -42,7 +42,7 @@ class TestBatcher(TestCase):
                 self.assertEqual(results[i][j]["test_tensor"], torch.tensor([i * batch_size + j]))
                 self.assertEqual(results[i][j]["test_str"], f"str_{i * batch_size + j}")
 
-    @parameterized.expand(itertools.product([0, 1, 3], [True, False]))
+    @parameterized.expand(itertools.product([0, 2], [True, False]))
     def test_save_load_state_fast_forward(self, midpoint: int, drop_last: bool):
         batch_size = 6
         src = MockSource(num_samples=20)

--- a/test/nodes/test_batch.py
+++ b/test/nodes/test_batch.py
@@ -6,15 +6,15 @@
 
 import itertools
 
-import testslide
 import torch
 from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase
 from torchdata.nodes.batch import Batcher
 
 from .utils import MockSource, run_test_save_load_state
 
 
-class TestBatcher(testslide.TestCase):
+class TestBatcher(TestCase):
     def test_batcher(self) -> None:
         batch_size = 6
         src = MockSource(num_samples=20)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -108,54 +108,54 @@ class TestMap(testslide.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    @parameterized.expand(
-        itertools.product(
-            [0, 7, 14],
-            [True],  # TODO: define and fix in_order = False
-            [0, 1, 9],  # TODO: define and fix in_order = False
-        )
-    )
-    def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-        method = "thread"
-        batch_size = 6
-        n = 80
-        multiprocessing_context = None if IS_WINDOWS else "forkserver"
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
-        node = Prefetcher(node, prefetch_factor=2)
-        run_test_save_load_state(self, node, midpoint)
+    # @parameterized.expand(
+    #     itertools.product(
+    #         [0, 7, 14],
+    #         [True],  # TODO: define and fix in_order = False
+    #         [0, 1, 9],  # TODO: define and fix in_order = False
+    #     )
+    # )
+    # def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+    #     method = "thread"
+    #     batch_size = 6
+    #     n = 80
+    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
+    #     src = MockSource(num_samples=n)
+    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
+    #     node = ParallelMapper(
+    #         node,
+    #         RandomSleepUdf(),
+    #         num_workers=4,
+    #         in_order=in_order,
+    #         method=method,
+    #         multiprocessing_context=multiprocessing_context,
+    #         snapshot_frequency=snapshot_frequency,
+    #     )
+    #     node = Prefetcher(node, prefetch_factor=2)
+    #     run_test_save_load_state(self, node, midpoint)
 
-    @parameterized.expand(
-        itertools.product(
-            [0, 7, 14],
-            [True],  # TODO: define and fix in_order = False
-            [0, 1, 9],  # TODO: define and fix in_order = False
-        )
-    )
-    def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-        method = "process"
-        batch_size = 6
-        n = 80
-        multiprocessing_context = None if IS_WINDOWS else "forkserver"
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
-        node = Prefetcher(node, prefetch_factor=2)
-        run_test_save_load_state(self, node, midpoint)
+    # @parameterized.expand(
+    #     itertools.product(
+    #         [0, 7, 14],
+    #         [True],  # TODO: define and fix in_order = False
+    #         [0, 1, 9],  # TODO: define and fix in_order = False
+    #     )
+    # )
+    # def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+    #     method = "process"
+    #     batch_size = 6
+    #     n = 80
+    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
+    #     src = MockSource(num_samples=n)
+    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
+    #     node = ParallelMapper(
+    #         node,
+    #         RandomSleepUdf(),
+    #         num_workers=4,
+    #         in_order=in_order,
+    #         method=method,
+    #         multiprocessing_context=multiprocessing_context,
+    #         snapshot_frequency=snapshot_frequency,
+    #     )
+    #     node = Prefetcher(node, prefetch_factor=2)
+    #     run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -20,6 +20,7 @@ from torchdata.nodes.prefetch import Prefetcher
 from .utils import MockSource, RandomSleepUdf, run_test_save_load_state, udf_raises
 
 
+@unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
 class TestMap(testslide.TestCase):
     def _test_exception_handling_mapper(self, pin_memory, method):
         batch_size = 6

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -108,34 +108,6 @@ class TestMap(unittest.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    @parameterized.expand(
-        itertools.product(
-            [0, 7, 14],
-            [True],  # TODO: define and fix in_order = False
-            [0, 1, 9],  # TODO: define and fix in_order = False
-        )
-    )
-    def test_save_load_state_thread(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int
-    ):
-        method = "thread"
-        batch_size = 6
-        n = 80
-        multiprocessing_context = None if IS_WINDOWS else "forkserver"
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
-        node = Prefetcher(node, prefetch_factor=2)
-        run_test_save_load_state(self, node, midpoint)
-
     # @parameterized.expand(
     #     itertools.product(
     #         [0, 7, 14],
@@ -143,8 +115,10 @@ class TestMap(unittest.TestCase):
     #         [0, 1, 9],  # TODO: define and fix in_order = False
     #     )
     # )
-    # def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-    #     method = "process"
+    # def test_save_load_state_thread(
+    #     self, midpoint: int, in_order: bool, snapshot_frequency: int
+    # ):
+    #     method = "thread"
     #     batch_size = 6
     #     n = 80
     #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
@@ -161,3 +135,31 @@ class TestMap(unittest.TestCase):
     #     )
     #     node = Prefetcher(node, prefetch_factor=2)
     #     run_test_save_load_state(self, node, midpoint)
+
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_process(
+        self, midpoint: int, in_order: bool, snapshot_frequency: int
+    ):
+        method = "process"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -108,58 +108,54 @@ class TestMap(testslide.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    @parameterized.expand(
-        itertools.product(
-            [0, 7, 14],
-            [True],  # TODO: define and fix in_order = False
-            [0, 1, 9],  # TODO: define and fix in_order = False
-        )
-    )
-    def test_save_load_state_thread(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int
-    ):
-        method = "thread"
-        batch_size = 6
-        n = 80
-        multiprocessing_context = None if IS_WINDOWS else "forkserver"
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
-        node = Prefetcher(node, prefetch_factor=2)
-        run_test_save_load_state(self, node, midpoint)
+    # @parameterized.expand(
+    #     itertools.product(
+    #         [0, 7, 14],
+    #         [True],  # TODO: define and fix in_order = False
+    #         [0, 1, 9],  # TODO: define and fix in_order = False
+    #     )
+    # )
+    # def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+    #     method = "thread"
+    #     batch_size = 6
+    #     n = 80
+    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
+    #     src = MockSource(num_samples=n)
+    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
+    #     node = ParallelMapper(
+    #         node,
+    #         RandomSleepUdf(),
+    #         num_workers=4,
+    #         in_order=in_order,
+    #         method=method,
+    #         multiprocessing_context=multiprocessing_context,
+    #         snapshot_frequency=snapshot_frequency,
+    #     )
+    #     node = Prefetcher(node, prefetch_factor=2)
+    #     run_test_save_load_state(self, node, midpoint)
 
-    @parameterized.expand(
-        itertools.product(
-            [0, 7, 14],
-            [True],  # TODO: define and fix in_order = False
-            [0, 1, 9],  # TODO: define and fix in_order = False
-        )
-    )
-    def test_save_load_state_process(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int
-    ):
-        method = "process"
-        batch_size = 6
-        n = 80
-        multiprocessing_context = None if IS_WINDOWS else "forkserver"
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
-        node = Prefetcher(node, prefetch_factor=2)
-        run_test_save_load_state(self, node, midpoint)
+    # @parameterized.expand(
+    #     itertools.product(
+    #         [0, 7, 14],
+    #         [True],  # TODO: define and fix in_order = False
+    #         [0, 1, 9],  # TODO: define and fix in_order = False
+    #     )
+    # )
+    # def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+    #     method = "process"
+    #     batch_size = 6
+    #     n = 80
+    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
+    #     src = MockSource(num_samples=n)
+    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
+    #     node = ParallelMapper(
+    #         node,
+    #         RandomSleepUdf(),
+    #         num_workers=4,
+    #         in_order=in_order,
+    #         method=method,
+    #         multiprocessing_context=multiprocessing_context,
+    #         snapshot_frequency=snapshot_frequency,
+    #     )
+    #     node = Prefetcher(node, prefetch_factor=2)
+    #     run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -124,17 +124,16 @@ class TestMap(testslide.TestCase):
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
         src = MockSource(num_samples=n)
         node = Batcher(src, batch_size=batch_size, drop_last=False)
-        # node = ParallelMapper(
-        #     node,
-        #     RandomSleepUdf(),
-        #     num_workers=4,
-        #     in_order=in_order,
-        #     method=method,
-        #     multiprocessing_context=multiprocessing_context,
-        #     snapshot_frequency=snapshot_frequency,
-        # )
-        node = Mapper(node, RandomSleepUdf())
-        # node = Prefetcher(node, prefetch_factor=2)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)
 
     @parameterized.expand(
@@ -153,15 +152,14 @@ class TestMap(testslide.TestCase):
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
         src = MockSource(num_samples=n)
         node = Batcher(src, batch_size=batch_size, drop_last=False)
-        # node = ParallelMapper(
-        #     node,
-        #     RandomSleepUdf(),
-        #     num_workers=4,
-        #     in_order=in_order,
-        #     method=method,
-        #     multiprocessing_context=multiprocessing_context,
-        #     snapshot_frequency=snapshot_frequency,
-        # )
-        node = Mapper(node, RandomSleepUdf())
-        # node = Prefetcher(node, prefetch_factor=2)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -20,7 +20,6 @@ from torchdata.nodes.prefetch import Prefetcher
 from .utils import MockSource, RandomSleepUdf, run_test_save_load_state, udf_raises
 
 
-@unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
 class TestMap(testslide.TestCase):
     def _test_exception_handling_mapper(self, pin_memory, method):
         batch_size = 6

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -110,7 +110,7 @@ class TestMap(TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [0, 7, 14],
+            [0, 7, 13],
             [True],  # TODO: define and fix in_order = False
             [0, 1, 9],  # TODO: define and fix in_order = False
         )
@@ -136,7 +136,7 @@ class TestMap(TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [0, 7, 14],
+            [0, 7, 13],
             [True],  # TODO: define and fix in_order = False
             [0, 1, 9],  # TODO: define and fix in_order = False
         )

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -20,7 +20,7 @@ from torchdata.nodes.prefetch import Prefetcher
 from .utils import MockSource, RandomSleepUdf, run_test_save_load_state, udf_raises
 
 
-class TestMap(testslide.TestCase):
+class TestMap(unittest.TestCase):
     def _test_exception_handling_mapper(self, pin_memory, method):
         batch_size = 6
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
@@ -108,31 +108,33 @@ class TestMap(testslide.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    # @parameterized.expand(
-    #     itertools.product(
-    #         [0, 7, 14],
-    #         [True],  # TODO: define and fix in_order = False
-    #         [0, 1, 9],  # TODO: define and fix in_order = False
-    #     )
-    # )
-    # def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-    #     method = "thread"
-    #     batch_size = 6
-    #     n = 80
-    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
-    #     src = MockSource(num_samples=n)
-    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
-    #     node = ParallelMapper(
-    #         node,
-    #         RandomSleepUdf(),
-    #         num_workers=4,
-    #         in_order=in_order,
-    #         method=method,
-    #         multiprocessing_context=multiprocessing_context,
-    #         snapshot_frequency=snapshot_frequency,
-    #     )
-    #     node = Prefetcher(node, prefetch_factor=2)
-    #     run_test_save_load_state(self, node, midpoint)
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_thread(
+        self, midpoint: int, in_order: bool, snapshot_frequency: int
+    ):
+        method = "thread"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)
 
     # @parameterized.expand(
     #     itertools.product(

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -110,12 +110,13 @@ class TestMap(testslide.TestCase):
 
     @parameterized.expand(
         itertools.product(
-            [0, 7, 80],
-            ["thread", "process"],
-            [True, False],
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
         )
     )
-    def test_save_load_state_stateful(self, midpoint: int, method: Literal["thread", "process"], in_order: bool):
+    def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+        method = "thread"
         batch_size = 6
         n = 80
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
@@ -128,6 +129,33 @@ class TestMap(testslide.TestCase):
             in_order=in_order,
             method=method,
             multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)
+
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
+        method = "process"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
         )
         node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -134,7 +134,7 @@ class TestMap(testslide.TestCase):
         #     snapshot_frequency=snapshot_frequency,
         # )
         node = Mapper(node, RandomSleepUdf())
-        node = Prefetcher(node, prefetch_factor=2)
+        # node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)
 
     @parameterized.expand(
@@ -163,5 +163,5 @@ class TestMap(testslide.TestCase):
         #     snapshot_frequency=snapshot_frequency,
         # )
         node = Mapper(node, RandomSleepUdf())
-        node = Prefetcher(node, prefetch_factor=2)
+        # node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -20,7 +20,7 @@ from torchdata.nodes.prefetch import Prefetcher
 from .utils import MockSource, RandomSleepUdf, run_test_save_load_state, udf_raises
 
 
-class TestMap(unittest.TestCase):
+class TestMap(testslide.TestCase):
     def _test_exception_handling_mapper(self, pin_memory, method):
         batch_size = 6
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
@@ -124,15 +124,16 @@ class TestMap(unittest.TestCase):
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
         src = MockSource(num_samples=n)
         node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
+        # node = ParallelMapper(
+        #     node,
+        #     RandomSleepUdf(),
+        #     num_workers=4,
+        #     in_order=in_order,
+        #     method=method,
+        #     multiprocessing_context=multiprocessing_context,
+        #     snapshot_frequency=snapshot_frequency,
+        # )
+        node = Mapper(node, RandomSleepUdf())
         node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)
 
@@ -152,14 +153,15 @@ class TestMap(unittest.TestCase):
         multiprocessing_context = None if IS_WINDOWS else "forkserver"
         src = MockSource(num_samples=n)
         node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = ParallelMapper(
-            node,
-            RandomSleepUdf(),
-            num_workers=4,
-            in_order=in_order,
-            method=method,
-            multiprocessing_context=multiprocessing_context,
-            snapshot_frequency=snapshot_frequency,
-        )
+        # node = ParallelMapper(
+        #     node,
+        #     RandomSleepUdf(),
+        #     num_workers=4,
+        #     in_order=in_order,
+        #     method=method,
+        #     multiprocessing_context=multiprocessing_context,
+        #     snapshot_frequency=snapshot_frequency,
+        # )
+        node = Mapper(node, RandomSleepUdf())
         node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -5,14 +5,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-import unittest
-from typing import List, Literal
 
-import testslide
+import unittest
+from typing import List
 
 from parameterized import parameterized
-from torch.testing._internal.common_utils import IS_WINDOWS, TEST_CUDA
+from torch.testing._internal.common_utils import IS_WINDOWS, TEST_CUDA, TestCase
 from torchdata.nodes.batch import Batcher
+
 from torchdata.nodes.map import Mapper, ParallelMapper
 from torchdata.nodes.pin_memory import PinMemory
 from torchdata.nodes.prefetch import Prefetcher
@@ -20,7 +20,7 @@ from torchdata.nodes.prefetch import Prefetcher
 from .utils import MockSource, RandomSleepUdf, run_test_save_load_state, udf_raises
 
 
-class TestMap(testslide.TestCase):
+class TestMap(TestCase):
     def _test_exception_handling_mapper(self, pin_memory, method):
         batch_size = 6
         multiprocessing_context = None if IS_WINDOWS else "forkserver"

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -115,9 +115,7 @@ class TestMap(testslide.TestCase):
             [0, 1, 9],  # TODO: define and fix in_order = False
         )
     )
-    def test_save_load_state_thread(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int
-    ):
+    def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
         method = "thread"
         batch_size = 6
         n = 80
@@ -143,9 +141,7 @@ class TestMap(testslide.TestCase):
             [0, 1, 9],  # TODO: define and fix in_order = False
         )
     )
-    def test_save_load_state_process(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int
-    ):
+    def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
         method = "process"
         batch_size = 6
         n = 80

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -108,54 +108,58 @@ class TestMap(testslide.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    # @parameterized.expand(
-    #     itertools.product(
-    #         [0, 7, 14],
-    #         [True],  # TODO: define and fix in_order = False
-    #         [0, 1, 9],  # TODO: define and fix in_order = False
-    #     )
-    # )
-    # def test_save_load_state_thread(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-    #     method = "thread"
-    #     batch_size = 6
-    #     n = 80
-    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
-    #     src = MockSource(num_samples=n)
-    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
-    #     node = ParallelMapper(
-    #         node,
-    #         RandomSleepUdf(),
-    #         num_workers=4,
-    #         in_order=in_order,
-    #         method=method,
-    #         multiprocessing_context=multiprocessing_context,
-    #         snapshot_frequency=snapshot_frequency,
-    #     )
-    #     node = Prefetcher(node, prefetch_factor=2)
-    #     run_test_save_load_state(self, node, midpoint)
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_thread(
+        self, midpoint: int, in_order: bool, snapshot_frequency: int
+    ):
+        method = "thread"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)
 
-    # @parameterized.expand(
-    #     itertools.product(
-    #         [0, 7, 14],
-    #         [True],  # TODO: define and fix in_order = False
-    #         [0, 1, 9],  # TODO: define and fix in_order = False
-    #     )
-    # )
-    # def test_save_load_state_process(self, midpoint: int, in_order: bool, snapshot_frequency: int):
-    #     method = "process"
-    #     batch_size = 6
-    #     n = 80
-    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
-    #     src = MockSource(num_samples=n)
-    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
-    #     node = ParallelMapper(
-    #         node,
-    #         RandomSleepUdf(),
-    #         num_workers=4,
-    #         in_order=in_order,
-    #         method=method,
-    #         multiprocessing_context=multiprocessing_context,
-    #         snapshot_frequency=snapshot_frequency,
-    #     )
-    #     node = Prefetcher(node, prefetch_factor=2)
-    #     run_test_save_load_state(self, node, midpoint)
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_process(
+        self, midpoint: int, in_order: bool, snapshot_frequency: int
+    ):
+        method = "process"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -108,33 +108,33 @@ class TestMap(unittest.TestCase):
     def test_out_of_order_process(self):
         self._test_map(False, "process")
 
-    # @parameterized.expand(
-    #     itertools.product(
-    #         [0, 7, 14],
-    #         [True],  # TODO: define and fix in_order = False
-    #         [0, 1, 9],  # TODO: define and fix in_order = False
-    #     )
-    # )
-    # def test_save_load_state_thread(
-    #     self, midpoint: int, in_order: bool, snapshot_frequency: int
-    # ):
-    #     method = "thread"
-    #     batch_size = 6
-    #     n = 80
-    #     multiprocessing_context = None if IS_WINDOWS else "forkserver"
-    #     src = MockSource(num_samples=n)
-    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
-    #     node = ParallelMapper(
-    #         node,
-    #         RandomSleepUdf(),
-    #         num_workers=4,
-    #         in_order=in_order,
-    #         method=method,
-    #         multiprocessing_context=multiprocessing_context,
-    #         snapshot_frequency=snapshot_frequency,
-    #     )
-    #     node = Prefetcher(node, prefetch_factor=2)
-    #     run_test_save_load_state(self, node, midpoint)
+    @parameterized.expand(
+        itertools.product(
+            [0, 7, 14],
+            [True],  # TODO: define and fix in_order = False
+            [0, 1, 9],  # TODO: define and fix in_order = False
+        )
+    )
+    def test_save_load_state_thread(
+        self, midpoint: int, in_order: bool, snapshot_frequency: int
+    ):
+        method = "thread"
+        batch_size = 6
+        n = 80
+        multiprocessing_context = None if IS_WINDOWS else "forkserver"
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = ParallelMapper(
+            node,
+            RandomSleepUdf(),
+            num_workers=4,
+            in_order=in_order,
+            method=method,
+            multiprocessing_context=multiprocessing_context,
+            snapshot_frequency=snapshot_frequency,
+        )
+        node = Prefetcher(node, prefetch_factor=2)
+        run_test_save_load_state(self, node, midpoint)
 
     @parameterized.expand(
         itertools.product(

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -70,14 +70,14 @@ class TestPinMemory(testslide.TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    # @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
-    # def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
-    #     batch_size = 6
-    #     n = 200
-    #     node = MockSource(num_samples=n)
-    #     node = Batcher(node, batch_size=batch_size, drop_last=False)
-    #     node = Mapper(node, Collate())
-    #     node = PinMemory(node, snapshot_frequency=snapshot_frequency)
-    #     node = Prefetcher(node, prefetch_factor=8)
+    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
+        batch_size = 6
+        n = 200
+        node = MockSource(num_samples=n)
+        node = Batcher(node, batch_size=batch_size, drop_last=False)
+        node = Mapper(node, Collate())
+        node = PinMemory(node, snapshot_frequency=snapshot_frequency)
+        node = Prefetcher(node, prefetch_factor=8)
 
-    #     run_test_save_load_state(self, node, midpoint)
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -7,12 +7,11 @@
 import itertools
 import unittest
 
-import testslide
 import torch
 
 from parameterized import parameterized
 
-from torch.testing._internal.common_utils import TEST_CUDA
+from torch.testing._internal.common_utils import TEST_CUDA, TestCase
 
 from torchdata.nodes.batch import Batcher
 from torchdata.nodes.map import Mapper
@@ -23,7 +22,7 @@ from .utils import Collate, IterInitError, MockSource, run_test_save_load_state
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-class TestPinMemory(testslide.TestCase):
+class TestPinMemory(TestCase):
     def test_pin_memory(self) -> None:
         batch_size = 6
         src = MockSource(num_samples=20)

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -65,7 +65,7 @@ class TestPinMemory(TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    @parameterized.expand(itertools.product([0, 7, 33], [0, 1, 9]))
     def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
         batch_size = 6
         n = 200

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -39,8 +39,12 @@ class TestPinMemory(testslide.TestCase):
             for i in range(3):
                 for j in range(batch_size):
                     self.assertEqual(results[i]["step"][j], i * batch_size + j)
-                    self.assertEqual(results[i]["test_tensor"][j], torch.tensor([i * batch_size + j]))
-                    self.assertEqual(results[i]["test_str"][j], f"str_{i * batch_size + j}")
+                    self.assertEqual(
+                        results[i]["test_tensor"][j], torch.tensor([i * batch_size + j])
+                    )
+                    self.assertEqual(
+                        results[i]["test_str"][j], f"str_{i * batch_size + j}"
+                    )
 
     def test_exception_handling(self):
         class PinMemoryFails:
@@ -66,14 +70,14 @@ class TestPinMemory(testslide.TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
-    def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
-        batch_size = 6
-        n = 200
-        node = MockSource(num_samples=n)
-        node = Batcher(node, batch_size=batch_size, drop_last=False)
-        node = Mapper(node, Collate())
-        node = PinMemory(node, snapshot_frequency=snapshot_frequency)
-        node = Prefetcher(node, prefetch_factor=8)
+    # @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    # def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
+    #     batch_size = 6
+    #     n = 200
+    #     node = MockSource(num_samples=n)
+    #     node = Batcher(node, batch_size=batch_size, drop_last=False)
+    #     node = Mapper(node, Collate())
+    #     node = PinMemory(node, snapshot_frequency=snapshot_frequency)
+    #     node = Prefetcher(node, prefetch_factor=8)
 
-        run_test_save_load_state(self, node, midpoint)
+    #     run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -39,12 +39,8 @@ class TestPinMemory(testslide.TestCase):
             for i in range(3):
                 for j in range(batch_size):
                     self.assertEqual(results[i]["step"][j], i * batch_size + j)
-                    self.assertEqual(
-                        results[i]["test_tensor"][j], torch.tensor([i * batch_size + j])
-                    )
-                    self.assertEqual(
-                        results[i]["test_str"][j], f"str_{i * batch_size + j}"
-                    )
+                    self.assertEqual(results[i]["test_tensor"][j], torch.tensor([i * batch_size + j]))
+                    self.assertEqual(results[i]["test_str"][j], f"str_{i * batch_size + j}")
 
     def test_exception_handling(self):
         class PinMemoryFails:

--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -4,10 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import itertools
 import unittest
 
 import testslide
 import torch
+
+from parameterized import parameterized
 
 from torch.testing._internal.common_utils import TEST_CUDA
 
@@ -16,7 +19,7 @@ from torchdata.nodes.map import Mapper
 from torchdata.nodes.pin_memory import PinMemory
 from torchdata.nodes.prefetch import Prefetcher
 
-from .utils import Collate, IterInitError, MockSource
+from .utils import Collate, IterInitError, MockSource, run_test_save_load_state
 
 
 @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
@@ -62,3 +65,15 @@ class TestPinMemory(testslide.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
+
+    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
+        batch_size = 6
+        n = 200
+        node = MockSource(num_samples=n)
+        node = Batcher(node, batch_size=batch_size, drop_last=False)
+        node = Mapper(node, Collate())
+        node = PinMemory(node, snapshot_frequency=snapshot_frequency)
+        node = Prefetcher(node, prefetch_factor=8)
+
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_prefetch.py
+++ b/test/nodes/test_prefetch.py
@@ -6,16 +6,16 @@
 
 import itertools
 
-import testslide
 import torch
 from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase
 from torchdata.nodes.batch import Batcher
 from torchdata.nodes.prefetch import Prefetcher
 
 from .utils import IterInitError, MockSource, run_test_save_load_state
 
 
-class TestPrefetcher(testslide.TestCase):
+class TestPrefetcher(TestCase):
     def test_prefetcher(self) -> None:
         batch_size = 6
         src = MockSource(num_samples=20)

--- a/test/nodes/test_prefetch.py
+++ b/test/nodes/test_prefetch.py
@@ -39,7 +39,7 @@ class TestPrefetcher(TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    @parameterized.expand(itertools.product([0, 7, 32], [0, 1, 9]))
     def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
         batch_size = 6
         n = 200

--- a/test/nodes/test_prefetch.py
+++ b/test/nodes/test_prefetch.py
@@ -29,8 +29,12 @@ class TestPrefetcher(testslide.TestCase):
             for i in range(3):
                 for j in range(batch_size):
                     self.assertEqual(results[i][j]["step"], i * batch_size + j)
-                    self.assertEqual(results[i][j]["test_tensor"], torch.tensor([i * batch_size + j]))
-                    self.assertEqual(results[i][j]["test_str"], f"str_{i * batch_size + j}")
+                    self.assertEqual(
+                        results[i][j]["test_tensor"], torch.tensor([i * batch_size + j])
+                    )
+                    self.assertEqual(
+                        results[i][j]["test_str"], f"str_{i * batch_size + j}"
+                    )
 
     def test_iter_init_error(self):
         node = IterInitError()
@@ -39,11 +43,11 @@ class TestPrefetcher(testslide.TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
-    def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
-        batch_size = 6
-        n = 200
-        src = MockSource(num_samples=n)
-        node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = Prefetcher(node, prefetch_factor=8, snapshot_frequency=snapshot_frequency)
-        run_test_save_load_state(self, node, midpoint)
+    # @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    # def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
+    #     batch_size = 6
+    #     n = 200
+    #     src = MockSource(num_samples=n)
+    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
+    #     node = Prefetcher(node, prefetch_factor=8, snapshot_frequency=snapshot_frequency)
+    #     run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_prefetch.py
+++ b/test/nodes/test_prefetch.py
@@ -29,12 +29,8 @@ class TestPrefetcher(testslide.TestCase):
             for i in range(3):
                 for j in range(batch_size):
                     self.assertEqual(results[i][j]["step"], i * batch_size + j)
-                    self.assertEqual(
-                        results[i][j]["test_tensor"], torch.tensor([i * batch_size + j])
-                    )
-                    self.assertEqual(
-                        results[i][j]["test_str"], f"str_{i * batch_size + j}"
-                    )
+                    self.assertEqual(results[i][j]["test_tensor"], torch.tensor([i * batch_size + j]))
+                    self.assertEqual(results[i][j]["test_str"], f"str_{i * batch_size + j}")
 
     def test_iter_init_error(self):
         node = IterInitError()
@@ -49,7 +45,5 @@ class TestPrefetcher(testslide.TestCase):
         n = 200
         src = MockSource(num_samples=n)
         node = Batcher(src, batch_size=batch_size, drop_last=False)
-        node = Prefetcher(
-            node, prefetch_factor=8, snapshot_frequency=snapshot_frequency
-        )
+        node = Prefetcher(node, prefetch_factor=8, snapshot_frequency=snapshot_frequency)
         run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_prefetch.py
+++ b/test/nodes/test_prefetch.py
@@ -43,11 +43,13 @@ class TestPrefetcher(testslide.TestCase):
         with self.assertRaisesRegex(ValueError, "Iter Init Error"):
             list(root)
 
-    # @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
-    # def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
-    #     batch_size = 6
-    #     n = 200
-    #     src = MockSource(num_samples=n)
-    #     node = Batcher(src, batch_size=batch_size, drop_last=False)
-    #     node = Prefetcher(node, prefetch_factor=8, snapshot_frequency=snapshot_frequency)
-    #     run_test_save_load_state(self, node, midpoint)
+    @parameterized.expand(itertools.product([0, 7, 34], [0, 1, 9]))
+    def test_save_load_state_stateful(self, midpoint: int, snapshot_frequency: int):
+        batch_size = 6
+        n = 200
+        src = MockSource(num_samples=n)
+        node = Batcher(src, batch_size=batch_size, drop_last=False)
+        node = Prefetcher(
+            node, prefetch_factor=8, snapshot_frequency=snapshot_frequency
+        )
+        run_test_save_load_state(self, node, midpoint)

--- a/test/nodes/test_snapshot_store.py
+++ b/test/nodes/test_snapshot_store.py
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch.testing._internal.common_utils import TestCase
+from torchdata.nodes.adapters import IterableWrapper
+from torchdata.nodes.base_node import BaseNodeIterator
+from torchdata.nodes.snapshot_store import DequeSnapshotStore
+
+from .utils import run_test_save_load_state
+
+
+class TestDequeSnapshotStore(TestCase):
+    def test_snapshot_store(self) -> None:
+        store = DequeSnapshotStore()
+        store.append({"a": 1}, 0)
+        store.append({"a": 2}, 10)
+
+        self.assertEqual(len(store._deque), 2)
+
+        val = store.pop_version(0)
+        self.assertEqual(val, {"a": 1})
+        self.assertEqual(len(store._deque), 1)
+        val = store.pop_version(1)
+        self.assertIsNone(val)
+        self.assertEqual(len(store._deque), 1)
+        val = store.pop_version(7)
+        self.assertIsNone(val)
+        self.assertEqual(len(store._deque), 1)
+        val = store.pop_version(10)
+        self.assertEqual(val, {"a": 2})
+        self.assertEqual(len(store._deque), 0)
+
+        val = store.pop_version(11)
+        self.assertIsNone(val)
+        self.assertEqual(len(store._deque), 0)
+
+        with self.assertRaisesRegex(ValueError, "is not strictly greater than"):
+            store.append({"a": 3}, 3)
+
+        self.assertEqual(len(store._deque), 0)
+
+        with self.assertRaisesRegex(ValueError, "is not strictly greater than"):
+            store.append({"a": 4}, 10)
+        self.assertEqual(len(store._deque), 0)
+
+        store.append({"a": 4}, 11)
+        store.append({"a": 5}, 19)
+        val = store.pop_version(19)
+        self.assertEqual(val, {"a": 5})
+        self.assertEqual(len(store._deque), 0)

--- a/test/nodes/utils.py
+++ b/test/nodes/utils.py
@@ -89,14 +89,27 @@ def run_test_save_load_state(test, x: BaseNode, midpoint: int):
     for val in it:
         results.append(val)
 
+    state_dict_0_end = x.state_dict()
+
+    # store epoch 1's results
+    results_1 = list(x)
+
     x.load_state_dict(state_dict)
     results_after = list(x)
-
     test.assertEqual(results_after, results[midpoint:])
 
-    full_results = list(x)
-    test.assertEqual(full_results, results)
+    # Test for second epoch after resume
+    results_after_1 = list(x)
+    test.assertEqual(results_after_1, results_1)
 
+    # Test initialize from beginning after resume
     x.load_state_dict(initial_state_dict)
     full_results = list(x)
     test.assertEqual(full_results, results)
+    full_results_1 = list(x)
+    test.assertEqual(full_results_1, results_1)
+
+    # Test restoring from end of epoch 0
+    x.load_state_dict(state_dict_0_end)
+    results_after_dict_0 = list(x)
+    test.assertEqual(results_after_dict_0, results_1)

--- a/test/nodes/utils.py
+++ b/test/nodes/utils.py
@@ -6,7 +6,7 @@
 
 import random
 import time
-from typing import Iterator
+from typing import Any, Dict, Iterator, Optional
 
 import torch
 from torchdata.nodes.adapters import IterableWrapper
@@ -51,8 +51,11 @@ class IterInitError(BaseNode[int]):
     def __init__(self, msg: str = "Iter Init Error") -> None:
         self.msg = msg
 
-    def iterator(self) -> Iterator[int]:
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[int]:
         raise ValueError(self.msg)
+
+    def get_state(self) -> Dict[str, Any]:
+        return {}
 
 
 class DummyIterableDataset(torch.utils.data.IterableDataset):

--- a/test/nodes/utils.py
+++ b/test/nodes/utils.py
@@ -79,6 +79,8 @@ class DummyMapDataset(torch.utils.data.Dataset):
 
 
 def run_test_save_load_state(test, x: BaseNode, midpoint: int):
+    # Test before iter call
+    initial_state_dict = x.state_dict()
     it = iter(x)
     results = []
     for _ in range(midpoint):
@@ -92,5 +94,9 @@ def run_test_save_load_state(test, x: BaseNode, midpoint: int):
 
     test.assertEqual(results_after, results[midpoint:])
 
+    full_results = list(x)
+    test.assertEqual(full_results, results)
+
+    x.load_state_dict(initial_state_dict)
     full_results = list(x)
     test.assertEqual(full_results, results)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -8,3 +8,4 @@ graphviz
 adlfs
 awscli>=1.27.66
 psutil
+parameterized

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,4 @@
 pytest
-testslide
 expecttest
 fsspec
 numpy<2

--- a/torchdata/nodes/__init__.py
+++ b/torchdata/nodes/__init__.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .adapters import IterableWrapper, MapStyleWrapper, ToIterableDataset
+from .adapters import IterableWrapper, MapStyleWrapper
 from .base_node import BaseNode, T
 from .batch import Batcher
 from .map import Mapper, ParallelMapper
@@ -17,14 +17,13 @@ __all__ = [
     "BaseNode",
     "Batcher",
     "IterableWrapper",
-    "Mapper",
     "MapStyleWrapper",
-    "Prefetcher",
+    "Mapper",
     "ParallelMapper",
     "PinMemory",
+    "Prefetcher",
     "Stateful",
     "T",
-    "ToIterableDataset",
 ]
 
 assert sorted(__all__) == __all__

--- a/torchdata/nodes/__init__.py
+++ b/torchdata/nodes/__init__.py
@@ -4,20 +4,27 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .adapters import IterableWrapper, MapStyleWrapper
+from .adapters import IterableWrapper, MapStyleWrapper, ToIterableDataset
 from .base_node import BaseNode, T
 from .batch import Batcher
 from .map import Mapper, ParallelMapper
 from .pin_memory import PinMemory
 from .prefetch import Prefetcher
+from .types import Stateful
 
 
 __all__ = [
     "BaseNode",
     "Batcher",
+    "IterableWrapper",
     "Mapper",
+    "MapStyleWrapper",
     "Prefetcher",
     "ParallelMapper",
     "PinMemory",
+    "Stateful",
     "T",
+    "ToIterableDataset",
 ]
+
+assert sorted(__all__) == __all__

--- a/torchdata/nodes/_apply_udf.py
+++ b/torchdata/nodes/_apply_udf.py
@@ -41,9 +41,9 @@ def _apply_udf(
             continue
 
         if isinstance(item, ExceptionWrapper):
-            out_q.put((item, idx))
+            out_q.put((item, idx), block=False)
         elif isinstance(item, StopIteration):
-            out_q.put((item, idx))
+            out_q.put((item, idx), block=False)
         else:
             try:
                 y = udf(item)

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -50,7 +50,7 @@ def _populate_queue(
         _idx = idx.get()
         if snapshot:
             snapshot_store.append(snapshot=snapshot, version=_idx)
-        q.put((item, _idx), block=block)
+        q.put((item, _idx), block=block, timeout=1.0 if block else None)
 
     try:
         assert (
@@ -78,6 +78,8 @@ def _populate_queue(
         except Exception:
             item = ExceptionWrapper(where="in _populate_queue")
         try:
-            _put(item, block=False, snapshot=snapshot)  # Semaphore should prevent this from throwing
+            _put(
+                item, block=False, snapshot=snapshot
+            )  # Semaphore should prevent this from throwing
         except queue.Full:
             raise RuntimeError("Queue should not be full")

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -6,7 +6,6 @@
 
 import queue
 import threading
-from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 import torch.multiprocessing as mp
@@ -14,22 +13,9 @@ import torch.multiprocessing as mp
 from torchdata.nodes.base_node import BaseNode
 
 from torchdata.nodes.exception_wrapper import ExceptionWrapper, StartupExceptionWrapper
-from torchdata.nodes.snapshot_store import SnapshotStore
+from torchdata.nodes.snapshot_store import MonotonicIndex, SnapshotStore
 
 from .constants import QUEUE_TIMEOUT
-
-
-@dataclass
-class _MonotonicIndex:
-    initial: int = 0
-
-    def __post_init__(self):
-        self._idx = self.initial
-
-    def get(self) -> int:
-        idx = self._idx
-        self._idx += 1
-        return idx
 
 
 def _populate_queue(
@@ -58,7 +44,7 @@ def _populate_queue(
     """
 
     # Include a monotonic index starting from 0 to each item in the queue
-    idx = _MonotonicIndex()
+    idx = MonotonicIndex()
 
     def _put(item, block: bool = True, snapshot: Optional[Dict[str, Any]] = None):
         _idx = idx.get()

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -7,9 +7,14 @@
 import queue
 import threading
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Any, Dict, Optional, Union
+
+import torch.multiprocessing as mp
+
+from torchdata.nodes.base_node import BaseNode
 
 from torchdata.nodes.exception_wrapper import ExceptionWrapper, StartupExceptionWrapper
+from torchdata.nodes.snapshot_store import SnapshotStore
 
 from .constants import QUEUE_TIMEOUT
 
@@ -28,18 +33,19 @@ class _MonotonicIndex:
 
 
 def _populate_queue(
-    source: Iterable,
-    q: queue.Queue,
+    source: BaseNode,
+    q: Union[queue.Queue, mp.Queue],
+    snapshot_store: SnapshotStore,
+    snapshot_frequency: int,
     semaphore: threading.BoundedSemaphore,
     stop_event: threading.Event,
-    add_index: bool = False,
 ):
     """_populate_queue calls `iter(source)` to get an iterator `it`, waits for semaphore.acquire,
     and puts its outputs onto q. It never releases the sempahore. It continues to put items on the
     q as long as it can acquire the sempahore, stop_event is not set, and StopIteration has not
     been thrown by the `it`.
 
-    If add_index = True, this function will always put tuples of (x, idx) on the q where idx
+    This function will always put tuples of (x, idx) on the q where idx
     starts from 0 and is monotonically increasing. x may be the output of next(it), StopIteration,
     or an ExceptionWrapper.
 
@@ -54,30 +60,38 @@ def _populate_queue(
     # Include a monotonic index starting from 0 to each item in the queue
     idx = _MonotonicIndex()
 
-    def _put(item, block: bool = True):
-        if add_index:
-            q.put((item, idx.get()), block=block)
-        else:
-            q.put(item, block=block)
+    def _put(item, block: bool = True, snapshot: Optional[Dict[str, Any]] = None):
+        _idx = idx.get()
+        if snapshot:
+            snapshot_store.append(snapshot=snapshot, version=_idx)
+        q.put((item, _idx), block=block)
 
     try:
+        assert (
+            isinstance(snapshot_frequency, int) and snapshot_frequency >= 0
+        ), f"snapshot_frequency {snapshot_frequency} must be non-negative integer!"
         src_iter = iter(source)
     except Exception:
         e = StartupExceptionWrapper(where="in _populate_queue startup for device")
         _put(e)
         return
 
+    yielded = 0
     while not stop_event.is_set():
+        snapshot = None
         if not semaphore.acquire(blocking=True, timeout=QUEUE_TIMEOUT):
             continue
         try:
             item = next(src_iter)  # FIXME: This may hang!
+            yielded += 1
+            if snapshot_frequency > 0 and yielded % snapshot_frequency == 0:
+                snapshot = source.state_dict()
         except StopIteration as e:
             _put(e)
             break
         except Exception:
             item = ExceptionWrapper(where="in _populate_queue")
         try:
-            _put(item, block=False)  # Semaphore should prevent this from throwing
+            _put(item, block=False, snapshot=snapshot)  # Semaphore should prevent this from throwing
         except queue.Full:
             raise RuntimeError("Queue should not be full")

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -59,7 +59,7 @@ def _populate_queue(
         src_iter = iter(source)
     except Exception:
         e = StartupExceptionWrapper(where="in _populate_queue startup for device")
-        _put(e)
+        _put(e, block=False)
         return
 
     yielded = 0
@@ -73,7 +73,7 @@ def _populate_queue(
             if snapshot_frequency > 0 and yielded % snapshot_frequency == 0:
                 snapshot = source.state_dict()
         except StopIteration as e:
-            _put(e)
+            _put(e, block=False)
             break
         except Exception:
             item = ExceptionWrapper(where="in _populate_queue")

--- a/torchdata/nodes/_populate_queue.py
+++ b/torchdata/nodes/_populate_queue.py
@@ -69,7 +69,7 @@ def _populate_queue(
     try:
         assert (
             isinstance(snapshot_frequency, int) and snapshot_frequency >= 0
-        ), f"snapshot_frequency {snapshot_frequency} must be non-negative integer!"
+        ), f"snapshot_frequency must be non-negative integer! Got {snapshot_frequency}"
         src_iter = iter(source)
     except Exception:
         e = StartupExceptionWrapper(where="in _populate_queue startup for device")

--- a/torchdata/nodes/adapters.py
+++ b/torchdata/nodes/adapters.py
@@ -7,8 +7,6 @@
 
 from typing import Any, Dict, Iterable, Iterator, Mapping, Optional, TypeVar
 
-from torch.utils.data import IterableDataset
-
 from torchdata.nodes.base_node import BaseNode, T
 
 from .map import Mapper
@@ -66,23 +64,9 @@ def MapStyleWrapper(map_dataset: Mapping[K, T], sampler: Iterable[K]) -> BaseNod
     """Thin Wrapper that converts any MapDataset in to a torchdata.node
     If you want parallelism, copy this and replace Mapper with ParallelMapper.
 
-    :param map_dataset: MapDataset to wrap.
-    :param sampler: IterableDataset to wrap.
+    :param map_dataset: Mapping to wrap.
+    :param sampler: Optional[Iterable].
     """
     sampler_node = IterableWrapper(sampler)
     mapper_node = Mapper(sampler_node, map_dataset.__getitem__)
     return mapper_node
-
-
-class ToIterableDataset(IterableDataset[T]):
-    def __init__(self, base_node: BaseNode[T]):
-        self.base_node = base_node
-
-    def __iter__(self) -> Iterator[T]:
-        return iter(self.base_node)
-
-    def state_dict(self) -> Dict[str, Any]:
-        return self.base_node.state_dict()
-
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
-        self.base_node.load_state_dict(state_dict)

--- a/torchdata/nodes/adapters.py
+++ b/torchdata/nodes/adapters.py
@@ -25,9 +25,22 @@ class IterableWrapper(BaseNode[T]):
 
     def __init__(self, iterable: Iterable[T]):
         self.iterable = iterable
+        self._num_yielded = 0
 
     def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
-        return iter(self.iterable)
+        it = iter(self.iterable)
+        if initial_state is not None:
+            self._num_yielded = initial_state["_num_yielded"]
+            # Naively fast-forwarding
+            for _ in range(self._num_yielded):
+                next(it)
+
+        for item in it:
+            self._num_yielded += 1
+            yield item
+
+    def get_state(self) -> Dict[str, Any]:
+        return {"_num_yielded": self._num_yielded}
 
 
 class MapStyleWrapper(BaseNode[T], Generic[K, T]):

--- a/torchdata/nodes/adapters.py
+++ b/torchdata/nodes/adapters.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Generic, Iterable, Iterator, Mapping, Optional, Sized, TypeVar
+from typing import Any, Dict, Generic, Iterable, Iterator, Mapping, Optional, Sized, TypeVar
 
 from torch.utils.data import IterableDataset, Sampler, SequentialSampler
 
@@ -26,7 +26,7 @@ class IterableWrapper(BaseNode[T]):
     def __init__(self, iterable: Iterable[T]):
         self.iterable = iterable
 
-    def iterator(self) -> Iterator[T]:
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
         return iter(self.iterable)
 
 

--- a/torchdata/nodes/base_node.py
+++ b/torchdata/nodes/base_node.py
@@ -45,7 +45,7 @@ class BaseNode(Iterable[T]):
         """
         raise NotImplementedError()
 
-    def __iter__(self) -> Iterator[T]:
+    def __iter__(self) -> BaseNodeIterator[T]:
         if self._it is not None and self._it.started():
             # Only create a new iter if the last requested one did not start/finish
             self._it = None

--- a/torchdata/nodes/base_node.py
+++ b/torchdata/nodes/base_node.py
@@ -4,33 +4,105 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterable, Iterator, TypeVar
+import logging
+from typing import Any, Dict, Iterable, Iterator, Optional, TypeVar
+
+logger = logging.getLogger(__name__)
 
 
 T = TypeVar("T", covariant=True)
 
 
+class BaseNodeIterator(Iterator[T]):
+    def state_dict(self) -> Dict[str, Any]:
+        raise NotImplementedError()
+
+    def started(self) -> bool:
+        raise NotImplementedError()
+
+    def finished(self) -> bool:
+        raise NotImplementedError()
+
+
 class BaseNode(Iterable[T]):
-    def iterator(self) -> Iterator[T]:
+    _it: Optional[BaseNodeIterator[T]] = None  # holds pointer to last iter() requested
+    _initial_state: Optional[Dict[str, Any]] = None
+
+    def iterator(self, initial_state: Optional[dict]) -> Iterator[T]:
         """Override this method to implement the iterator.
         Iterators are expected to raise StopIteration to signal
         end of iteration, so they can be used in for loops.
         Generators just need to return, as usual.
+
+        initial_state will be passed if `load_state_dict(initial_state)` was called
+        on this node before the __iter__ is requested, otherwise None will be passed
         """
         raise NotImplementedError()
 
-    def __iter__(self) -> "_EagerIter[T]":
-        return _EagerIter(self)
+    def get_state(self) -> Dict[str, Any]:
+        """Return a dictionary that can be passed to iterator(...) which
+        can be used to initialize iterator at a certain state.
+        """
+        raise NotImplementedError()
+
+    def __iter__(self) -> Iterator[T]:
+        if self._it is not None and self._it.started():
+            # Only create a new iter if the last requested one did not start/finish
+            self._it = None
+
+        if self._it is None:
+            self._it = _EagerIter(self, self._initial_state)
+            self._initial_state = None
+        return self._it
+
+    def state_dict(self) -> Dict[str, Any]:
+        if self._it is None:
+            logger.info("state_dict() on BaseNode before __iter__ requested, instantiating iterator to make the call")
+            iter(self)
+        assert self._it is not None
+        return self._it.state_dict()
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        self._initial_state = state_dict
 
 
-class _EagerIter(Iterator[T]):
+class _EagerIter(BaseNodeIterator[T]):
     """
     Basic iterator which will runs next-calls eagerly
     """
 
-    def __init__(self, parent: BaseNode[T]):
-        self.parent = parent
-        self.it = self.parent.iterator()
+    STARTED_KEY = "started"
+    FINISHED_KEY = "finished"
+    BASE_NODE_KEY = "base_node"
 
-    def __next__(self):
-        return next(self.it)
+    def __init__(self, base_node: BaseNode[T], initial_state: Optional[Dict[str, Any]]):
+        self.base_node = base_node
+        if initial_state is not None:
+            self._it = self.base_node.iterator(initial_state[self.BASE_NODE_KEY])
+            self._started = initial_state[self.STARTED_KEY]
+            self._finished = initial_state[self.FINISHED_KEY]
+        else:
+            self._it = self.base_node.iterator(None)
+            self._started = False
+            self._finished = False
+
+    def __next__(self) -> T:
+        self._started = True
+        try:
+            return next(self._it)
+        except StopIteration:
+            self._finished = True
+            raise
+
+    def state_dict(self) -> Dict[str, Any]:
+        return {
+            self.BASE_NODE_KEY: self.base_node.get_state(),
+            self.STARTED_KEY: self._started,
+            self.FINISHED_KEY: self._finished,
+        }
+
+    def started(self) -> bool:
+        return self._started
+
+    def finished(self) -> bool:
+        return self._finished

--- a/torchdata/nodes/batch.py
+++ b/torchdata/nodes/batch.py
@@ -10,7 +10,7 @@ from torchdata.nodes.base_node import BaseNode, T
 
 
 class Batcher(BaseNode[List[T]]):
-    SOURCE_KEY = "_source"
+    SOURCE_KEY = "source"
 
     def __init__(self, source: BaseNode[T], batch_size: int, drop_last: bool = True):
         self.source = source

--- a/torchdata/nodes/batch.py
+++ b/torchdata/nodes/batch.py
@@ -4,18 +4,23 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterator, List
+from typing import Any, Dict, Iterator, List, Optional
 
-from torchdata.nodes import BaseNode, T
+from torchdata.nodes.base_node import BaseNode, T
 
 
 class Batcher(BaseNode[List[T]]):
+    SOURCE_KEY = "_source"
+
     def __init__(self, source: BaseNode[T], batch_size: int, drop_last: bool = True):
         self.source = source
         self.batch_size = batch_size
         self.drop_last = drop_last
 
-    def iterator(self) -> Iterator[List[T]]:
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[List[T]]:
+        if initial_state is not None:
+            self.source.load_state_dict(initial_state[self.SOURCE_KEY])
+
         batch = []
         for item in self.source:
             batch.append(item)
@@ -25,3 +30,6 @@ class Batcher(BaseNode[List[T]]):
 
         if len(batch) and not self.drop_last:
             yield batch
+
+    def get_state(self) -> Dict[str, Any]:
+        return {self.SOURCE_KEY: self.source.state_dict()}

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -175,7 +175,7 @@ class _ParallelMapperIter(Iterator[T]):
             self._workers.append(
                 threading.Thread(target=_apply_udf, args=args, daemon=True)
                 if self.method == "thread"
-                else mp_context.Process(target=_apply_udf, args=args)
+                else mp_context.Process(target=_apply_udf, args=args, daemon=True)
             )
         self._sort_q: queue.Queue = queue.Queue()
         self._sort_thread = threading.Thread(

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -173,9 +173,9 @@ class _ParallelMapperIter(Iterator[T]):
                 self._stop if self.method == "thread" else self._mp_stop,
             )
             self._workers.append(
-                threading.Thread(target=_apply_udf, args=args)
+                threading.Thread(target=_apply_udf, args=args, daemon=True)
                 if self.method == "thread"
-                else mp_context.Process(target=_apply_udf, args=args)
+                else mp_context.Process(target=_apply_udf, args=args, daemon=True)
             )
         self._sort_q: queue.Queue = queue.Queue()
         self._sort_thread = threading.Thread(

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -6,18 +6,7 @@
 
 import queue
 import threading
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterator,
-    List,
-    Literal,
-    Optional,
-    Protocol,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Iterator, List, Literal, Optional, Protocol, TypeVar, Union
 
 import torch.multiprocessing as mp
 from torchdata.nodes.base_node import BaseNode, T
@@ -33,11 +22,14 @@ from .constants import QUEUE_TIMEOUT
 
 # We define this protocol for type checking
 class _MultiprocessContext(Protocol):
-    def Process(self, *args, **kwargs): ...
+    def Process(self, *args, **kwargs):
+        ...
 
-    def Event(self, *args, **kwargs): ...
+    def Event(self, *args, **kwargs):
+        ...
 
-    def Queue(self, *args, **kwargs): ...
+    def Queue(self, *args, **kwargs):
+        ...
 
 
 X = TypeVar("X")
@@ -64,9 +56,7 @@ class Mapper(BaseNode[T]):
         return {self.SOURCE_KEY: self.source.state_dict()}
 
 
-def _sort_worker(
-    in_q: Union[queue.Queue, mp.Queue], out_q: queue.Queue, stop_event: threading.Event
-):
+def _sort_worker(in_q: Union[queue.Queue, mp.Queue], out_q: queue.Queue, stop_event: threading.Event):
     buffer: Dict[int, Any] = {}
     cur_idx = 0
     while not stop_event.is_set():
@@ -81,9 +71,7 @@ def _sort_worker(
             if idx in buffer:
                 # This is the easiest way to create an exception wrapper
                 try:
-                    raise ValueError(
-                        f"Duplicate index {idx=}, {buffer.keys()=}, {item=}"
-                    )
+                    raise ValueError(f"Duplicate index {idx=}, {buffer.keys()=}, {item=}")
                 except Exception:
                     item = ExceptionWrapper(where="in _sort_worker")
                 out_q.put((item, idx), block=False)
@@ -125,15 +113,9 @@ class _ParallelMapperIter(Iterator[T]):
         self.mp_context = mp_context
         self.snapshot_frequency = snapshot_frequency
 
-        self._in_q: Union[queue.Queue, mp.Queue] = (
-            queue.Queue() if method == "thread" else mp_context.Queue()
-        )
-        self._intermed_q: Union[queue.Queue, mp.Queue] = (
-            queue.Queue() if method == "thread" else mp_context.Queue()
-        )
-        self._max_tasks = (
-            2 * self.num_workers if max_concurrent is None else max_concurrent
-        )
+        self._in_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
+        self._intermed_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
+        self._max_tasks = 2 * self.num_workers if max_concurrent is None else max_concurrent
         self._sem = threading.BoundedSemaphore(value=self._max_tasks)
 
         self._done = False
@@ -299,9 +281,7 @@ class ParallelMapper(BaseNode[T]):
         self._it: Optional[_ParallelMapperIter[T]] = None
         self._iter_for_state_dict: bool = False
 
-    def _get_iterator(
-        self, initial_state: Optional[Dict[str, Any]]
-    ) -> _ParallelMapperIter[T]:
+    def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _ParallelMapperIter[T]:
         return _ParallelMapperIter(
             source=self.source,
             map_fn=self.map_fn,

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -229,12 +229,12 @@ class _ParallelMapperIter(Iterator[T]):
         self._stop.set()
         self._mp_stop.set()
         if self._read_thread.is_alive():
-            self._read_thread.join(timeout=QUEUE_TIMEOUT)
+            self._read_thread.join(timeout=QUEUE_TIMEOUT * 5)
         if self._sort_thread.is_alive():
-            self._sort_thread.join(timeout=QUEUE_TIMEOUT)
+            self._sort_thread.join(timeout=QUEUE_TIMEOUT * 5)
         for t in self._workers:
             if t.is_alive():
-                t.join(timeout=QUEUE_TIMEOUT)
+                t.join(timeout=QUEUE_TIMEOUT * 5)
 
 
 class ParallelMapper(BaseNode[T]):
@@ -445,4 +445,4 @@ class _SingleThreadedMapper(Iterator[T]):
     def _shutdown(self):
         self._stop_event.set()
         if self._thread.is_alive():
-            self._thread.join(timeout=QUEUE_TIMEOUT)
+            self._thread.join(timeout=QUEUE_TIMEOUT * 5)

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -173,9 +173,9 @@ class _ParallelMapperIter(Iterator[T]):
                 self._stop if self.method == "thread" else self._mp_stop,
             )
             self._workers.append(
-                threading.Thread(target=_apply_udf, args=args, daemon=True)
+                threading.Thread(target=_apply_udf, args=args)
                 if self.method == "thread"
-                else mp_context.Process(target=_apply_udf, args=args, daemon=True)
+                else mp_context.Process(target=_apply_udf, args=args)
             )
         self._sort_q: queue.Queue = queue.Queue()
         self._sort_thread = threading.Thread(

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -173,7 +173,7 @@ class _ParallelMapperIter(Iterator[T]):
                 self._stop if self.method == "thread" else self._mp_stop,
             )
             self._workers.append(
-                threading.Thread(target=_apply_udf, args=args)
+                threading.Thread(target=_apply_udf, args=args, daemon=True)
                 if self.method == "thread"
                 else mp_context.Process(target=_apply_udf, args=args)
             )

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -14,7 +14,7 @@ import torch
 import torch.multiprocessing
 
 from torch.utils.data._utils.pin_memory import pin_memory
-from torchdata.nodes import BaseNode, T
+from torchdata.nodes.base_node import BaseNode, T
 
 from torchdata.nodes.exception_wrapper import ExceptionWrapper, StartupExceptionWrapper
 from torchdata.nodes.map import _SingleThreadedMapper

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -63,9 +63,7 @@ def _pin_memory_loop(
         ), f"snapshot_frequency must be non-negative integer! Got {snapshot_frequency}"
         src_iter = iter(source)
     except Exception:
-        e = StartupExceptionWrapper(
-            where=f"in _pin_memory_loop startup for device {device_id}"
-        )
+        e = StartupExceptionWrapper(where=f"in _pin_memory_loop startup for device {device_id}")
         _put(e, block=False)
         return
 
@@ -117,9 +115,7 @@ class PinMemory(BaseNode[T]):
         self._it: Optional[_SingleThreadedMapper[T]] = None
         self._iter_for_state_dict: bool = False
 
-    def _get_iterator(
-        self, initial_state: Optional[Dict[str, Any]]
-    ) -> _SingleThreadedMapper[T]:
+    def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _SingleThreadedMapper[T]:
         return _SingleThreadedMapper(
             source=self.source,
             prefetch_factor=1,

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -18,7 +18,7 @@ from torchdata.nodes import BaseNode, T
 
 from torchdata.nodes.exception_wrapper import ExceptionWrapper, StartupExceptionWrapper
 from torchdata.nodes.map import _SingleThreadedMapper
-from torchdata.nodes.snapshot_store import SnapshotStore
+from torchdata.nodes.snapshot_store import MonotonicIndex, SnapshotStore
 
 
 def _pin_memory_loop(
@@ -36,6 +36,15 @@ def _pin_memory_loop(
 
     # This setting is thread local, and prevents the copy in pin_memory from
     # consuming all CPU cores.
+
+    idx = MonotonicIndex()
+
+    def _put(item, block: bool = True, snapshot: Optional[Dict[str, Any]] = None):
+        _idx = idx.get()
+        if snapshot:
+            snapshot_store.append(snapshot=snapshot, version=_idx)
+        q.put((item, _idx), block=block)
+
     try:
         torch.set_num_threads(1)
 
@@ -49,26 +58,34 @@ def _pin_memory_loop(
             custom_device_mod = getattr(torch, torch._C._get_privateuse1_backend_name())
             custom_device_mod.set_device(device_id)
 
+        assert (
+            isinstance(snapshot_frequency, int) and snapshot_frequency >= 0
+        ), f"snapshot_frequency must be non-negative integer! Got {snapshot_frequency}"
         src_iter = iter(source)
     except Exception:
         e = StartupExceptionWrapper(where=f"in _pin_memory_loop startup for device {device_id}")
-        q.put(e)
+        _put(e)
         return
 
+    yielded = 0
     while not stop_event.is_set():
         if not semaphore.acquire(blocking=True, timeout=0.1):
             continue
         try:
             item = next(src_iter)
             item = pin_memory(item, device)
-            q.put(item, block=False)
+            yielded += 1
+            snapshot = None
+            if snapshot_frequency > 0 and yielded % snapshot_frequency == 0:
+                snapshot = source.state_dict()
+            _put(item, block=False, snapshot=snapshot)
         except StopIteration as e:
             item = e
-            q.put(item, block=False)
+            _put(item, block=False)
             break
         except Exception:
             item = ExceptionWrapper(where=f"in _pin_memory_loop for device {device_id}")
-            q.put(item, block=False)
+            _put(item, block=False)
             break
 
 
@@ -77,8 +94,10 @@ class PinMemory(BaseNode[T]):
         self,
         source: BaseNode[T],
         pin_memory_device: str = "",
+        snapshot_frequency: int = 1,
     ):
         self.source = source
+        self.snapshot_frequency = snapshot_frequency
         self._pin_memory = torch.cuda.is_available()
         if len(pin_memory_device) == 0:
             self._pin_memory_device = None
@@ -93,10 +112,10 @@ class PinMemory(BaseNode[T]):
         else:
             self._current_device = torch.cuda.current_device()
 
-        self._it: Optional[_SingleThreadedMapper] = None
+        self._it: Optional[_SingleThreadedMapper[T]] = None
 
-    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
-        self._it = _SingleThreadedMapper(
+    def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _SingleThreadedMapper[T]:
+        return _SingleThreadedMapper(
             source=self.source,
             prefetch_factor=1,
             worker=functools.partial(
@@ -104,10 +123,20 @@ class PinMemory(BaseNode[T]):
                 device_id=self._current_device,
                 device=self._pin_memory_device,
             ),
+            snapshot_frequency=self.snapshot_frequency,
+            initial_state=initial_state,
         )
+
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
+        if self._iter_for_state_dict:
+            self._iter_for_state_dict = False
+        else:
+            self._it = self._get_iterator(initial_state)
+        assert self._it is not None
         return self._it
 
     def get_state(self) -> Dict[str, Any]:
-        assert self._it is not None, "get_state() should not be called before iterator()!"
+        if self._it is None:
+            self._it = self._get_iterator(None)
+            self._iter_for_state_dict = True
         return self._it.get_state()
-        return {self.SOURCE_KEY: self.source.state_dict()}

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -63,8 +63,10 @@ def _pin_memory_loop(
         ), f"snapshot_frequency must be non-negative integer! Got {snapshot_frequency}"
         src_iter = iter(source)
     except Exception:
-        e = StartupExceptionWrapper(where=f"in _pin_memory_loop startup for device {device_id}")
-        _put(e)
+        e = StartupExceptionWrapper(
+            where=f"in _pin_memory_loop startup for device {device_id}"
+        )
+        _put(e, block=False)
         return
 
     yielded = 0
@@ -115,7 +117,9 @@ class PinMemory(BaseNode[T]):
         self._it: Optional[_SingleThreadedMapper[T]] = None
         self._iter_for_state_dict: bool = False
 
-    def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _SingleThreadedMapper[T]:
+    def _get_iterator(
+        self, initial_state: Optional[Dict[str, Any]]
+    ) -> _SingleThreadedMapper[T]:
         return _SingleThreadedMapper(
             source=self.source,
             prefetch_factor=1,

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -113,6 +113,7 @@ class PinMemory(BaseNode[T]):
             self._current_device = torch.cuda.current_device()
 
         self._it: Optional[_SingleThreadedMapper[T]] = None
+        self._iter_for_state_dict: bool = False
 
     def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _SingleThreadedMapper[T]:
         return _SingleThreadedMapper(

--- a/torchdata/nodes/prefetch.py
+++ b/torchdata/nodes/prefetch.py
@@ -14,22 +14,32 @@ from ._populate_queue import _populate_queue
 
 
 class Prefetcher(BaseNode[T]):
-    def __init__(self, source: BaseNode[T], prefetch_factor: int, snapshot_frequency: int = 0):
+    def __init__(self, source: BaseNode[T], prefetch_factor: int, snapshot_frequency: int = 1):
         self.source = source
         self.prefetch_factor = prefetch_factor
         self.snapshot_frequency = snapshot_frequency
-        self._it: Optional[_SingleThreadedMapper] = None
+        self._it: Optional[_SingleThreadedMapper[T]] = None
+        self._iter_for_state_dict: bool = False
 
-    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
-        self._it = _SingleThreadedMapper(
+    def _get_iterator(self, initial_state: Optional[Dict[str, Any]]) -> _SingleThreadedMapper[T]:
+        return _SingleThreadedMapper(
             source=self.source,
             prefetch_factor=self.prefetch_factor,
             worker=_populate_queue,
             snapshot_frequency=self.snapshot_frequency,
             initial_state=initial_state,
         )
+
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
+        if self._iter_for_state_dict:
+            self._iter_for_state_dict = False
+        else:
+            self._it = self._get_iterator(initial_state)
+        assert self._it is not None
         return self._it
 
     def get_state(self) -> Dict[str, Any]:
-        assert self._it is not None
+        if self._it is None:
+            self._it = self._get_iterator(None)
+            self._iter_for_state_dict = True
         return self._it.get_state()

--- a/torchdata/nodes/prefetch.py
+++ b/torchdata/nodes/prefetch.py
@@ -4,7 +4,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Iterator
+from typing import Any, Dict, Iterator, Optional
 
 from torchdata.nodes import BaseNode, T
 
@@ -14,13 +14,22 @@ from ._populate_queue import _populate_queue
 
 
 class Prefetcher(BaseNode[T]):
-    def __init__(self, source: BaseNode[T], prefetch_factor: int):
+    def __init__(self, source: BaseNode[T], prefetch_factor: int, snapshot_frequency: int = 0):
         self.source = source
         self.prefetch_factor = prefetch_factor
+        self.snapshot_frequency = snapshot_frequency
+        self._it: Optional[_SingleThreadedMapper] = None
 
-    def iterator(self) -> Iterator[T]:
-        return _SingleThreadedMapper(
+    def iterator(self, initial_state: Optional[Dict[str, Any]]) -> Iterator[T]:
+        self._it = _SingleThreadedMapper(
             source=self.source,
             prefetch_factor=self.prefetch_factor,
             worker=_populate_queue,
+            snapshot_frequency=self.snapshot_frequency,
+            initial_state=initial_state,
         )
+        return self._it
+
+    def get_state(self) -> Dict[str, Any]:
+        assert self._it is not None
+        return self._it.get_state()

--- a/torchdata/nodes/snapshot_store.py
+++ b/torchdata/nodes/snapshot_store.py
@@ -31,7 +31,7 @@ class DequeSnapshotStore(SnapshotStore):
     """A snapshot store that uses a deque to store snapshots"""
 
     def __init__(self, max_size: Optional[int] = None) -> None:
-        self._deque = deque(maxlen=max_size)
+        self._deque: deque = deque(maxlen=max_size)
         self._lock = threading.Lock()
         self._max_version: int = -1
 

--- a/torchdata/nodes/snapshot_store.py
+++ b/torchdata/nodes/snapshot_store.py
@@ -1,0 +1,40 @@
+import threading
+from collections import deque
+from typing import Any, Optional, Protocol
+
+
+class SnapshotStore(Protocol):
+    """Protocol for passing snapshot state around between threads and processes"""
+
+    def append(self, snapshot: Any, version: int):
+        ...
+
+    def pop_version(self, version: int) -> Optional[Any]:
+        ...
+
+
+class DequeSnapshotStore(SnapshotStore):
+    """A snapshot store that uses a deque to store snapshots"""
+
+    def __init__(self, max_size: Optional[int] = None) -> None:
+        self._deque = deque(maxlen=max_size)
+        self._lock = threading.Lock()
+        self._max_version: int = -1
+
+    def append(self, snapshot: Any, version: int) -> None:
+        with self._lock:
+            if version <= self._max_version:
+                raise ValueError(f"{version=} is not strictly greater than {self._max_version=}")
+            self._max_version = version
+            self._deque.append((version, snapshot))
+
+    def pop_version(self, version: int) -> Optional[Any]:
+        with self._lock:
+            ver, val = None, None
+            while self._deque and version >= self._deque[0][0]:
+                ver, val = self._deque.popleft()
+
+            if ver == version:
+                return val
+            else:
+                return None

--- a/torchdata/nodes/snapshot_store.py
+++ b/torchdata/nodes/snapshot_store.py
@@ -1,4 +1,3 @@
-import threading
 from collections import deque
 from dataclasses import dataclass
 from typing import Any, Optional, Protocol
@@ -32,23 +31,20 @@ class DequeSnapshotStore(SnapshotStore):
 
     def __init__(self, max_size: Optional[int] = None) -> None:
         self._deque: deque = deque(maxlen=max_size)
-        self._lock = threading.Lock()
         self._max_version: int = -1
 
     def append(self, snapshot: Any, version: int) -> None:
-        with self._lock:
-            if version <= self._max_version:
-                raise ValueError(f"{version=} is not strictly greater than {self._max_version=}")
-            self._max_version = version
-            self._deque.append((version, snapshot))
+        if version <= self._max_version:
+            raise ValueError(f"{version=} is not strictly greater than {self._max_version=}")
+        self._max_version = version
+        self._deque.append((version, snapshot))
 
     def pop_version(self, version: int) -> Optional[Any]:
-        with self._lock:
-            ver, val = None, None
-            while self._deque and version >= self._deque[0][0]:
-                ver, val = self._deque.popleft()
+        ver, val = None, None
+        while self._deque and version >= self._deque[0][0]:
+            ver, val = self._deque.popleft()
 
-            if ver == version:
-                return val
-            else:
-                return None
+        if ver == version:
+            return val
+        else:
+            return None

--- a/torchdata/nodes/snapshot_store.py
+++ b/torchdata/nodes/snapshot_store.py
@@ -1,6 +1,20 @@
 import threading
 from collections import deque
+from dataclasses import dataclass
 from typing import Any, Optional, Protocol
+
+
+@dataclass
+class MonotonicIndex:
+    initial: int = 0
+
+    def __post_init__(self):
+        self._idx = self.initial
+
+    def get(self) -> int:
+        idx = self._idx
+        self._idx += 1
+        return idx
 
 
 class SnapshotStore(Protocol):

--- a/torchdata/nodes/types.py
+++ b/torchdata/nodes/types.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+from typing import Any, Dict, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class Stateful(Protocol):
+    def state_dict(self) -> Dict[str, Any]:
+        ...
+
+    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+        ...


### PR DESCRIPTION
Adds state_dict/load_state_dict interface to torchdata.nodes.base_node. Update all existing node definitions to save/load state correctly.

# Interface for users (external facing)
```
BaseNode.state_dict() -> Dict[str, Any]: ...
""" Can be called at any time, on the BaseNode, and return a dictionary representing state_dict that can be
passed to load_state_dict. Calling this will return state_dict of the last result of BaseNode.__iter__()"""

BaseNode.load_state_dict(state_dict: Dict[str, Any]): ...
""" When called with the output of BaseNode.state_dict(), affects the next iterator returned by BaseNode.__iter__()
""" 
```

# Interface for developers (implementing Nodes)
```
BaseNode.iterator(initial_state: Optional[Dict[str, Any]]) -> Iterator[T]: ...
""" Resuming state is only possible at iterator instantiation. Developers must explicitly define how to handle non-null initial_state, and ensure that their generator or iterator is set up to resume correctly. input will be an output of BaseNode.get_state().

As usual, users should not call `.iterator()` directly, but instaed call `.__iter__()` instead (through `iter(...)`).
"""

BaseNode.get_state() -> Dict[str, Any]: ...
""" Developers of Nodes are required to implement and explicitly handle state management for their class.
Notably, if the node depends on a parent base node, you might do something like:
`return {"parent": self.parent.state_dict()}`

Note that users implement `get_state()` but should call `parent.state_dict()`
""" 
```

## Notable design choices: 
* the Iterator returned from BaseNode does not have state_dict/load_state_dict methods. 
  * Rationale: this greatly simplifies assumptions on where state may live, and is the lowest common denominator for defining both explicit Iterator classes, or defining generators. 
  * If we call state_dict in iterators, we can either a) force everyone to have explicit iterators, or b) check both base-node and iterator for state, which can get hairy (see eg stateful_dataloader). Consider having to reason about correctly configuring state for this scenario: `base_node.load_state_dict(sd["base"]); it = iter(base_node); it.load_state_dict(["base_iter"])`
* As a result of this, we're making the decision to assume that each BaseNode may have one active iterator at any time, which again unifies state-management for both generators and explicitly defined Iterators.
* state can only be resumed at iterator instantiation `.iterator(initial_state)`.
* We follow the same convention as StatefulDataLoader:
  * state_dict will return state of the last iterator returned by __iter__.
  * load_state_dict() will set the initial_state for the iterator returned by the next __iter__ call. 

## Testing
We'll provide a re-usable test function (or suite of tests) for developers to call in their own tests. To develop new nodes, devs will need to:
1) subclass BaseNode[T]
2) implement `.iterator(initial_state)`
3) implement `.get_state()`
4) write unit-tests that call `tests.nodes.utils.run_test_save_load_state`, in addition to testing the basic functionality.
