### PR TITLE
Changes default behaviour of StopIteration immediately after load_state_dict to be false

### DIFF
--- a/torchdata/nodes/base_node.py
+++ b/torchdata/nodes/base_node.py
@@ -27,6 +27,7 @@ class BaseNodeIterator(Iterator[T]):
 class BaseNode(Iterable[T]):
     __it: Optional[BaseNodeIterator[T]] = None  # holds pointer to last iter() requested
     __initial_state: Optional[Dict[str, Any]] = None
+    __restart_on_stop_iteration: bool = False
 
     def iterator(self, initial_state: Optional[dict]) -> Iterator[T]:
         """Override this method to implement the iterator.
@@ -47,14 +48,15 @@ class BaseNode(Iterable[T]):
 
     def __iter__(self) -> BaseNodeIterator[T]:
         if self.__it is not None and not self.__it.started():
-            # Only create a new iter if the last requested one did not start
+            # Only create a new iter if the last requested one has already started
             return self.__it
 
         if self.__initial_state is not None:
             self.__it = _EagerIter(self, self.__initial_state)
             self.__initial_state = None
-            if not self.__it.has_next():
+            if self.__restart_on_stop_iteration and not self.__it.has_next():
                 self.__it = _EagerIter(self, self.__initial_state)
+            self.__restart_on_stop_iteration = False
         else:
             self.__it = _EagerIter(self, self.__initial_state)
         return self.__it
@@ -62,8 +64,46 @@ class BaseNode(Iterable[T]):
     def state_dict(self) -> Dict[str, Any]:
         return self.get_state()
 
-    def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
+    def load_state_dict(
+        self,
+        state_dict: Dict[str, Any],
+        restart_on_stop_iteration: bool = False,
+    ) -> None:
+        """
+        When iter() is next requested from this node, it will be instantiated with state_dict.
+        state_dict will be passed directly to the .iterator(...) method of this node which will
+        handle proper initialization.
+
+        [ state_dict end of iteration handling ]
+        Special care must be taken when state_dict is requested after StopIteration.
+        Consider the following common example of saving state_dict after one epoch.
+        ```python
+        node: BaseNode = ...
+        for batch in node:
+            # do something
+
+        state_dict = node.state_dict()
+        ```
+        Technically, since state_dict() was called before a new iterator was requested from `node`,
+        you should expect the following behaviour:
+        ```python
+        node: BaseNode = ...
+        node.load_state_dict(state_dict)  # Load state_dict from above
+        next(iter(node))  # Throws StopIteration immediately
+        ```
+
+        You can avoid the above (default) behaviour by passing `restart_on_stop_iteration=True` when
+        calling `load_state_dict`.
+
+        Note: we can not make the True the default for restart_on_stop_iteration because it would
+        prevent StopIteration thrown in leaves from propogating up to the node where load_state_dict is called.
+
+        :param state_dict: state_dict to load in next __iter__ requested
+        :param restart_on_stop_iteration: (default False) - whether to restart the iterator automatically
+            when the first next() call would throw StopIteration.
+        """
         self.__initial_state = state_dict
+        self.__restart_on_stop_iteration = restart_on_stop_iteration
 
 
 class _EagerIter(BaseNodeIterator[T]):


### PR DESCRIPTION
Adds docstring about saving/loading state_dict at end-of-iteration (either after or just before StopIteration is thrown). 

See Docstring for details on the rationale behind this change.

TL;DR - If you load a state_dict from end-of-epoch, calling next(iter(node)) on it would throw stop iteration. This is unexpected for the (very) common case of saving state_dict at end of epoch, and loading it and expecting it to restart from the beginning of the next epoch, so the old default behaviour is to catch that stop iteration (through has_next()), and restart the iterator automatically.

The problem is that this breaks down when BaseNodes actually _need to know_ that StopIteration is going to be thrown, for example, multi-dataset samplers that need to handle end-of-iteration from one of their datasets.

We introduce a flag `restart_on_stop_iteration` in the `load_state_dict` as it's the most obvious place to set this, without making `.iterator()` implementations aware of this (they don't need to be). For this to work properly, the default MUST be False, because otherwise all child and grand-child nodes in a dag would catch it and prevent the root node from being able to handle it itself. 