### PR TITLE
Exclude 3.13 for windows on release v10

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -65,7 +65,7 @@ jobs:
           - pure
         exclude:
           - os: windows-latest
-            python-version: pure
+            python-version: [pure, "3.13"]
     steps:
       - name: Checkout Source Repository
         uses: actions/checkout@v3

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -65,7 +65,9 @@ jobs:
           - pure
         exclude:
           - os: windows-latest
-            python-version: [pure, "3.13"]
+            python-version: pure
+          - os: windows-latest
+            python-version: "3.13"
     steps:
       - name: Checkout Source Repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We tried to setup a test workflow for v10 release, but it failed because windows has no support for 3.13 in torch.

Flow: https://github.com/pytorch/data/actions/runs/12208526204/job/34061897521#step:8:300

We believe that is because the flow config `_build_test_upload.yml` doesn't exclude 3.13 for windows. This PR is adding that.

I tried to test the workflow with this change by running the test release workflow on the branch `divyanshk/exclude_3.13_...` but that doesn't work. Mostly because of the filtering rules built in the config (https://github.com/pytorch/data/actions/runs/12209869119/workflow#L31).

Edit: `build_test_upload` got kicked by this PR and succeeds https://github.com/pytorch/data/actions/runs/12210112227/job/34065795491?pr=1386 (i.e. excludes 3.13 and pure for windows)

