### PR TITLE
Update action versions

### DIFF
--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -141,7 +141,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: torchdata-artifact-${{ matrix.runs-on }}
+          name: torchdata-artifact-${{ matrix.os }}-${{ matrix.python-version }}
           path: dist/torchdata*.whl
 
   wheel_upload:
@@ -169,7 +169,7 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: torchdata-artifact-*
+          pattern: torchdata-artifact-*
           merge-multiple: true
       - name: Determine if Wheel Uploading is needed
         run: |

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -68,7 +68,7 @@ jobs:
             python-version: pure
     steps:
       - name: Checkout Source Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           submodules: recursive
@@ -167,7 +167,7 @@ jobs:
           aws-region: us-east-1
       - name: Download Artifacts from Github
         continue-on-error: true
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: torchdata-artifact
       - name: Determine if Wheel Uploading is needed
@@ -220,7 +220,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
           submodules: recursive

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload Wheels to Github
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: torchdata-artifact
           path: dist/torchdata*.whl

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -141,7 +141,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: torchdata-artifact
+          name: torchdata-artifact-${{ matrix.runs-on }}
           path: dist/torchdata*.whl
 
   wheel_upload:
@@ -169,7 +169,8 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
-          name: torchdata-artifact
+          name: torchdata-artifact-*
+          merge-multiple: true
       - name: Determine if Wheel Uploading is needed
         run: |
           upload=false

--- a/.github/workflows/_build_test_upload.yml
+++ b/.github/workflows/_build_test_upload.yml
@@ -74,7 +74,7 @@ jobs:
           submodules: recursive
       - name: Setup Python ${{ matrix.python-version }} for Windows
         if: ${{ startsWith( matrix.os, 'windows' ) }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Add temp runner environment variables
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: "3.9"
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install lint utilities
         run: |
           pip install pre-commit
@@ -47,7 +47,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install PyTorch
         run: |
           pip3 install networkx
@@ -83,6 +83,6 @@ jobs:
         with:
           python-version: "3.9"
       - name: Check out source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check if documentation is complete
         run: python ./.github/scripts/check_complete_doc.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Check out source repository
@@ -43,7 +43,7 @@ jobs:
           echo "value=$PT_CHANNEL" >> $GITHUB_OUTPUT
         id: pytorch_channel
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
       - name: Check out source repository
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
       - name: Check out source repository


### PR DESCRIPTION
Github is [deprecating artifact actions v3.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

Made the following changes:

`actions/setup-python@v4 -> actions/setup-python@v5`
`actions/checkout@v3 -> actions/checkout@v4`
`actions/download-artifact@v3 -> actions/download-artifact@v4`
`actions/upload-artifact@v3 -> actions/upload-artifact@v4`
refs:

1. https://github.com/pytorch/executorch/pull/7573
2. https://github.com/pytorch/test-infra/pull/5877

