### PR TITLE
Make Multi Node sampler cycle forever

### DIFF
--- a/test/nodes/test_multi_node_weighted_sampler.py
+++ b/test/nodes/test_multi_node_weighted_sampler.py
@@ -43,7 +43,7 @@ class TestMultiNodeWeightedSampler(TestCase):
         datasets = {f"ds{i}": IterableWrapper(DummyIterableDataset(num_samples, f"ds{i}")) for i in range(num_datasets)}
         weights = {f"ds{i}": weights_fn(i) for i in range(num_datasets)}
         node = MultiNodeWeightedSampler(datasets, weights, stop_criteria)
-        return Prefetcher(node, prefetch_factor=1)
+        return Prefetcher(node, prefetch_factor=3)
 
     def test_multi_node_weighted_sampler_weight_sampler_keys_mismatch(self) -> None:
         """Test validation logic for MultiNodeWeightedSampler if the keys of source_nodes and weights are not the same"""

--- a/test/nodes/test_multi_node_weighted_sampler.py
+++ b/test/nodes/test_multi_node_weighted_sampler.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+from collections import defaultdict
 
 from parameterized import parameterized
 from torch.testing._internal.common_utils import TestCase
@@ -30,6 +31,7 @@ class TestMultiNodeWeightedSampler(TestCase):
             for i in range(self._num_datasets)
         }
         self.weights = {f"ds{i}": self._weights_fn(i) for i in range(self._num_datasets)}
+        self.equal_weights = {f"ds{i}": 1.0 for i in range(self._num_datasets)}
 
     def test_torchdata_nodes_imports(self) -> None:
         try:
@@ -148,6 +150,23 @@ class TestMultiNodeWeightedSampler(TestCase):
             # check that all datasets are exhausted
             self.assertEqual(sorted(datasets_in_results), ["ds0", "ds1", "ds2", "ds3"])
             mixer.reset()
+
+    def test_multi_node_weighted_sampler_cycle_forever(self) -> None:
+        """Test MultiNodeWeightedSampler with stop criteria CYCLE_FOREVER"""
+        mixer = MultiNodeWeightedSampler(
+            self.datasets,
+            self.equal_weights,
+            stop_criteria=StopCriteria.CYCLE_FOREVER,
+        )
+
+        num_yielded = 0
+        _it = iter(mixer)
+        while num_yielded < 256:  # total number of samples is 4 * 10 = 40, 256 is an arbitrary larger number
+            next(_it)
+            num_yielded += 1
+
+        mixer_num_yielded = mixer.get_state()[MultiNodeWeightedSampler.NUM_YIELDED_KEY]
+        self.assertEqual(mixer_num_yielded, num_yielded)
 
     @parameterized.expand([(1, 8), (8, 32)])
     def test_multi_node_weighted_batch_sampler_set_rank_world_size(self, rank, world_size):

--- a/test/nodes/test_multi_node_weighted_sampler.py
+++ b/test/nodes/test_multi_node_weighted_sampler.py
@@ -5,7 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-from collections import defaultdict
 
 from parameterized import parameterized
 from torch.testing._internal.common_utils import TestCase
@@ -44,7 +43,7 @@ class TestMultiNodeWeightedSampler(TestCase):
         datasets = {f"ds{i}": IterableWrapper(DummyIterableDataset(num_samples, f"ds{i}")) for i in range(num_datasets)}
         weights = {f"ds{i}": weights_fn(i) for i in range(num_datasets)}
         node = MultiNodeWeightedSampler(datasets, weights, stop_criteria)
-        return Prefetcher(node, prefetch_factor=3)
+        return Prefetcher(node, prefetch_factor=1)
 
     def test_multi_node_weighted_sampler_weight_sampler_keys_mismatch(self) -> None:
         """Test validation logic for MultiNodeWeightedSampler if the keys of source_nodes and weights are not the same"""

--- a/torchdata/nodes/samplers/stop_criteria.py
+++ b/torchdata/nodes/samplers/stop_criteria.py
@@ -17,8 +17,12 @@ class StopCriteria:
        dataset is seen exactly once. No wraparound or restart will be performed.
 
     3) FIRST_DATASET_EXHAUSTED: Stop when the first dataset is exhausted.
+
+    4) CYCLE_FOREVER: Cycle through the datasets by reinitializing each exhausted source nodes.
+       This is useful when trainer want control over certain number of steps instead of epochs.
     """
 
     CYCLE_UNTIL_ALL_DATASETS_EXHAUSTED = "CYCLE_UNTIL_ALL_DATASETS_EXHAUSTED"
     ALL_DATASETS_EXHAUSTED = "ALL_DATASETS_EXHAUSTED"
     FIRST_DATASET_EXHAUSTED = "FIRST_DATASET_EXHAUSTED"
+    CYCLE_FOREVER = "CYCLE_FOREVER"


### PR DESCRIPTION
This PR adds support for continuous cycling through each base node in multi node weighted sampler. With the current setup this was each to extend. We do cycle through each node to support `StopCriteria.CYCLE_UNTIL_ALL_DATASETS_EXHAUSTED`, for `StopCriteria.CYCLE_FOREVER` we skip raising a `StopIteration`.

This should be functionally equivalent to having an infinite sampler plugged on top of each base dataset. 

The dataset order (as defined by `weights`) remains the same.