### PR TITLE
Add tests for out of order with checkpointing

### DIFF
--- a/torchdata/stateful_dataloader/stateful_dataloader.py
+++ b/torchdata/stateful_dataloader/stateful_dataloader.py
@@ -181,8 +181,6 @@ class StatefulDataLoader(DataLoader[_T_co]):
 
     .. warning:: Setting `in_order` to `False` can harm reproducibility and may lead to a skewed data distribution being fed to the trainer in cases with imbalanced data.
 
-    .. warning:: Setting `in_order` to `False` currently has no guarantees for state management.
-
     .. _multiprocessing context:
         https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
     """
@@ -233,13 +231,6 @@ class StatefulDataLoader(DataLoader[_T_co]):
 
         if persistent_workers and num_workers == 0:
             raise ValueError("persistent_workers option needs num_workers > 0")
-
-        if num_workers > 0 and not in_order:
-            # TODO: remove warning log when state management is supported with in_order=False
-            logger.warning(
-                "using in_order=False with multiple workers does not give any guarantees for state management "
-                "and loading from a checkpoint may not work as expected."
-            )
 
         self.dataset = dataset
         self.num_workers = num_workers
@@ -1170,12 +1161,6 @@ class _StatefulMultiProcessingDataLoaderIter(_StatefulBaseDataLoaderIter):
         self._worker_snapshots[worker_key].apply_delta(state_dict)
 
     def state_dict(self):
-        if not self._in_order:
-            # TODO: remove warning log when state management is supported with in_order=False
-            logger.warning(
-                "using in_order=False with multiple workers does not give any guarantees for state management "
-                "and loading from a checkpoint may not work as expected."
-            )
         steps_since_snapshot = self._num_yielded - self._snapshot[self._SNAPSHOT_STEP]
         state_dict = {
             self._SNAPSHOT: self._snapshot,


### PR DESCRIPTION
Follow up to #1423

### Changes

- Add tests for state management of both index datasets and iterable datasets when `in_order=False`
- Remove warning logs about `in_order=False`

State management with `in_order=False` actually _just works_ which is really nice.

I'm happy to keep the warning logs in for longer if we'd like to err on the side of caution. And please let me know if there are any other test cases I should add.
