### PR TITLE
Rescalability layer

### DIFF
--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -45,7 +45,7 @@ mesh = dist.device_mesh.init_device_mesh("cpu", [world_size])
 placement = [dist.tensor.placement_types.Shard(0)]
 
 # Build dataloader
-data = DummyDataset("data", rank, world_size, delimiter_token=-1, seed=args.seed)
+data = DummyDataset(os.path.join(args.ckpt_path, "data"), rank, world_size, delimiter_token=-1, seed=args.seed)
 # Pretend that we're sampling over multiple sub-datasets
 subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
 [os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -49,15 +49,15 @@ subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
 # Build dataloader
 data = DummyDataset(os.path.join(args.ckpt_path, "data"), rank, world_size, delimiter_token=-1, seed=args.seed)
 # Pretend that we're sampling over multiple sub-datasets
-# data = SamplingDataset(
-#     os.path.join(args.ckpt_path, "data"),
-#     data,
-#     delimiter_token=-1,
-#     datasets=subdatas,
-#     weights=[12, 17, 5],
-# )
+data = SamplingDataset(
+    os.path.join(args.ckpt_path, "data"),
+    data,
+    delimiter_token=-1,
+    datasets=subdatas,
+    weights=[12, 17, 5],
+)
 # Apply rescalability layer
-# data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
+data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -137,6 +137,10 @@ else:
     # Get all vals onto each rank
     vals = dist.tensor.DTensor.from_local(vals, mesh, placement).full_tensor()
 
+    # Diag save
+    os.makedirs(os.path.join(args.ckpt_path, "diag"))
+    torch.save(data.state_dict(), os.path.join(args.ckpt_path, "diag", f"loader_state_{rank}.pth"))
+
     # Perform data coverage check on rank 0 only
     if rank == 0:
         # Invert avoid to get expected vals

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -79,7 +79,7 @@ if not os.path.exists(datapath):
 # Build dataloader
 data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)
 # Pad entries to make them batch-able
-data = PreprocessDataset(data, lambda x: x + [-1]*(30-len))
+data = PreprocessDataset(data, lambda x: x + [-1]*(30-len(x)))
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -125,8 +125,8 @@ else:
     if rank == 0:
         print("Checkpoint detected!")
     load_distributed_state_dict(data, ckpt_path, mesh)
-    print("FINAL")
-    time.sleep(10000)
+    # print("FINAL")
+    # time.sleep(10000)
     avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 
     # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -125,6 +125,7 @@ else:
     if rank == 0:
         print("Checkpoint detected!")
     load_distributed_state_dict(data, ckpt_path, mesh)
+    time.sleep(10)
     avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 
     # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -130,7 +130,6 @@ else:
     if rank == 0:
         avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth"))
         include = torch.load(os.path.join(args.ckpt_path, "include.pth"))
-        torch.save(vals, os.path.join(args.ckpt_path, "vals.pth"))
 
         def _in(v, m):
             # Returns whether vector v is a row of matrix m (both tensors)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -43,12 +43,12 @@ world_size = int(os.getenv("WORLD_SIZE", 1))
 dist.init_process_group()
 mesh = dist.device_mesh.init_device_mesh("cpu", [world_size])
 placement = [dist.tensor.placement_types.Shard(0)]
+subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
+[os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]
 
 # Build dataloader
 data = DummyDataset(os.path.join(args.ckpt_path, "data"), rank, world_size, delimiter_token=-1, seed=args.seed)
 # Pretend that we're sampling over multiple sub-datasets
-subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
-[os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]
 # data = SamplingDataset(
 #     os.path.join(args.ckpt_path, "data"),
 #     data,

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -49,13 +49,13 @@ data = DummyDataset(None, rank, world_size, delimiter_token=-1, seed=args.seed)
 # Pretend that we're sampling over multiple sub-datasets
 subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
 [os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]
-data = SamplingDataset(
-    os.path.join(args.ckpt_path, "data"),
-    data,
-    delimiter_token=-1,
-    datasets=subdatas,
-    weights=[12, 17, 5],
-)
+# data = SamplingDataset(
+#     os.path.join(args.ckpt_path, "data"),
+#     data,
+#     delimiter_token=-1,
+#     datasets=subdatas,
+#     weights=[12, 17, 5],
+# )
 # Apply rescalability layer
 data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
 # Statelessly convert all outputs to tensors

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -54,7 +54,7 @@ assert args.n_steps*args.b_size*world_size < 3000, f"Number of items drawn befor
 
 # Build dataset
 datapath = os.path.join(args.ckpt_path, "dataset")
-if not os.path.exists(datapath):
+if rank==0 and not os.path.exists(datapath):
     os.makedirs(datapath)
     schema = pa.schema([pa.field("tokens", pa.uint32())])
     with pa.ipc.new_file(

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -138,7 +138,7 @@ else:
     vals = dist.tensor.DTensor.from_local(vals, mesh, placement).full_tensor()
 
     # Diag save
-    os.makedirs(os.path.join(args.ckpt_path, "diag"))
+    os.makedirs(os.path.join(args.ckpt_path, "diag"), exist_ok=True)
     torch.save(data.state_dict(), os.path.join(args.ckpt_path, "diag", f"loader_state_{rank}.pth"))
     time.sleep(10)
 

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -45,7 +45,7 @@ mesh = dist.device_mesh.init_device_mesh("cpu", [world_size])
 placement = [dist.tensor.placement_types.Shard(0)]
 
 # Build dataloader
-data = DummyDataset(None, rank, world_size, delimiter_token=-1, seed=args.seed)
+data = DummyDataset("data", rank, world_size, delimiter_token=-1, seed=args.seed)
 # Pretend that we're sampling over multiple sub-datasets
 subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
 [os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -125,6 +125,7 @@ else:
     if rank == 0:
         print("Checkpoint detected!")
     load_distributed_state_dict(data, ckpt_path, mesh)
+    print("FINAL")
     time.sleep(10000)
     avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -22,6 +22,7 @@ from torchdata.stateful_dataloader.ibm_rescalable import (
 # Example usage:
 # torchrun [torchrun args] examples/ibm_rescaling/rescaling_demo.py --ckpt_path=~/ckpts/rescale_test --logical_shards=48 --num_workers=6
 
+# Do not change the batch size or number of steps between the first and second runs!
 
 parser = argparse.ArgumentParser(description="Script to validate rescaling of dataloader checkpoints")
 parser.add_argument("--ckpt_path", type=str, default="./rescale_test")
@@ -54,7 +55,7 @@ assert args.n_steps*args.b_size*world_size < 3000, f"Number of items drawn befor
 # Build dataset
 datapath = os.path.join(args.ckpt_path, "dataset")
 if not os.path.exists(datapath):
-    os.mkdir(datapath)
+    os.makedirs(datapath)
 schema = pa.schema([pa.field("tokens", pa.uint32())])
 with pa.ipc.new_file(
     os.path.join(datapath, "fileshard_1.arrow"), schema

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -57,7 +57,7 @@ subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
 #     weights=[12, 17, 5],
 # )
 # Apply rescalability layer
-data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
+# data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -85,6 +85,10 @@ data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader
 data = StatefulDataLoader(data, batch_size=args.b_size, num_workers=args.num_workers)
 
+# TODO: debug: can't change n_workers when reloading - keyerror
+# TODO: debug: going from 4/2/2 gpu/bsize/workers to 6/1/2 causes epoch not to finish
+
+
 # If checkpoint does not exist, create it
 ckpt_path = os.path.join(args.ckpt_path, "loader_dcp_state")
 if not os.path.exists(ckpt_path) or len(os.listdir(ckpt_path)) == 0:
@@ -126,7 +130,7 @@ else:
     # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)
     vals = []
     n_steps = (
-        math.ceil((3000 - len(avoid)) / (world_size * args.num_workers)) 
+        math.ceil((3000 - len(avoid)) / (world_size * args.b_size)) 
         + 2 * math.ceil(1000/args.logical_shards)
     )
     for i, inp in enumerate(data):

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -129,11 +129,11 @@ else:
     # time.sleep(10000)
     avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 
-    # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)
+    # Finish out epoch (extra 2*ceil(n_items/n_shards) steps to account for worst-case uneven finishing times)
     vals = []
     n_steps = (
         math.ceil((3000 - len(avoid)) / (world_size * args.b_size)) 
-        + 2 * math.ceil(1000/args.logical_shards)
+        + 2 * math.ceil(3000/args.logical_shards)
     )
     for i, inp in enumerate(data):
         if i == n_steps:
@@ -146,9 +146,9 @@ else:
     # Diag save
     os.makedirs(os.path.join(args.ckpt_path, "diag"), exist_ok=True)
     torch.save(data.state_dict(), os.path.join(args.ckpt_path, "diag", f"loader_state_{rank}.pth"))
-    if rank == 0:
-        torch.save(vals, os.path.join(args.ckpt_path, "diag", "vals.pth"))
-    time.sleep(10)
+    # if rank == 0:
+    #     torch.save(vals, os.path.join(args.ckpt_path, "diag", "vals.pth"))
+    # time.sleep(10)
 
     # Perform data coverage check on rank 0 only
     if rank == 0:

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -125,7 +125,7 @@ else:
     if rank == 0:
         print("Checkpoint detected!")
     load_distributed_state_dict(data, ckpt_path, mesh)
-    time.sleep(10)
+    time.sleep(10000)
     avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 
     # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -64,7 +64,7 @@ data = PreprocessDataset(data, torch.tensor)
 data = StatefulDataLoader(data, batch_size=args.b_size, num_workers=args.num_workers)
 
 # If checkpoint does not exist, create it
-if not os.path.exists(args.ckpt_path) or len(os.listdir(cfg.ckpt_save_path)) == 0:
+if not os.path.exists(args.ckpt_path) or len(os.listdir(args.ckpt_path)) == 0:
     os.makedirs(args.ckpt_path, exist_ok=True)
     # Iterate, assemble values to exclude
     if rank == 0:

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -56,20 +56,20 @@ assert args.n_steps*args.b_size*world_size < 3000, f"Number of items drawn befor
 datapath = os.path.join(args.ckpt_path, "dataset")
 if not os.path.exists(datapath):
     os.makedirs(datapath)
-schema = pa.schema([pa.field("tokens", pa.uint32())])
-with pa.ipc.new_file(
-    os.path.join(datapath, "fileshard_1.arrow"), schema
-) as writer:
-    for i in range(500):
-        out = list(range(i * 100, i * 100 + 100))
-        writer.write(pa.record_batch([out], schema=schema))
-
-with pa.ipc.new_file(
-    os.path.join(datapath, "subfolder/fileshard_2.arrow"), schema
-) as writer:
-    for i in range(500):
-        out = list(range(50000 + i * 100, 50000 + i * 100 + 100))
-        writer.write(pa.record_batch([out], schema=schema))
+    schema = pa.schema([pa.field("tokens", pa.uint32())])
+    with pa.ipc.new_file(
+        os.path.join(datapath, "fileshard_1.arrow"), schema
+    ) as writer:
+        for i in range(500):
+            out = list(range(i * 100, i * 100 + 100))
+            writer.write(pa.record_batch([out], schema=schema))
+    os.makedirs(os.path.join(datapath, "subfolder"))
+    with pa.ipc.new_file(
+        os.path.join(datapath, "subfolder/fileshard_2.arrow"), schema
+    ) as writer:
+        for i in range(500):
+            out = list(range(50000 + i * 100, 50000 + i * 100 + 100))
+            writer.write(pa.record_batch([out], schema=schema))
 
 # Build dataloader
 data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -1,23 +1,23 @@
 import argparse
+import math
 import os
-
+import pyarrow as pa
 import torch
 from torch import distributed as dist
 
 from torchdata.stateful_dataloader import StatefulDataLoader
 from torchdata.stateful_dataloader.ibm_rescalable import (
-    DummyDataset,
+    ArrowHandler,
     PreprocessDataset,
-    SamplingDataset,
-    ScalableShardDataset,
+    ScalableReader,
     load_distributed_state_dict,
     save_distributed_state_dict,
 )
 
 # This example script validates the rescaling behavior of the ibm rescalable distributed datasets.
-# On first run, saves a distributed checkpoint to the desired location.
+# On first run, creates a dummy dataset and saves a distributed checkpoint at the desired location.
 # On subsequent runs, loads the checkpoint (possibly on a different world size / num workers)
-# and verifies that previous data is not revisited, while upcoming data is.
+# and verifies that all remaining data is covered by the time the epoch finishes.
 
 # Example usage:
 # torchrun [torchrun args] examples/ibm_rescaling/rescaling_demo.py --ckpt_path=~/ckpts/rescale_test --logical_shards=48 --num_workers=6
@@ -28,14 +28,16 @@ parser.add_argument("--ckpt_path", type=str, default="./rescale_test")
 parser.add_argument(
     "--logical_shards",
     type=int,
-    default=96,
-    help="Total number of data partitions. (worldsize * n_workers) must divide this evenly.",
+    default=350,
+    help="Total number of data partitions. Must exceed (worldsize * n_workers) but not n_docs (1000).",
 )
 parser.add_argument("--num_workers", type=int, default=1, help="Number of dataloader workers per device")
-parser.add_argument("--b_size", type=int, default=1, help="Number of data points per step per device")
+parser.add_argument("--b_size", type=int, default=2, help="Number of data points per step per device")
+parser.add_argument("--n_steps", type=int, default=50, help="Number of steps to take before saving. (n_steps * b_size * worldsize) cannot exceed number of items in epoch (3000)")
 parser.add_argument("--seed", type=int, default=42)
 
 args = parser.parse_args()
+
 
 # Setup
 rank = int(os.getenv("RANK", 0))
@@ -43,21 +45,33 @@ world_size = int(os.getenv("WORLD_SIZE", 1))
 dist.init_process_group()
 mesh = dist.device_mesh.init_device_mesh("cpu", [world_size])
 placement = [dist.tensor.placement_types.Shard(0)]
-subdatas = ["sub_dataset", "second_subdataset", "small_subdataset"]
-[os.makedirs(os.path.join(args.ckpt_path, "data", subdata), exist_ok=True) for subdata in subdatas]
+
+# Check input args
+assert args.logical_shards >= world_size*args.num_workers, f"Logical shards {args.logical_shards} cannot be less than total workers {world_size*args.num_workers}"
+assert args.logical_shards <= 1000, f"Logical shards {args.logical_shards} cannot exceed number of documents 1000"
+assert args.n_steps*args.b_size*world_size < 3000, f"Number of items drawn before saving {args.n_steps*args.b_size*world_size} cannot exceed number of document chunks 3000."
+
+# Build dataset
+datapath = os.path.join(args.ckpt_path, "dataset")
+if not os.path.exists(datapath):
+    os.mkdir(datapath)
+schema = pa.schema([pa.field("tokens", pa.uint32())])
+with pa.ipc.new_file(
+    os.path.join(datapath, "fileshard_1.arrow"), schema
+) as writer:
+    for i in range(500):
+        out = list(range(i * 100, i * 100 + 100))
+        writer.write(pa.record_batch([out], schema=schema))
+
+with pa.ipc.new_file(
+    os.path.join(datapath, "subfolder/fileshard_2.arrow"), schema
+) as writer:
+    for i in range(500):
+        out = list(range(50000 + i * 100, 50000 + i * 100 + 100))
+        writer.write(pa.record_batch([out], schema=schema))
 
 # Build dataloader
-data = DummyDataset(os.path.join(args.ckpt_path, "data"), rank, world_size, delimiter_token=-1, seed=args.seed)
-# Pretend that we're sampling over multiple sub-datasets
-data = SamplingDataset(
-    os.path.join(args.ckpt_path, "data"),
-    data,
-    delimiter_token=-1,
-    datasets=subdatas,
-    weights=[12, 17, 5],
-)
-# Apply rescalability layer
-data = ScalableShardDataset(data, n_logical_shards=args.logical_shards)
+data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader
@@ -69,16 +83,16 @@ if not os.path.exists(ckpt_path) or len(os.listdir(ckpt_path)) == 0:
     os.makedirs(ckpt_path, exist_ok=True)
     # Iterate, assemble values to exclude
     if rank == 0:
-        print("No existing checkpoint. Processing 100 steps.")
+        print(f"No existing checkpoint. Processing {args.n_steps} steps.")
 
     avoid = []
     for i, inp in enumerate(data):
-        if i == 100:
+        if i == args.n_steps:
             if rank == 0:
                 print("Iteration complete!")
             save_distributed_state_dict(data, ckpt_path, mesh)
             break
-        avoid.append(inp)
+        avoid.append(inp[:,0])
     avoid = torch.cat(avoid)
     # Get all vals onto each rank
     avoid = dist.tensor.DTensor.from_local(
@@ -87,63 +101,46 @@ if not os.path.exists(ckpt_path) or len(os.listdir(ckpt_path)) == 0:
         placement,
     ).full_tensor()
 
-    # Continue, assemble values to include
-    load_distributed_state_dict(data, ckpt_path, mesh)
-    if rank == 0:
-        print("DCP state loaded!")
-
-    include = []
-    for i, inp in enumerate(data):
-        if i == 10:
-            break
-        include.append(inp)
-    include = torch.cat(include)
-    if rank == 0:
-        print("Iteration round 2 complete!")
-    # Get all vals onto each rank
-    include = dist.tensor.DTensor.from_local(include, mesh, placement).full_tensor()
-
     if rank == 0:
         torch.save(avoid, os.path.join(args.ckpt_path, "avoid.pth"))
-        torch.save(include, os.path.join(args.ckpt_path, "include.pth"))
         print(
             "Generation complete! Please rerun (with different world size / workers if desired) to complete the check."
         )
 
-# If checkpoint does exist, load and take 100 steps.
-# Ensure avoid values are avoided, and all include values are included.
+# If checkpoint does exist, load and finish epoch.
+# Ensure all expected values are covered once epoch concludes.
 else:
     if rank == 0:
         print("Checkpoint detected!")
     load_distributed_state_dict(data, ckpt_path, mesh)
+    avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth")).tolist()
 
+    # Finish out epoch (extra 2*ceil(ndocs/nshards) steps to account for worst-case uneven finishing times)
     vals = []
+    n_steps = (
+        math.ceil((3000 - len(avoid)) / (world_size * args.num_workers)) 
+        + 2 * math.ceil(1000/args.logical_shards)
+    )
     for i, inp in enumerate(data):
-        if i == 100:
+        if i == n_steps:
             break
         vals.append(inp)
     vals = torch.cat(vals)
     # Get all vals onto each rank
     vals = dist.tensor.DTensor.from_local(vals, mesh, placement).full_tensor()
 
-    # Perform avoid/include checks on rank 0 only
+    # Perform data coverage check on rank 0 only
     if rank == 0:
-        avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth"))
-        include = torch.load(os.path.join(args.ckpt_path, "include.pth"))
+        # Invert avoid to get expected vals
+        expect = []
+        for i in range(1000):
+            for offset in [0,40,80]:
+                if i*100+offset not in avoid:
+                    expect.append(i*100+offset)
 
-        def _in(v, m):
-            # Returns whether vector v is a row of matrix m (both tensors)
-            return m.sub(v[None]).abs().sum(1).sign().prod().bool().logical_not().item()
-
-        # Avoid check
-        for i, x in enumerate(avoid.split(1)):
-            assert not _in(x[0], vals), i
-        print("Check passed: seen data was not revisited!")
-
-        # Include check
-        for i, x in enumerate(include.split(1)):
-            assert _in(x[0], vals), i
-        print("Check passed: upcoming data appears as expected!")
+        for x in expect:
+            assert x in vals, x
+        print("Check passed: upcoming data is covered as expected!")
 
 dist.barrier()
 dist.destroy_process_group()

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -77,9 +77,9 @@ if not os.path.exists(datapath):
         time.sleep(5)
 
 # Build dataloader
-data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)
+data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=40, n_logical_shards=args.logical_shards)
 # Pad entries to make them batch-able
-data = PreprocessDataset(data, lambda x: x + [-1]*(30-len(x)))
+data = PreprocessDataset(data, lambda x: x + [-1]*(40-len(x)))
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -2,6 +2,7 @@ import argparse
 import math
 import os
 import pyarrow as pa
+import time
 import torch
 from torch import distributed as dist
 
@@ -54,22 +55,26 @@ assert args.n_steps*args.b_size*world_size < 3000, f"Number of items drawn befor
 
 # Build dataset
 datapath = os.path.join(args.ckpt_path, "dataset")
-if rank==0 and not os.path.exists(datapath):
-    os.makedirs(datapath)
-    schema = pa.schema([pa.field("tokens", pa.uint32())])
-    with pa.ipc.new_file(
-        os.path.join(datapath, "fileshard_1.arrow"), schema
-    ) as writer:
-        for i in range(500):
-            out = list(range(i * 100, i * 100 + 100))
-            writer.write(pa.record_batch([out], schema=schema))
-    os.makedirs(os.path.join(datapath, "subfolder"))
-    with pa.ipc.new_file(
-        os.path.join(datapath, "subfolder/fileshard_2.arrow"), schema
-    ) as writer:
-        for i in range(500):
-            out = list(range(50000 + i * 100, 50000 + i * 100 + 100))
-            writer.write(pa.record_batch([out], schema=schema))
+if not os.path.exists(datapath):
+    if rank == 0:
+        os.makedirs(datapath)
+        schema = pa.schema([pa.field("tokens", pa.uint32())])
+        with pa.ipc.new_file(
+            os.path.join(datapath, "fileshard_1.arrow"), schema
+        ) as writer:
+            for i in range(500):
+                out = list(range(i * 100, i * 100 + 100))
+                writer.write(pa.record_batch([out], schema=schema))
+        os.makedirs(os.path.join(datapath, "subfolder"))
+        with pa.ipc.new_file(
+            os.path.join(datapath, "subfolder/fileshard_2.arrow"), schema
+        ) as writer:
+            for i in range(500):
+                out = list(range(50000 + i * 100, 50000 + i * 100 + 100))
+                writer.write(pa.record_batch([out], schema=schema))
+    else:
+        # Give other ranks time for worker 0 to finish
+        time.sleep(5)
 
 # Build dataloader
 data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -64,8 +64,9 @@ data = PreprocessDataset(data, torch.tensor)
 data = StatefulDataLoader(data, batch_size=args.b_size, num_workers=args.num_workers)
 
 # If checkpoint does not exist, create it
-if not os.path.exists(args.ckpt_path) or len(os.listdir(args.ckpt_path)) == 0:
-    os.makedirs(args.ckpt_path, exist_ok=True)
+ckpt_path = os.path.join(args.ckpt_path, "loader_dcp_state")
+if not os.path.exists(ckpt_path) or len(os.listdir(ckpt_path)) == 0:
+    os.makedirs(ckpt_path, exist_ok=True)
     # Iterate, assemble values to exclude
     if rank == 0:
         print("No existing checkpoint. Processing 100 steps.")
@@ -75,7 +76,7 @@ if not os.path.exists(args.ckpt_path) or len(os.listdir(args.ckpt_path)) == 0:
         if i == 100:
             if rank == 0:
                 print("Iteration complete!")
-            save_distributed_state_dict(data, os.path.join(args.ckpt_path, "loader_dcp_state"), mesh)
+            save_distributed_state_dict(data, ckpt_path, mesh)
             break
         avoid.append(inp)
     avoid = torch.cat(avoid)
@@ -87,7 +88,7 @@ if not os.path.exists(args.ckpt_path) or len(os.listdir(args.ckpt_path)) == 0:
     ).full_tensor()
 
     # Continue, assemble values to include
-    load_distributed_state_dict(data, os.path.join(args.ckpt_path, "loader_dcp_state"), mesh)
+    load_distributed_state_dict(data, ckpt_path, mesh)
     if rank == 0:
         print("DCP state loaded!")
 
@@ -114,7 +115,7 @@ if not os.path.exists(args.ckpt_path) or len(os.listdir(args.ckpt_path)) == 0:
 else:
     if rank == 0:
         print("Checkpoint detected!")
-    load_distributed_state_dict(data, os.path.join(args.ckpt_path, "loader_dcp_state"), mesh)
+    load_distributed_state_dict(data, ckpt_path, mesh)
 
     vals = []
     for i, inp in enumerate(data):

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -140,6 +140,7 @@ else:
     # Diag save
     os.makedirs(os.path.join(args.ckpt_path, "diag"))
     torch.save(data.state_dict(), os.path.join(args.ckpt_path, "diag", f"loader_state_{rank}.pth"))
+    time.sleep(10)
 
     # Perform data coverage check on rank 0 only
     if rank == 0:

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -95,12 +95,12 @@ if not os.path.exists(ckpt_path) or len(os.listdir(ckpt_path)) == 0:
 
     avoid = []
     for i, inp in enumerate(data):
-        if i == args.n_steps:
+        avoid.append(inp[:,0])
+        if i == args.n_steps-1:
             if rank == 0:
                 print("Iteration complete!")
             save_distributed_state_dict(data, ckpt_path, mesh)
             break
-        avoid.append(inp[:,0])
     avoid = torch.cat(avoid)
     # Get all vals onto each rank
     avoid = dist.tensor.DTensor.from_local(
@@ -140,6 +140,8 @@ else:
     # Diag save
     os.makedirs(os.path.join(args.ckpt_path, "diag"), exist_ok=True)
     torch.save(data.state_dict(), os.path.join(args.ckpt_path, "diag", f"loader_state_{rank}.pth"))
+    if rank == 0:
+        torch.save(vals, os.path.join(args.ckpt_path, "diag", "vals.pth"))
     time.sleep(10)
 
     # Perform data coverage check on rank 0 only

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -44,7 +44,7 @@ args = parser.parse_args()
 # Setup
 rank = int(os.getenv("RANK", 0))
 world_size = int(os.getenv("WORLD_SIZE", 1))
-dist.init_process_group()
+dist.init_process_group(backend="gloo")
 mesh = dist.device_mesh.init_device_mesh("cpu", [world_size])
 placement = [dist.tensor.placement_types.Shard(0)]
 

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -73,6 +73,8 @@ if rank==0 and not os.path.exists(datapath):
 
 # Build dataloader
 data = ScalableReader(datapath, rank, world_size, ArrowHandler, -1, seed=args.seed, max_chunksize=30, n_logical_shards=args.logical_shards)
+# Pad entries to make them batch-able
+data = PreprocessDataset(data, lambda x: x + [-1]*(30-len))
 # Statelessly convert all outputs to tensors
 data = PreprocessDataset(data, torch.tensor)
 # Wrap in StatefulDataLoader

--- a/examples/ibm_rescaling/rescaling_demo.py
+++ b/examples/ibm_rescaling/rescaling_demo.py
@@ -130,6 +130,7 @@ else:
     if rank == 0:
         avoid = torch.load(os.path.join(args.ckpt_path, "avoid.pth"))
         include = torch.load(os.path.join(args.ckpt_path, "include.pth"))
+        torch.save(vals, os.path.join(args.ckpt_path, "vals.pth"))
 
         def _in(v, m):
             # Returns whether vector v is a row of matrix m (both tensors)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -375,8 +375,6 @@ class DummyDataset(_StatefulDataset):
             out = torch.rand(self.seqlen, generator=self.generator)
             out = out.mul(self.vocab).int().tolist()
             out[-1] = self.delimiter
-            if self.rank==0:
-                print(out)
             yield out
 
     def state_dict(self):

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, List, Optional, Set
 
 import torch
 from torch.distributed import checkpoint
-from torch.distributed.checkpoint import _load_state_dict_from_keys
+from torch.distributed.checkpoint.state_dict_loader import _load_state_dict_from_keys
 import torch.distributed.tensor as dtensor
 import torch.distributed as dist
 import torch.utils.data as data

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -623,7 +623,7 @@ def load_distributed_state_dict(
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)
     inp = _load_state_dict_from_keys(
-        keys=set("state", "dstate"),
+        keys=set(["state", "dstate"]),
         storage_reader = reader,
     )  # NOTE: assumes inp["state"] is same across all devices
     # checkpoint.load_state_dict(

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -560,14 +560,15 @@ def save_distributed_state_dict(
     rank = loader.dataset.rank
     state = deepcopy(loader.state_dict())
     dstate = __pop_dstate(state, device_mesh, [dtensor.placement_types.Shard(0)])
+    out = {"state":state, "dstate":dstate}
     # Write distributed state dict
     writer = checkpoint.FileSystemWriter(path)
     checkpoint.save(
-        dstate,
+        out,
         writer,
     )
-    # Write nondistributed state dict
-    torch.save(state, os.path.join(path, f"__nondist_cp_{rank}.pth"))
+    # # Write nondistributed state dict
+    # torch.save(state, os.path.join(path, f"__nondist_cp_{rank}.pth"))
 
 
 def load_distributed_state_dict(

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -491,7 +491,7 @@ class ScalableReader(_StatefulDataset):
         file_info = state_dict[self.statename("file_info")]
         print(shard_states.size(0), self.worldsize)
         if self.rank == 0:
-            print(shard_states)
+            print(shard_states.shape, shard_states)
         if shard_states.size(0) == self.worldsize:
             self.filesizes = file_info
             self.shard_states = shard_states[self.rank]

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -490,6 +490,8 @@ class ScalableReader(_StatefulDataset):
         shard_states = state_dict[self.statename("shard_states")]
         file_info = state_dict[self.statename("file_info")]
         print(shard_states.size(0), self.worldsize)
+        if self.rank == 0:
+            print(shard_states)
         if shard_states.size(0) == self.worldsize:
             self.filesizes = file_info
             self.shard_states = shard_states[self.rank]

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -489,6 +489,7 @@ class ScalableReader(_StatefulDataset):
         # Load back shard states (global), filesizes (all)
         shard_states = state_dict[self.statename("shard_states")]
         file_info = state_dict[self.statename("file_info")]
+        print(shard_states.size(0), self.worldsize)
         if shard_states.size(0) == self.worldsize:
             self.filesizes = file_info
             self.shard_states = shard_states[self.rank]
@@ -541,6 +542,7 @@ class ScalableReader(_StatefulDataset):
             # Pad out with dummy shards if needed
             self.shard_states[len(shard_states):,0] = -1
             self.shard_states[len(shard_states):,4] = torch.iinfo(torch.int).max
+        print("GOTHERE 4")
         return None
 
 

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -48,16 +48,6 @@ def _shard_partition(itemlist: List[Any], rank: int, worldsize: int) -> List[Any
     return itemlist[(rank * len(itemlist)) // worldsize : ((rank + 1) * len(itemlist)) // worldsize]
 
 
-def _shard_inclusive(itemlist: List[Any], rank: int, worldsize: int) -> List[Any]:
-    """
-    In cases where len(itemlist) % worldsize != 0, allow for fractional ownership of items,
-    and return the span including all owned items, fractional or otherwise.
-    """
-    start = math.floor(len(itemlist) * rank / worldsize)
-    end = math.ceil(len(itemlist) * (rank + 1) / worldsize)
-    return itemlist[start:end]
-
-
 class _StatefulDataset(data.IterableDataset):
     """
     Stub for stateful datasets, extends data.IterableDataset with state_dict methods.
@@ -384,6 +374,8 @@ class DummyDataset(_StatefulDataset):
             out = torch.rand(self.seqlen, generator=self.generator)
             out = out.mul(self.vocab).int().tolist()
             out[-1] = self.delimiter
+            if self.rank==0:
+                print(out)
             yield out
 
     def state_dict(self):

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -633,7 +633,7 @@ def load_distributed_state_dict(
         # On mismatch, discard saved non-reshardable loader state and start fresh
         state = base
     # Repeat global tensor over all workers
-    print(inp["dstate"])
+    print(inp["dstate"]["ScalableReader.shard_states"][:,0].tolist())
     dstate = [inp["dstate"],]*nworkers
     # Re-insert worker states into loader state
     for i in range(nworkers):

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -622,7 +622,9 @@ def load_distributed_state_dict(
     inp = {"state":deepcopy(base), "dstate":dstate}
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)
-    inp = _load_state_dict_from_keys(storage_reader = reader)  # NOTE: assumes inp["state"] is same across all devices
+    inp = _load_state_dict_from_keys(
+        storage_reader = reader,
+    )  # NOTE: assumes inp["state"] is same across all devices
     # checkpoint.load_state_dict(
     #     inp,
     #     reader,

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -463,7 +463,7 @@ class ScalableReader(_StatefulDataset):
                             # Update position
                             self.shard_states[i][3] = chunk_pos+1
                             # Yield chunk
-                            yield torch.tensor(self._construct_chunk(chunk_pos, doc, nchunks))  # TODO: REMOVE TENSOR CALL!!!
+                            yield self._construct_chunk(chunk_pos, doc, nchunks)
                         # Reset chunk_pos after finishing doc
                         self.shard_states[i][3] = 0
                     # Reset doc_pos after finishing file

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -379,6 +379,7 @@ class DummyDataset(_StatefulDataset):
         self.generator = torch.Generator().manual_seed(self.seed + self.rank + len(self.datapath) * 100)
 
     def __iter__(self):
+        self.setup()
         while True:
             out = torch.rand(self.seqlen, generator=self.generator)
             out = out.mul(self.vocab).int().tolist()
@@ -386,6 +387,7 @@ class DummyDataset(_StatefulDataset):
             yield out
 
     def state_dict(self):
+        self.setup()
         # Write generator state manually
         self.g_state = self.generator.get_state().tolist()
         return super().state_dict()

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -614,7 +614,7 @@ def load_distributed_state_dict(
     )
     dstate = inp["dstate"]
     # Check that number of workers matches
-    ckp_ws = 0 if not os.path.exists(path) else len([x for x in os.lisdtdir(path) if "loader" in x])
+    ckp_ws = 0 if not os.path.exists(path) else len([x for x in os.listdir(path) if "loader" in x])
     if ckp_ws == loader.dataset.worldsize and nworkers == state["_snapshot"]["_main_snapshot"]["_num_workers"]:
         state = inp["state"]
     else:

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -492,6 +492,7 @@ class ScalableReader(_StatefulDataset):
         print(shard_states.size(0), self.worldsize)
         if self.rank == 0:
             print(shard_states.shape, shard_states)
+            torch.save(shard_states, "/gpfs/davis/test.pth")
         if shard_states.size(0) == self.worldsize:
             self.filesizes = file_info
             self.shard_states = shard_states[self.rank]

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -366,7 +366,8 @@ class DummyDataset(_StatefulDataset):
 
     def setup(self):
         super().setup()
-        self.generator = torch.Generator().manual_seed(self.seed + self.rank + len(self.datapath) * 100)
+        if self.generator is None:
+            self.generator = torch.Generator().manual_seed(self.seed + self.rank + len(self.datapath) * 100)
 
     def __iter__(self):
         self.setup()

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -623,6 +623,7 @@ def load_distributed_state_dict(
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)
     inp = _load_state_dict_from_keys(
+        keys=set("state", "dstate"),
         storage_reader = reader,
     )  # NOTE: assumes inp["state"] is same across all devices
     # checkpoint.load_state_dict(

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -629,6 +629,7 @@ def load_distributed_state_dict(
     #     inp,
     #     reader,
     # )
+    print(inp)
     dstate = inp["dstate"]
     # Re-pack the set of rankX args
     ranked_state = {k:dstate.pop(k) for k in dstate if "rank" in k}

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -614,7 +614,7 @@ def load_distributed_state_dict(
     )
     dstate = inp["dstate"]
     # De-DTensor-fy the shard states
-    dstate["ScalableReader.shard_states"] = dstate["ScalableReader.shard_states"].to_local()
+    dstate["ScalableReader.shard_states"] = dstate["ScalableReader.shard_states"].full_tensor()
     # Check that number of workers matches
     ckp_ws = 0 if not os.path.exists(path) else len([x for x in os.listdir(path) if "loader" in x])
     if ckp_ws == loader.dataset.worldsize and nworkers == state["_snapshot"]["_main_snapshot"]["_num_workers"]:

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -613,6 +613,8 @@ def load_distributed_state_dict(
         reader,
     )
     dstate = inp["dstate"]
+    # De-DTensor-fy the shard states
+    dstate["ScalableReader.shard_states"] = dstate["ScalableReader.shard_states"].to_local()
     # Check that number of workers matches
     ckp_ws = 0 if not os.path.exists(path) else len([x for x in os.listdir(path) if "loader" in x])
     if ckp_ws == loader.dataset.worldsize and nworkers == state["_snapshot"]["_main_snapshot"]["_num_workers"]:

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -484,6 +484,7 @@ class ScalableReader(_StatefulDataset):
         })
     
     def load_state_dict(self, state_dict):
+        print("GOTHERE 2")
         self.setup()
         # Load back shard states (global), filesizes (all)
         shard_states = state_dict[self.statename("shard_states")]
@@ -631,4 +632,5 @@ def load_distributed_state_dict(
     for i in range(nworkers):
         state["_snapshot"]["_worker_snapshots"][f"worker_{i}"]["dataset_state"] = dstate[i]
     # Load into loader
+    print("GOTHERE")
     loader.load_state_dict(state)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -525,8 +525,7 @@ class ScalableReader(_StatefulDataset):
             # Reverse sort incomplete shards by length
             incomplete_shards.sort(key=len, reverse=True)
 
-            if self.rank == 0:
-                print([len(x) for x in completed_shards], [len(x) for x in incomplete_shards])
+            print("shardlen", [len(x) for x in completed_shards], [len(x) for x in incomplete_shards])
 
             # Pull out shard allocation for this worker
             # (sort/reverse-sort ensures allocations are off by no more than 1)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -604,7 +604,7 @@ def load_distributed_state_dict(
     """
     base = loader.state_dict()
     nworkers = base["_snapshot"]["_main_snapshot"]["_num_workers"]
-    dstate = __pop_dstate(base, device_mesh, [dtensor.placement_types.Replicate(0)], True)
+    dstate = __pop_dstate(base, device_mesh, [dtensor.placement_types.Replicate()], True)
     inp = {"state":deepcopy(base), "dstate":dstate}
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -493,6 +493,7 @@ class ScalableReader(_StatefulDataset):
             self.filesizes = file_info
             self.shard_states = shard_states[self.rank]
         else:
+            print("GOTHERE 3")
             shard_states = [s[0] for s in shard_states.split(1)]  # [w] n 5
             shard_states = torch.cat(shard_states, dim=0)  # wn 5
             # Sort shards by epoch count

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -388,7 +388,7 @@ class DummyDataset(_StatefulDataset):
     def state_dict(self):
         # Write generator state manually
         self.g_state = self.generator.get_state().tolist()
-        return super().state_dict()()
+        return super().state_dict()
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -524,6 +524,10 @@ class ScalableReader(_StatefulDataset):
             ]
             # Reverse sort incomplete shards by length
             incomplete_shards.sort(key=len, reverse=True)
+
+            if self.rank == 0:
+                print([len(x) for x in completed_shards], [len(x) for x in incomplete_shards])
+
             # Pull out shard allocation for this worker
             # (sort/reverse-sort ensures allocations are off by no more than 1)
             shard_states = torch.cat([

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -538,10 +538,13 @@ class ScalableReader(_StatefulDataset):
 
             # Pull out shard allocation for this worker
             # (sort/reverse-sort ensures allocations are off by no more than 1)
-            shard_states = torch.cat([
+            shards = [
                 completed_shards[self.rank],
                 incomplete_shards[self.rank]
-            ])
+            ]
+            if self.rank == 4:
+                print(shards)
+            shard_states = torch.cat(shards)
             # Order shards by global ID (for steady file progression)
             _, indices = shard_states[:,0].sort()
             self.shard_states[:len(shard_states)] = shard_states[indices]
@@ -630,7 +633,6 @@ def load_distributed_state_dict(
     #     inp,
     #     reader,
     # )
-    print(inp)
     dstate = inp["dstate"]
     # Re-pack the set of rankX args
     keys = list(dstate.keys())

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -585,9 +585,8 @@ def load_distributed_state_dict(
     """
     base = loader.state_dict()
     nworkers = base["_snapshot"]["_main_snapshot"]["_num_workers"]
-    rank = loader.dataset.rank
     dstate = __pop_dstate(base, device_mesh, [dtensor.placement_types.Shard(0)])  # placements)
-    inp = {"state":base, "dstate":dstate}
+    inp = {"state":deepcopy(base), "dstate":dstate}
     # Read nondistributed state dict
     ckp_ws = 0 if not os.path.exists(path) else len(os.listdir(path))
     # Read distributed state dict

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -534,16 +534,12 @@ class ScalableReader(_StatefulDataset):
             # Reverse sort incomplete shards by length
             incomplete_shards.sort(key=len, reverse=True)
 
-            print("shardlen", [len(x) for x in completed_shards], [len(x) for x in incomplete_shards])
-
             # Pull out shard allocation for this worker
             # (sort/reverse-sort ensures allocations are off by no more than 1)
             shards = [
                 completed_shards[self.rank],
                 incomplete_shards[self.rank]
             ]
-            if self.rank == 4:
-                print(shards)
             shard_states = torch.cat(shards)
             # Order shards by global ID (for steady file progression)
             _, indices = shard_states[:,0].sort()

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from typing import Any, Callable, List
 
 import torch
-import torch.distributed as dist
+from torch.distributed import checkpoint
 import torch.distributed.tensor as dtensor
 import torch.utils.data as data
 
@@ -569,8 +569,8 @@ def save_distributed_state_dict(
     state = deepcopy(loader.state_dict())
     dstate = __pop_dstate(state, device_mesh, [dtensor.placement_types.Shard(0)])
     # Write distributed state dict
-    writer = dist.checkpoint.FileSystemWriter(path)
-    dist.checkpoint.save(
+    writer = checkpoint.FileSystemWriter(path)
+    checkpoint.save(
         dstate,
         writer,
     )
@@ -606,8 +606,8 @@ def load_distributed_state_dict(
         # On mismatch, discard saved non-reshardable loader state and start fresh
         state = base
     # Read distributed state dict
-    reader = dist.checkpoint.FileSystemReader(path)
-    dist.checkpoint.load_state_dict(
+    reader = checkpoint.FileSystemReader(path)
+    checkpoint.load_state_dict(
         dstate,
         reader,
     )

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -633,6 +633,7 @@ def load_distributed_state_dict(
         # On mismatch, discard saved non-reshardable loader state and start fresh
         state = base
     # Repeat global tensor over all workers
+    print(inp["dstate"])
     dstate = [inp["dstate"],]*nworkers
     # Re-insert worker states into loader state
     for i in range(nworkers):

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, List, Optional, Set
 
 import torch
 from torch.distributed import checkpoint
+from torch.distributed.checkpoint import _load_state_dict_from_keys
 import torch.distributed.tensor as dtensor
 import torch.distributed as dist
 import torch.utils.data as data
@@ -621,7 +622,7 @@ def load_distributed_state_dict(
     inp = {"state":deepcopy(base), "dstate":dstate}
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)
-    inp = checkpoint._load_state_dict_from_keys(storage_reader = reader)  # NOTE: assumes inp["state"] is same across all devices
+    inp = _load_state_dict_from_keys(storage_reader = reader)  # NOTE: assumes inp["state"] is same across all devices
     # checkpoint.load_state_dict(
     #     inp,
     #     reader,

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -479,7 +479,7 @@ class ScalableReader(_StatefulDataset):
         # Values to save: shard states (shard/repl), filesizes (single/repl)
         # Deepcopy required to prevent in-place modification from later prefetches
         return deepcopy({
-            self.statename("shard_states"): self.shard_states.unsqueeze(0),
+            self.statename("shard_states"): self.shard_states,
             self.statename("file_info"): self.filesizes if self.rank == 0 else None
         })
     
@@ -498,8 +498,8 @@ class ScalableReader(_StatefulDataset):
             self.shard_states = shard_states[self.rank]
         else:
             print("GOTHERE 3")
-            shard_states = [s[0] for s in shard_states.split(1)]  # [w] n 5
-            shard_states = torch.cat(shard_states, dim=0)  # wn 5
+            # shard_states = [s[0] for s in shard_states.split(1)]  # [w] n 5
+            # shard_states = torch.cat(shard_states, dim=0)  # wn 5
             # Sort shards by epoch count
             sorted, indices = torch.sort(shard_states[:,4], descending=True, stable=True)
             shard_states = shard_states[indices]

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -604,7 +604,7 @@ def load_distributed_state_dict(
     """
     base = loader.state_dict()
     nworkers = base["_snapshot"]["_main_snapshot"]["_num_workers"]
-    dstate = __pop_dstate(base, device_mesh, [dtensor.placement_types.Replicate()], True)
+    dstate = __pop_dstate(base, device_mesh, [dtensor.placement_types.Shard(0)], True)
     inp = {"state":deepcopy(base), "dstate":dstate}
     # Read distributed state dict
     reader = checkpoint.FileSystemReader(path)

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -633,7 +633,8 @@ def load_distributed_state_dict(
     print(inp)
     dstate = inp["dstate"]
     # Re-pack the set of rankX args
-    ranked_state = {k:dstate.pop(k) for k in dstate if "rank" in k}
+    keys = list(dstate.keys())
+    ranked_state = {k:dstate.pop(k) for k in keys if "rank" in k}
     ranked_keylist = sorted(list(ranked_state.keys()))
     compiled_ranked = [ranked_state[k] for k in ranked_keylist]
     dstate[ranked_keylist[0][6:]] = compiled_ranked  # Drop "rank0." prefix

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -633,7 +633,7 @@ def load_distributed_state_dict(
         # On mismatch, discard saved non-reshardable loader state and start fresh
         state = base
     # Repeat global tensor over all workers
-    print(inp["dstate"]["ScalableReader.shard_states"][:,0].tolist())
+    print(inp["dstate"]["ScalableReader.shard_states"][:,0])
     dstate = [inp["dstate"],]*nworkers
     # Re-insert worker states into loader state
     for i in range(nworkers):

--- a/torchdata/stateful_dataloader/ibm_rescalable.py
+++ b/torchdata/stateful_dataloader/ibm_rescalable.py
@@ -392,9 +392,8 @@ class DummyDataset(_StatefulDataset):
 
     def load_state_dict(self, state_dict):
         super().load_state_dict(state_dict)
-        # Manually set generator state if it exists
-        if self.g_state is not None:
-            self.generator.set_state(torch.tensor(self.g_state, dtype=torch.uint8))
+        # Manually set generator state
+        self.generator.set_state(torch.tensor(self.g_state, dtype=torch.uint8))
 
 
 class ScalableShardDataset(_WrapperDataset):


### PR DESCRIPTION
Implements rescaling of checkpoints to different world sizes and numbers of workers. User specifies in advance the number of data partitions, and when saving/loading checkpoints with different total workers, stateful guarantees are maintained: seen data is not revisited until the next epoch.

Based off of the datasets in the corresponding IBM [torchtitan PR](https://github.com/pytorch/torchtitan/pull/376), but with an adjusted rescaling and iteration mechanism to support greater flexibility and robustness (removes divisibility constraints from worker and shard counts, and guarantees only one open file per physical worker regardless of number of logical shards). Uses StatefulDataLoader and DCP to manage checkpointing from the master process. An epoch completion testing script is included for demo purposes. It is possible that the IBM datasets can be merged into the existing torchdata Nodes structure.

### Changes

- Add IBM rescalable datasets and checkpointing functions to `torchdata/stateful_dataloader/ibm_rescalable.py`
- Add demo script and correctness check to `examples/ibm_rescaling/rescaling_demo.py`
