### PR TITLE
Add flag for non-daemonic _read_thread in ParallelMapper

### DIFF
--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -410,7 +410,7 @@ class ParallelMapper(BaseNode[T]):
         max_concurrent: Optional[int] = None,
         snapshot_frequency: int = 1,
         prebatch: Optional[int] = None,
-        daemonic_reading: Optional[bool] = False,
+        daemonic_reading: bool = False,
     ):
         super().__init__()
         assert method in ["thread", "process"]

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -408,7 +408,7 @@ class ParallelMapper(BaseNode[T]):
         max_concurrent: Optional[int] = None,
         snapshot_frequency: int = 1,
         prebatch: Optional[int] = None,
-        daemonic_reading: bool = False,
+        daemonic_reading: bool = True,
     ):
         super().__init__()
         assert method in ["thread", "process"]

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -141,6 +141,7 @@ class _ParallelMapperIter(Iterator[T]):
         max_concurrent: Optional[int],
         snapshot_frequency: int,
         initial_state: Optional[Dict[str, Any]],
+        daemonic_reading: bool,
     ):
         self.source = source
         self.map_fn = map_fn
@@ -149,6 +150,7 @@ class _ParallelMapperIter(Iterator[T]):
         self.method = method
         self.mp_context = mp_context
         self.snapshot_frequency = snapshot_frequency
+        self.daemonic_reading = daemonic_reading
 
         self._in_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
         self._intermed_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
@@ -182,7 +184,7 @@ class _ParallelMapperIter(Iterator[T]):
                 self._stop,
             ),
             name="read_thread(target=_populate_queue)",
-            daemon=True,
+            daemon=self.daemonic_reading,
         )
         self._workers: List[Union[threading.Thread, mp.Process]] = []
         for worker_id in range(self.num_workers):
@@ -281,7 +283,9 @@ class _ParallelMapperIter(Iterator[T]):
 
     def _shutdown(self):
         self._stop.set()
+        print("ss...")
         self._mp_stop.set()
+        print("ss.!!..")
         if hasattr(self, "_read_thread") and self._read_thread.is_alive():
             self._read_thread.join(timeout=QUEUE_TIMEOUT * 5)
         if hasattr(self, "_sort_thread") and self._sort_thread.is_alive():
@@ -311,6 +315,7 @@ class _ParallelMapperImpl(BaseNode[T]):
         multiprocessing_context: Optional[str] = None,
         max_concurrent: Optional[int] = None,
         snapshot_frequency: int = 1,
+        daemonic_reading: bool = True,
     ):
         super().__init__()
         assert method in ["thread", "process"]
@@ -329,6 +334,7 @@ class _ParallelMapperImpl(BaseNode[T]):
                 raise ValueError(f"{max_concurrent=} should be <= {num_workers=}!")
         self.max_concurrent = max_concurrent
         self.snapshot_frequency = snapshot_frequency
+        self.daemonic_reading = daemonic_reading
         self._it: Optional[Union[_InlineMapperIter[T], _ParallelMapperIter[T]]] = None
 
     def reset(self, initial_state: Optional[Dict[str, Any]] = None):
@@ -355,6 +361,7 @@ class _ParallelMapperImpl(BaseNode[T]):
             max_concurrent=self.max_concurrent,
             snapshot_frequency=self.snapshot_frequency,
             initial_state=initial_state,
+            daemonic_reading=self.daemonic_reading,
         )
 
     def next(self) -> T:
@@ -403,6 +410,7 @@ class ParallelMapper(BaseNode[T]):
         max_concurrent: Optional[int] = None,
         snapshot_frequency: int = 1,
         prebatch: Optional[int] = None,
+        daemonic_reading: Optional[bool] = False,
     ):
         super().__init__()
         assert method in ["thread", "process"]
@@ -416,6 +424,7 @@ class ParallelMapper(BaseNode[T]):
         self.max_concurrent = max_concurrent
         self.snapshot_frequency = snapshot_frequency
         self.prebatch = prebatch
+        self.daemonic_reading = daemonic_reading
         if prebatch is None:
             self.map_fn = map_fn
             self.source = source
@@ -434,6 +443,7 @@ class ParallelMapper(BaseNode[T]):
             multiprocessing_context=self.multiprocessing_context,
             max_concurrent=self.max_concurrent,
             snapshot_frequency=self.snapshot_frequency,
+            daemonic_reading=self.daemonic_reading,
         )
 
         if self.prebatch is None:

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -283,9 +283,7 @@ class _ParallelMapperIter(Iterator[T]):
 
     def _shutdown(self):
         self._stop.set()
-        print("ss...")
         self._mp_stop.set()
-        print("ss.!!..")
         if hasattr(self, "_read_thread") and self._read_thread.is_alive():
             self._read_thread.join(timeout=QUEUE_TIMEOUT * 5)
         if hasattr(self, "_sort_thread") and self._sort_thread.is_alive():


### PR DESCRIPTION
The daemonic _read_thread causes issues at exit in certain circumstances in which the `source` object that it refers to does not get collected by the garbage collector. Allowing the user to toggle this thread to be non-daemonic prevents this issue.