### PR TITLE
Replace launching explicit threads with a threadpoolexecutor

### DIFF
--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -48,12 +48,12 @@ class TestMap(TestCase):
     def test_exception_handling_mapper_cuda(self):
         self._test_exception_handling_mapper(True, "thread")
 
-    def test_exception_handling_mapper_multiprocess(self):
-        self._test_exception_handling_mapper(False, "process")
+    # def test_exception_handling_mapper_multiprocess(self):
+    #     self._test_exception_handling_mapper(False, "process")
 
-    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    def test_exception_handling_mapper_multiprocess_cuda(self):
-        self._test_exception_handling_mapper(True, "process")
+    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    # def test_exception_handling_mapper_multiprocess_cuda(self):
+    #     self._test_exception_handling_mapper(True, "process")
 
     def _test_map(self, in_order, method, prebatch) -> None:
         batch_size = 6
@@ -131,7 +131,11 @@ class TestMap(TestCase):
         )
     )
     def test_save_load_state_thread(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int, prebatch: Optional[int]
+        self,
+        midpoint: int,
+        in_order: bool,
+        snapshot_frequency: int,
+        prebatch: Optional[int],
     ):
         method = "thread"
         batch_size = 6
@@ -159,7 +163,11 @@ class TestMap(TestCase):
         )
     )
     def test_save_load_state_process(
-        self, midpoint: int, in_order: bool, snapshot_frequency: int, prebatch: Optional[int]
+        self,
+        midpoint: int,
+        in_order: bool,
+        snapshot_frequency: int,
+        prebatch: Optional[int],
     ):
         method = "process"
         batch_size = 6

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -5,9 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
-
 import unittest
 from typing import List, Optional
+from unittest import mock
 
 from parameterized import parameterized
 from torch.testing._internal.common_utils import IS_WINDOWS, TEST_CUDA, TestCase
@@ -187,3 +187,56 @@ class TestMap(TestCase):
         )
         node = Prefetcher(node, prefetch_factor=2)
         run_test_save_load_state(self, node, midpoint)
+
+    def test_thread_pool_executor_shutdown_on_del(self):
+        """Test that the ThreadPoolExecutor is properly shut down when the iterator is deleted."""
+        # Create a ParallelMapper with method="thread"
+        src = MockSource(num_samples=10)
+        node = ParallelMapper(
+            src,
+            RandomSleepUdf(),
+            num_workers=2,
+            method="thread",
+        )
+
+        # Reset the node to create the iterator
+        node.reset()
+
+        # We need to consume some items to ensure the ThreadPoolExecutor is created
+        # and the worker threads are started
+        for _ in range(5):
+            next(node)
+
+        # Use mock.patch to intercept the ThreadPoolExecutor.shutdown method
+        with mock.patch("concurrent.futures.ThreadPoolExecutor.shutdown") as mock_shutdown:
+            # Delete the node, which should trigger the shutdown of the ThreadPoolExecutor
+            del node
+
+            # Verify that shutdown was called
+            mock_shutdown.assert_called()
+
+    def test_thread_pool_executor_shutdown_on_exception(self):
+        """Test that the ThreadPoolExecutor is properly shut down when the iterator is deleted."""
+        # Create a ParallelMapper with method="thread"
+        src = MockSource(num_samples=10)
+        node = ParallelMapper(
+            src,
+            udf_raises,
+            num_workers=2,
+            method="thread",
+        )
+
+        # Reset the node to create the iterator
+        node.reset()
+
+        # Use mock.patch to intercept the ThreadPoolExecutor.shutdown method
+        with mock.patch("concurrent.futures.ThreadPoolExecutor.shutdown") as mock_shutdown:
+            # Consumer the iterator to ensure the ThreadPoolExecutor is created
+            # and exception is raised
+            try:
+                next(node)
+            except ValueError:
+                pass
+
+            # Verify that shutdown was called
+            mock_shutdown.assert_called()

--- a/test/nodes/test_map.py
+++ b/test/nodes/test_map.py
@@ -48,12 +48,12 @@ class TestMap(TestCase):
     def test_exception_handling_mapper_cuda(self):
         self._test_exception_handling_mapper(True, "thread")
 
-    # def test_exception_handling_mapper_multiprocess(self):
-    #     self._test_exception_handling_mapper(False, "process")
+    def test_exception_handling_mapper_multiprocess(self):
+        self._test_exception_handling_mapper(False, "process")
 
-    # @unittest.skipIf(not TEST_CUDA, "CUDA not found")
-    # def test_exception_handling_mapper_multiprocess_cuda(self):
-    #     self._test_exception_handling_mapper(True, "process")
+    @unittest.skipIf(not TEST_CUDA, "CUDA not found")
+    def test_exception_handling_mapper_multiprocess_cuda(self):
+        self._test_exception_handling_mapper(True, "process")
 
     def _test_map(self, in_order, method, prebatch) -> None:
         batch_size = 6

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -294,6 +294,7 @@ class _ParallelMapperIter(Iterator[T]):
             elif isinstance(item, ExceptionWrapper):
                 if not isinstance(item, StartupExceptionWrapper):
                     self._sem.release()
+                    self._shutdown()
                 item.reraise()
 
             self._steps_since_snapshot += 1

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -8,8 +8,8 @@ import queue
 import threading
 import time
 
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from typing import Any, Callable, Dict, Generic, Iterator, Literal, Optional, Protocol, Sequence, TypeVar, Union
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Dict, Generic, Iterator, List, Literal, Optional, Protocol, Sequence, TypeVar, Union
 
 import torch.multiprocessing as mp
 from torchdata.nodes.base_node import BaseNode, T
@@ -98,12 +98,12 @@ def _sort_worker(
 
 
 def _transformation_pool(
-    pool: Union[ProcessPoolExecutor, ThreadPoolExecutor],
+    pool: ThreadPoolExecutor,
     num_workers: int,
-    in_q: Union[queue.Queue, mp.Queue],
-    out_q: Union[queue.Queue, mp.Queue],
+    in_q: queue.Queue,
+    out_q: queue.Queue,
     map_fn: Callable[[X], T],
-    stop_event: Union[threading.Event, mp.Event],
+    stop_event: threading.Event,
 ):
     for worker_id in range(num_workers):
         args = (
@@ -113,7 +113,7 @@ def _transformation_pool(
             map_fn,
             stop_event,
         )
-        pool.submit(_apply_udf, *args)  # type: ignore[union-attr]
+        pool.submit(_apply_udf, *args)
 
 
 class _InlineMapperIter(Iterator[T]):
@@ -211,45 +211,33 @@ class _ParallelMapperIter(Iterator[T]):
             name="read_thread(target=_populate_queue)",
             daemon=self.daemonic_reading,
         )
+        self._read_thread.start()
 
-        if self.method == "process":
-            self.pool = ProcessPoolExecutor(max_workers=self.num_workers)
-        elif self.method == "thread":
+        if self.method == "thread":
             self.pool = ThreadPoolExecutor(max_workers=self.num_workers)
 
-        self._transformation_thread = threading.Thread(
-            target=_transformation_pool,  # make this sit outside of the class?
-            args=(
+            _transformation_pool(
                 self.pool,
                 self.num_workers,
                 self._in_q,
                 self._intermed_q,
                 self.map_fn,
-                self._stop if self.method == "thread" else self._mp_stop,
-            ),
-            name="transformation_thread(target=transformation_pool)",
-            daemon=True,
-        )
-        self._transformation_thread.start()
+                self._stop,
+            )
 
-        # for worker_id in range(self.num_workers):
-        #     args = (
-        #         worker_id,
-        #         self._in_q,
-        #         self._intermed_q,
-        #         self.map_fn,
-        #         self._stop if self.method == "thread" else self._mp_stop,
-        #     )
-        #     self._workers.append(
-        #         threading.Thread(
-        #             target=_apply_udf,
-        #             args=args,
-        #             daemon=True,
-        #             name=f"worker_thread_{worker_id}(target=_apply_udf)",
-        #         )
-        #         if self.method == "thread"
-        #         else mp_context.Process(target=_apply_udf, args=args, daemon=True)
-        #     )
+        elif self.method == "process":
+            self._workers: List[mp.Process] = []
+            for worker_id in range(self.num_workers):
+                args = (
+                    worker_id,
+                    self._in_q,
+                    self._intermed_q,
+                    self.map_fn,
+                    self._mp_stop,
+                )
+                self._workers.append(mp_context.Process(target=_apply_udf, args=args, daemon=True))
+            for t in self._workers:
+                t.start()
 
         self._out_q = self._intermed_q
         if self.in_order:
@@ -266,9 +254,6 @@ class _ParallelMapperIter(Iterator[T]):
             )
             self._out_q = self._sort_q
 
-        self._read_thread.start()
-        # for t in self._workers:
-        #     t.start()
         if self.in_order:
             self._sort_thread.start()
 
@@ -335,15 +320,14 @@ class _ParallelMapperIter(Iterator[T]):
         self._mp_stop.set()
         if hasattr(self, "_read_thread") and self._read_thread.is_alive():
             self._read_thread.join(timeout=QUEUE_TIMEOUT * 5)
-        self.pool.shutdown(wait=True)
-        if hasattr(self, "_transformation_thread") and self._transformation_thread.is_alive():
-            self._transformation_thread.join(timeout=QUEUE_TIMEOUT * 5)
+        if hasattr(self, "pool"):
+            self.pool.shutdown(wait=True)
+        if hasattr(self, "_workers"):
+            for t in self._workers:
+                if t.is_alive():
+                    t.join(timeout=QUEUE_TIMEOUT * 5)
         if hasattr(self, "_sort_thread") and self._sort_thread.is_alive():
             self._sort_thread.join(timeout=QUEUE_TIMEOUT * 5)
-        # if hasattr(self, "_workers"):
-        #     for t in self._workers:
-        #         if t.is_alive():
-        #             t.join(timeout=QUEUE_TIMEOUT * 5)
 
 
 class _ParallelMapperImpl(BaseNode[T]):

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -67,7 +67,11 @@ class MapOverBatch(Generic[X, T]):
         return [self.map_fn(x) for x in xlist]
 
 
-def _sort_worker(in_q: Union[queue.Queue, mp.Queue], out_q: queue.Queue, stop_event: threading.Event):
+def _sort_worker(
+    in_q: Union[queue.Queue, mp.Queue],
+    out_q: queue.Queue,
+    stop_event: threading.Event,
+):
     buffer: Dict[int, Any] = {}
     cur_idx = 0
     while not stop_event.is_set():
@@ -91,6 +95,25 @@ def _sort_worker(in_q: Union[queue.Queue, mp.Queue], out_q: queue.Queue, stop_ev
         while cur_idx in buffer:
             out_q.put((buffer.pop(cur_idx), cur_idx), block=False)
             cur_idx += 1
+
+
+def _transformation_pool(
+    pool: Union[ProcessPoolExecutor, ThreadPoolExecutor],
+    num_workers: int,
+    in_q: Union[queue.Queue, mp.Queue],
+    out_q: Union[queue.Queue, mp.Queue],
+    map_fn: Callable[[X], T],
+    stop_event: Union[threading.Event, mp.Event],
+):
+    for worker_id in range(num_workers):
+        args = (
+            worker_id,
+            in_q,
+            out_q,
+            map_fn,
+            stop_event,
+        )
+        pool.submit(_apply_udf, *args)  # type: ignore[union-attr]
 
 
 class _InlineMapperIter(Iterator[T]):
@@ -195,7 +218,15 @@ class _ParallelMapperIter(Iterator[T]):
             self.pool = ThreadPoolExecutor(max_workers=self.num_workers)
 
         self._transformation_thread = threading.Thread(
-            target=self._transformation_pool,
+            target=_transformation_pool,  # make this sit outside of the class?
+            args=(
+                self.pool,
+                self.num_workers,
+                self._in_q,
+                self._intermed_q,
+                self.map_fn,
+                self._stop if self.method == "thread" else self._mp_stop,
+            ),
             name="transformation_thread(target=transformation_pool)",
             daemon=True,
         )
@@ -225,7 +256,11 @@ class _ParallelMapperIter(Iterator[T]):
             self._sort_q: queue.Queue = queue.Queue()
             self._sort_thread = threading.Thread(
                 target=_sort_worker,
-                args=(self._intermed_q, self._sort_q, self._stop),
+                args=(
+                    self._intermed_q,
+                    self._sort_q,
+                    self._stop,
+                ),
                 daemon=True,
                 name="sort_thread(target=_sort_worker)",
             )
@@ -248,17 +283,6 @@ class _ParallelMapperIter(Iterator[T]):
                     f"Tried to fast-forward {fast_forward} items during init but "
                     f"hit StopIteration after {i} items, this is likely a bug or malformed state_dict"
                 )
-
-    def _transformation_pool(self):
-        for worker_id in range(self.num_workers):
-            args = (
-                worker_id,
-                self._in_q,
-                self._intermed_q,
-                self.map_fn,
-                self._stop if self.method == "thread" else self._mp_stop,
-            )
-            self.pool.submit(_apply_udf, *args)  # type: ignore[union-attr]
 
     def __iter__(self) -> Iterator[T]:
         return self
@@ -311,13 +335,15 @@ class _ParallelMapperIter(Iterator[T]):
         self._mp_stop.set()
         if hasattr(self, "_read_thread") and self._read_thread.is_alive():
             self._read_thread.join(timeout=QUEUE_TIMEOUT * 5)
+        self.pool.shutdown(wait=True)
+        if hasattr(self, "_transformation_thread") and self._transformation_thread.is_alive():
+            self._transformation_thread.join(timeout=QUEUE_TIMEOUT * 5)
         if hasattr(self, "_sort_thread") and self._sort_thread.is_alive():
             self._sort_thread.join(timeout=QUEUE_TIMEOUT * 5)
         # if hasattr(self, "_workers"):
         #     for t in self._workers:
         #         if t.is_alive():
         #             t.join(timeout=QUEUE_TIMEOUT * 5)
-        self.pool.shutdown(wait=True)
 
 
 class _ParallelMapperImpl(BaseNode[T]):


### PR DESCRIPTION
## Context
Current `ParallelMapper` has the following model:  

Arrows and dotted line represent the main process
 ---->----(spawn a background read_thread)---->---(start explicit transformation threads)---->---(spawn a background sort_thread)---->----

## Change
We are updating that to be:
 ---->----(spawn a background read_thread)  ---->----(start transformation threads within a threadpoolexecutor)---->----(spawn a background sort_thread) ---->----

Here we do not update the `method=process` workflow.

### Edit
Unit tests looks good on local. Tested GPU unit tests internally. 

Benchmarked thread pool vs explicit thread creation for transformation, almost identical performance in both settings.