### PR TITLE
Fix an example in docs by properly importing torch.utils.data.RandomSampler

### DIFF
--- a/docs/source/getting_started_with_torchdata_nodes.rst
+++ b/docs/source/getting_started_with_torchdata_nodes.rst
@@ -32,7 +32,7 @@ example.
 
 .. code:: python
 
-   import torch.utils.data
+   from torch.utils.data import RandomSampler
    from torchdata.nodes import SamplerWrapper, ParallelMapper, Loader
 
 


### PR DESCRIPTION
Hi, I am just fixing an example where `torch.utils.data.RandomSampler` is not properly imported.