### PR TITLE
Give an option to either provide dataset or dataset_size in distributed sampler

### DIFF
--- a/torchdata/stateful_dataloader/sampler.py
+++ b/torchdata/stateful_dataloader/sampler.py
@@ -5,7 +5,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import itertools
+import math
 from typing import Any, Dict, Iterator, List, Optional, Sized
+
+import torch.distributed as dist
 
 import torch.utils.data.sampler
 from torch.utils.data import Dataset
@@ -179,19 +182,56 @@ class BatchSampler(torch.utils.data.sampler.BatchSampler):
         )
 
 
-class StatefulDistributedSampler(torch.utils.data.distributed.DistributedSampler):
+class StatefulDistributedSampler(Sampler[int]):
     _YIELDED = "yielded"
 
     def __init__(
         self,
-        dataset: Dataset,
+        dataset: Optional[Dataset] = None,
         num_replicas: Optional[int] = None,
         rank: Optional[int] = None,
         shuffle: bool = True,
         seed: int = 0,
         drop_last: bool = False,
+        dataset_size: Optional[int] = None,
     ) -> None:
-        super().__init__(dataset, num_replicas, rank, shuffle, seed, drop_last)
+
+        # Validate inputs
+        if dataset is None and dataset_size is None:
+            raise ValueError("Either dataset or dataset_size must be provided.")
+        if dataset is not None and dataset_size is not None and dataset_size != len(dataset):
+            raise ValueError(f"dataset_size must match the length of the dataset. {dataset_size=} and {len(dataset)=}")
+
+        if num_replicas is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            num_replicas = dist.get_world_size()
+        if rank is None:
+            if not dist.is_available():
+                raise RuntimeError("Requires distributed package to be available")
+            rank = dist.get_rank()
+        if rank >= num_replicas or rank < 0:
+            raise ValueError(f"Invalid rank {rank}, rank should be in the interval [0, {num_replicas - 1}]")
+        self.dataset_size = dataset_size if dataset_size is not None else len(dataset)
+        self.num_replicas = num_replicas
+        self.rank = rank
+        self.epoch = 0
+        self.drop_last = drop_last
+        # If the dataset length is evenly divisible by # of replicas, then there
+        # is no need to drop any data, since the dataset will be split equally.
+        if self.drop_last and self.dataset_size % self.num_replicas != 0:  # type: ignore[arg-type]
+            # Split to nearest available length that is evenly divisible.
+            # This is to ensure each rank receives the same amount of data when
+            # using this Sampler.
+            self.num_samples = math.ceil(
+                (self.dataset_size - self.num_replicas) / self.num_replicas  # type: ignore[arg-type]
+            )
+        else:
+            self.num_samples = math.ceil(self.dataset_size / self.num_replicas)  # type: ignore[arg-type]
+        self.total_size = self.num_samples * self.num_replicas
+        self.shuffle = shuffle
+        self.seed = seed
+
         self.yielded = 0
         self.next_yielded = None
 
@@ -200,10 +240,51 @@ class StatefulDistributedSampler(torch.utils.data.distributed.DistributedSampler
         if self.next_yielded is not None:
             self.yielded = self.next_yielded
             self.next_yielded = None
-        it = super().__iter__()
+        if self.shuffle:
+            # deterministically shuffle based on epoch and seed
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch)
+            indices = torch.randperm(self.dataset_size, generator=g).tolist()  # type: ignore[arg-type]
+        else:
+            indices = list(range(self.dataset_size))  # type: ignore[arg-type]
+
+        if not self.drop_last:
+            # add extra samples to make it evenly divisible
+            padding_size = self.total_size - len(indices)
+            if padding_size <= len(indices):
+                indices += indices[:padding_size]
+            else:
+                indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
+        else:
+            # remove tail of data to make it evenly divisible.
+            indices = indices[: self.total_size]
+        assert len(indices) == self.total_size
+
+        # subsample
+        indices = indices[self.rank : self.total_size : self.num_replicas]
+        assert len(indices) == self.num_samples
+
+        it = iter(indices)
+
         for idx in itertools.islice(it, self.yielded, None):
             self.yielded += 1
             yield idx
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def set_epoch(self, epoch: int) -> None:
+        r"""
+        Set the epoch for this sampler.
+
+        When :attr:`shuffle=True`, this ensures all replicas
+        use a different random ordering for each epoch. Otherwise, the next iteration of this
+        sampler will yield the same ordering.
+
+        Args:
+            epoch (int): Epoch number.
+        """
+        self.epoch = epoch
 
     def state_dict(self) -> Dict[str, Any]:
         return {self._YIELDED: self.yielded}


### PR DESCRIPTION
Currently the StatefulDistributedSampler takes the dataset as an argument, but only uses the length/size of the dataset. 
Adding an option to provide size of the dataset instead, for more flexibility. 