### PR TITLE
Explicit iterator shutdown

### DIFF
--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -377,6 +377,7 @@ class _ParallelMapperImpl(BaseNode[T]):
     def reset(self, initial_state: Optional[Dict[str, Any]] = None):
         super().reset(initial_state)
         if self._it is not None:
+            self._it._shutdown()
             del self._it
 
         if self.num_workers > 0:


### PR DESCRIPTION
## Bug

Currently resetting `ParallelMap` kills threads with `del self._it`, which is not guaranteed to immediately call `self._it.__del__` and thus `._shutdown` method. It leads to an extra living read thread. This extra thread can consume extra items from `self.source` node, which will be missing from new `self._it`

I faced this issue with `lightning.pytorch` training. I could not figure out, if lightning just calls `iter` twice in a short time, or increases ref count of the old iterator object somehow, but as a matter of fact I have two running read threads, which breaks my pipeline at the first batch.

## Fix
Add explicit `self._it._shutdown()` into `reset` method. This fixes described bug
