### PR TITLE
Threadpoolexecutor in map

### DIFF
--- a/test/nodes/test_multi_node_weighted_sampler.py
+++ b/test/nodes/test_multi_node_weighted_sampler.py
@@ -333,10 +333,7 @@ class TestMultiNodeWeightedSampler(TestCase):
 
     def test_multi_node_weighted_sampler_tag_output_non_dict_items(self) -> None:
         """Test MultiNodeWeightedSampler with tag_output=True for non-dictionary items"""
-        non_dict_datasets = {
-            f"ds{i}": IterableWrapper(range(i * 10, (i + 1) * 10))
-            for i in range(self._num_datasets)
-        }
+        non_dict_datasets = {f"ds{i}": IterableWrapper(range(i * 10, (i + 1) * 10)) for i in range(self._num_datasets)}
 
         node = MultiNodeWeightedSampler(
             non_dict_datasets,

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -9,20 +9,7 @@ import threading
 import time
 
 from concurrent.futures import ThreadPoolExecutor
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterator,
-    List,
-    Literal,
-    Optional,
-    Protocol,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Generic, Iterator, List, Literal, Optional, Protocol, Sequence, TypeVar, Union
 
 import torch.multiprocessing as mp
 from torchdata.nodes.base_node import BaseNode, T
@@ -41,11 +28,14 @@ ACK_TIMEOUT = 300  # Timeout after 5 minutes
 
 # We define this protocol for type checking
 class _MultiprocessContext(Protocol):
-    def Process(self, *args, **kwargs): ...
+    def Process(self, *args, **kwargs):
+        ...
 
-    def Event(self, *args, **kwargs): ...
+    def Event(self, *args, **kwargs):
+        ...
 
-    def Queue(self, *args, **kwargs): ...
+    def Queue(self, *args, **kwargs):
+        ...
 
 
 X = TypeVar("X")
@@ -96,9 +86,7 @@ def _sort_worker(
             if idx in buffer:
                 # This is the easiest way to create an exception wrapper
                 try:
-                    raise ValueError(
-                        f"Duplicate index {idx=}, {buffer.keys()=}, {item=}"
-                    )
+                    raise ValueError(f"Duplicate index {idx=}, {buffer.keys()=}, {item=}")
                 except Exception:
                     item = ExceptionWrapper(where="in _sort_worker")
                 out_q.put((item, idx), block=False)
@@ -168,15 +156,9 @@ class _ParallelMapperIter(Iterator[T]):
         self.mp_context = mp_context
         self.snapshot_frequency = snapshot_frequency
 
-        self._in_q: Union[queue.Queue, mp.Queue] = (
-            queue.Queue() if method == "thread" else mp_context.Queue()
-        )
-        self._intermed_q: Union[queue.Queue, mp.Queue] = (
-            queue.Queue() if method == "thread" else mp_context.Queue()
-        )
-        self._max_tasks = (
-            2 * self.num_workers if max_concurrent is None else max_concurrent
-        )
+        self._in_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
+        self._intermed_q: Union[queue.Queue, mp.Queue] = queue.Queue() if method == "thread" else mp_context.Queue()
+        self._max_tasks = 2 * self.num_workers if max_concurrent is None else max_concurrent
         self._sem = threading.BoundedSemaphore(value=self._max_tasks)
 
         self._done = False
@@ -227,9 +209,7 @@ class _ParallelMapperIter(Iterator[T]):
                     self.map_fn,
                     self._mp_stop,
                 )
-                self._workers.append(
-                    mp_context.Process(target=_apply_udf, args=_args, daemon=True)
-                )
+                self._workers.append(mp_context.Process(target=_apply_udf, args=_args, daemon=True))
             for t in self._workers:
                 t.start()
 
@@ -245,9 +225,7 @@ class _ParallelMapperIter(Iterator[T]):
             self._out_q = self._sort_q
 
         time.sleep(0.01)
-        self._snapshot = self._snapshot_store.get_initial_snapshot(
-            thread=_read_future, timeout=ACK_TIMEOUT
-        )
+        self._snapshot = self._snapshot_store.get_initial_snapshot(thread=_read_future, timeout=ACK_TIMEOUT)
 
         for i in range(fast_forward):
             try:
@@ -369,9 +347,7 @@ class _ParallelMapperImpl(BaseNode[T]):
             self._it = self._inline_reset(initial_state)
 
     def _inline_reset(self, initial_state: Optional[Dict[str, Any]]):
-        return _InlineMapperIter(
-            source=self.source, map_fn=self.map_fn, initial_state=initial_state
-        )
+        return _InlineMapperIter(source=self.source, map_fn=self.map_fn, initial_state=initial_state)
 
     def _parallel_reset(self, initial_state: Optional[Dict[str, Any]]):
         return _ParallelMapperIter(
@@ -568,9 +544,7 @@ class _SingleThreadedMapper(Iterator[T]):
         self._thread.start()
 
         # Try and get initial snapshot
-        self._snapshot = self._snapshot_store.get_initial_snapshot(
-            thread=self._thread, timeout=ACK_TIMEOUT
-        )
+        self._snapshot = self._snapshot_store.get_initial_snapshot(thread=self._thread, timeout=ACK_TIMEOUT)
 
         for i in range(self._fast_forward):
             try:

--- a/torchdata/nodes/samplers/multi_node_weighted_sampler.py
+++ b/torchdata/nodes/samplers/multi_node_weighted_sampler.py
@@ -207,7 +207,6 @@ class MultiNodeWeightedSampler(BaseNode[T]):
 
         return item
 
-
     def get_state(self) -> Dict[str, Any]:
         return {
             self.DATASETS_EXHAUSTED_KEY: copy.deepcopy(self._datasets_exhausted),

--- a/torchdata/nodes/snapshot_store.py
+++ b/torchdata/nodes/snapshot_store.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 import queue
 import threading
 import time


### PR DESCRIPTION
This PR replaces reading thread and sorting thread with submissions to a thread pool executor. After this the parallelmapper will entirely be based on a thread pool rather explicit thread creation. 

We continue to maintain `num_workers + 2` and the pool size, with `num_workers`  being a knob for users to tune the threads to use for applying transformations. 