### PR TITLE
Keep _SingleThreadedMapper to continue using a daemon thread

### DIFF
--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -573,7 +573,7 @@ class _SingleThreadedMapper(Iterator[T]):
                 self._sem,
                 self._stop_event,
             ),
-            daemon=False,
+            daemon=True,
             name=f"worker_thread(target={self.worker.__name__})",
         )
         self._thread.start()


### PR DESCRIPTION
Summary:
We found some hanging unit tests in D74440999.

Reverting this back for now. I will add a cleaner shutdown as a follow up.

Differential Revision: D74673949


