### PR TITLE
Add non-blocking option in thread pool executor

### DIFF
--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -285,11 +285,14 @@ class _ParallelMapperIter(Iterator[T]):
     def __del__(self):
         self._shutdown()
 
-    def _shutdown(self):
+    def _shutdown(self, blocking=True):
         self._stop.set()
         self._mp_stop.set()
         if hasattr(self, "pool"):
-            self.pool.shutdown(wait=True)
+            if blocking:
+                self.pool.shutdown(wait=True)
+            else:
+                self.pool.shutdown(wait=False, cancel_futures=True)
         if hasattr(self, "_workers"):
             for t in self._workers:
                 if t.is_alive():


### PR DESCRIPTION
Summary:
This option will come handy when we add an explicit shutdown method which should be non-blocking and doesn't allow pending tasks to proceed.

This change is backwards compatible.

Differential Revision: D75312613


