### PR TITLE
Add shutdown method to nodes

### DIFF
--- a/test/nodes/test_pin_memory.py
+++ b/test/nodes/test_pin_memory.py
@@ -6,6 +6,7 @@
 
 import itertools
 import unittest
+from unittest import mock
 
 import torch
 
@@ -77,3 +78,17 @@ class TestPinMemory(TestCase):
         node = Prefetcher(node, prefetch_factor=8)
 
         run_test_save_load_state(self, node, midpoint)
+
+    def test_explicit_shutdown(self):
+        """Test that the explicit shutdown method properly shuts down the node."""
+        mock_source = mock.MagicMock()
+        mock_source.shutdown = mock.MagicMock()
+        node = PinMemory(
+            mock_source,
+        )
+        node.reset()
+        # Mock the _shutdown method of the iterator
+        with mock.patch.object(node._it, "_shutdown") as mock_shutdown:
+            node.shutdown()
+            mock_shutdown.assert_called_once()
+            mock_source.shutdown.assert_called_once()

--- a/torchdata/nodes/base_node.py
+++ b/torchdata/nodes/base_node.py
@@ -103,3 +103,11 @@ class BaseNode(Iterator[T]):
                     f"Failed to initialize after .reset(), did you call super().reset() in your .reset() method? {type(self)=}"
                 )
         return self.get_state()
+
+    def shutdown(self):
+        """Shutdown the node, freeing any resources it may be holding on to.
+
+        Shutting down should be take care of when the node is garbage collected, but it is recommended to call this explicitly
+        when the node is no longer needed.
+        """
+        pass

--- a/torchdata/nodes/pin_memory.py
+++ b/torchdata/nodes/pin_memory.py
@@ -155,3 +155,9 @@ class PinMemory(BaseNode[T]):
 
     def get_state(self) -> Dict[str, Any]:
         return self._it.get_state()  # type: ignore[union-attr]
+
+    def shutdown(self):
+        if self._it is not None:
+            self._it._shutdown()
+        if hasattr(self.source, "shutdown"):
+            self.source.shutdown()

--- a/torchdata/nodes/prefetch.py
+++ b/torchdata/nodes/prefetch.py
@@ -50,3 +50,9 @@ class Prefetcher(BaseNode[T]):
 
     def get_state(self) -> Dict[str, Any]:
         return self._it.get_state()  # type: ignore[union-attr]
+
+    def shutdown(self):
+        if self._it is not None:
+            self._it._shutdown()
+        if hasattr(self.source, "shutdown"):
+            self.source.shutdown()


### PR DESCRIPTION
Summary:
## What is the change?

This diff stack adds an optional method to the `base_node` for explicit shutdown. This is not BC-breaking as it not mandatory to implement `shutdown`, although encouraged.

## Motivation

```
data_node1 = IterableWrapper(DummyIterableDataset(1000000))
node1 = Prefetcher(data_node1, prefetch_factor=1000)

/ ... do some user code using node1 ... /

data_node2 = IterableWrapper(DummyIterableDataset(10000))
node2 = Prefetcher(data_node2, prefetch_factor=500)

/ ... training loop ... /
```
In the above snippet, we create two nodes with the second node actually used in training. The first one is created but not really iterated upon. Now, this is an anti-pattern, i.e. users should not be ideally doing this. Because the first node (`node1`), although not used has led to the creation of a background thread which is hard at work pulling items from its source nodes (till it populates a buffer of size 1000. Ok so what?
* This is wasting CPU cycles and memory
* This can easily led to a background thread running which will prevent graceful shutdown

Actually, the second point above is not a problem because we create the background thread in `Prefetcher` as a daemon thread. Which means it will exit once that is the only thread remaining. But it does led to wasted CPU cycles, potentially harming the actual training loop. 

To remediate this, we want to provide an optional shutdown method to let users explicitly shutdown the nodes they don't need. This would look like:

```
data_node1 = IterableWrapper(DummyIterableDataset(1000000))
node1 = Prefetcher(data_node1, prefetch_factor=1000)

/ ... do some user code using node1 ... /
node1.shutdown()

data_node2 = IterableWrapper(DummyIterableDataset(10000))
node2 = Prefetcher(data_node2, prefetch_factor=500)

/ ... training loop ... /
```

FWIW, pytorch dataloder also would behave the same way as code snippet 1. That is, if you start a dataloader and abandon it without deleting it, it will continue working in the background eating your CPU cycles. We are leaning towards an explicit shutdown vs relying on `del node1`.

Differential Revision: D75241769


