### PR TITLE
Add Round Robin Cycler Node

### DIFF
--- a/test/nodes/test_round_robin_cycler.py
+++ b/test/nodes/test_round_robin_cycler.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import itertools
+
+from parameterized import parameterized
+from torch.testing._internal.common_utils import TestCase
+from torchdata.nodes.adapters import IterableWrapper
+
+from torchdata.nodes.round_robin_cycler import RoundRobinNode
+
+from .utils import run_test_save_load_state
+
+
+class TestRoundRobinNode(TestCase):
+    def _create_test_nodes(self) -> list[IterableWrapper]:
+        node_A = IterableWrapper([{"text": "A", "label": 0}])
+        node_B = IterableWrapper(
+            [
+                {"text": "B", "label": 0},
+                {"text": "B", "label": 1},
+            ]
+        )
+        node_C = IterableWrapper(
+            [
+                {"text": "C", "label": 0},
+                {"text": "C", "label": 1},
+                {"text": "C", "label": 2},
+            ]
+        )
+        return [node_A, node_B, node_C]
+
+    def _create_single_node(self) -> list[IterableWrapper]:
+        return [IterableWrapper([{"text": "A", "label": 0}])]
+
+    def test_init(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        self.assertEqual(round_robin_node.source_nodes, nodes)
+        self.assertEqual(round_robin_node._total_items_yielded, 0)
+        self.assertEqual(round_robin_node._current_node_index, 0)
+        self.assertEqual(round_robin_node._active_nodes, list(range(len(nodes))))
+        self.assertEqual(round_robin_node._node_item_indices, {0: 0, 1: 0, 2: 0})
+
+    def test_init_empty_source_list(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            RoundRobinNode([])
+        self.assertIn("At least one source node must be provided", str(cm.exception))
+
+    def test_next(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        self.assertEqual(round_robin_node.next(), {"text": "A", "label": 0})
+        self.assertEqual(round_robin_node.next(), {"text": "B", "label": 0})
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 0})
+        self.assertEqual(round_robin_node.next(), {"text": "B", "label": 1})
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 1})
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 2})
+
+        with self.assertRaises(StopIteration):
+            round_robin_node.next()
+
+    def test_reset(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        for _ in range(2):
+            round_robin_node.next()
+
+        state = round_robin_node.get_state()
+
+        round_robin_node.reset()
+
+        self.assertEqual(round_robin_node._total_items_yielded, 0)
+        self.assertEqual(round_robin_node._current_node_index, 0)
+        self.assertEqual(round_robin_node._active_nodes, list(range(len(nodes))))
+        self.assertEqual(round_robin_node._node_item_indices, {0: 0, 1: 0, 2: 0})
+
+        restarted_round_robin_node = RoundRobinNode(nodes)
+        restarted_round_robin_node.reset(state)
+
+        self.assertEqual(restarted_round_robin_node._total_items_yielded, 2)
+        self.assertEqual(restarted_round_robin_node._current_node_index, 2)
+
+        self.assertEqual(next(restarted_round_robin_node), {"text": "C", "label": 0})
+
+    def test_single_source_node(self) -> None:
+        single_node = self._create_single_node()
+        round_robin_node = RoundRobinNode(single_node)
+
+        self.assertEqual(len(round_robin_node._active_nodes), 1)
+        self.assertEqual(round_robin_node._node_item_indices, {0: 0})
+
+        self.assertEqual(round_robin_node.next(), {"text": "A", "label": 0})
+
+        with self.assertRaises(StopIteration):
+            round_robin_node.next()
+
+    def test_explicit_iterator_exhaustion(self) -> None:
+        node_A = IterableWrapper([{"text": "A", "label": 0}])
+        node_B = IterableWrapper([{"text": "B", "label": 0}, {"text": "B", "label": 1}])
+        node_C = IterableWrapper(
+            [
+                {"text": "C", "label": 0},
+                {"text": "C", "label": 1},
+                {"text": "C", "label": 2},
+            ]
+        )
+
+        round_robin_node = RoundRobinNode([node_A, node_B, node_C])
+
+        self.assertEqual(round_robin_node.next(), {"text": "A", "label": 0})
+        self.assertEqual(round_robin_node.next(), {"text": "B", "label": 0})
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 0})
+
+        self.assertEqual(round_robin_node.next(), {"text": "B", "label": 1})
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 1})
+
+        self.assertEqual(round_robin_node.next(), {"text": "C", "label": 2})
+
+        with self.assertRaises(StopIteration):
+            round_robin_node.next()
+
+        self.assertEqual(len(round_robin_node._active_nodes), 0)
+        self.assertEqual(round_robin_node._node_item_indices, {0: 1, 1: 2, 2: 3})
+
+    def test_state_management(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        initial_state = round_robin_node.get_state()
+
+        self.assertIn(RoundRobinNode.SOURCE_STATES_KEY, initial_state)
+        self.assertIn(RoundRobinNode.ACTIVE_NODES_KEY, initial_state)
+        self.assertIn(RoundRobinNode.NODE_ITEM_INDICES_KEY, initial_state)
+        self.assertIn(RoundRobinNode.CURRENT_NODE_INDEX_KEY, initial_state)
+        self.assertIn(RoundRobinNode.TOTAL_ITEMS_YIELDED_KEY, initial_state)
+
+        self.assertEqual(initial_state[RoundRobinNode.TOTAL_ITEMS_YIELDED_KEY], 0)
+        self.assertEqual(initial_state[RoundRobinNode.CURRENT_NODE_INDEX_KEY], 0)
+        self.assertEqual(len(initial_state[RoundRobinNode.SOURCE_STATES_KEY]), len(nodes))
+        self.assertEqual(initial_state[RoundRobinNode.ACTIVE_NODES_KEY], list(range(len(nodes))))
+        self.assertEqual(initial_state[RoundRobinNode.NODE_ITEM_INDICES_KEY], {0: 0, 1: 0, 2: 0})
+
+        round_robin_node.next()
+        round_robin_node.next()
+
+        updated_state = round_robin_node.get_state()
+
+        self.assertEqual(updated_state[RoundRobinNode.TOTAL_ITEMS_YIELDED_KEY], 2)
+        self.assertEqual(updated_state[RoundRobinNode.CURRENT_NODE_INDEX_KEY], 2)
+        self.assertEqual(updated_state[RoundRobinNode.NODE_ITEM_INDICES_KEY], {0: 1, 1: 1, 2: 0})
+
+    def test_error_handling_invalid_state(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        incomplete_state = {
+            RoundRobinNode.TOTAL_ITEMS_YIELDED_KEY: 1,
+        }
+
+        with self.assertRaises(KeyError):
+            round_robin_node.reset(incomplete_state)
+
+    @parameterized.expand(itertools.product([0, 2, 4]))
+    def test_save_load_state(self, midpoint: int) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+        run_test_save_load_state(self, round_robin_node, midpoint)
+
+    def test_round_robin_behavior_detailed(self) -> None:
+        nodes = self._create_test_nodes()
+        round_robin_node = RoundRobinNode(nodes)
+
+        expected_sequence = [
+            {"text": "A", "label": 0},
+            {"text": "B", "label": 0},
+            {"text": "C", "label": 0},
+            {"text": "B", "label": 1},
+            {"text": "C", "label": 1},
+            {"text": "C", "label": 2},
+        ]
+
+        results = []
+        for expected_item in expected_sequence:
+            item = round_robin_node.next()
+            results.append(item)
+            self.assertEqual(item, expected_item)
+
+        self.assertEqual(results, expected_sequence)
+        self.assertEqual(round_robin_node._total_items_yielded, len(expected_sequence))
+
+        self.assertEqual(len(round_robin_node._active_nodes), 0)
+
+    def test_empty_nodes_mixed_with_valid_nodes(self) -> None:
+        empty_node = IterableWrapper([])
+        valid_node = IterableWrapper([{"text": "Valid", "label": 1}])
+        another_empty = IterableWrapper([])
+
+        round_robin_node = RoundRobinNode([empty_node, valid_node, another_empty])
+
+        self.assertEqual(round_robin_node.next(), {"text": "Valid", "label": 1})
+
+        with self.assertRaises(StopIteration):
+            round_robin_node.next()

--- a/torchdata/nodes/round_robin_cycler.py
+++ b/torchdata/nodes/round_robin_cycler.py
@@ -1,0 +1,115 @@
+import copy
+from collections.abc import Sequence
+from typing import Any, TypeVar
+
+from torchdata.nodes.base_node import BaseNode
+
+T = TypeVar("T")
+
+
+class RoundRobinCyclerNode(BaseNode[T]):
+    """A node that cycles through multiple datasets in a round-robin way.
+
+    This node takes a sequence of source nodes and iterates through them.
+    It yields one item from each node in order, and when a node is exhausted, it is
+    immediately removed from the rotation. This continues until all nodes are exhausted.
+
+    On complete exhaustion of all source nodes, the node will raise StopIteration.
+
+    Args:
+        source_nodes (Sequence[BaseNode[T]]): A sequence of source nodes.
+
+    """
+
+    SOURCE_STATES_KEY = "source_states"
+    ACTIVE_NODES_KEY = "active_nodes"
+    NODE_ITEM_INDICES_KEY = "node_item_indices"
+    CURRENT_NODE_INDEX_KEY = "current_node_index"
+    TOTAL_ITEMS_YIELDED_KEY = "total_items_yielded"
+
+    def __init__(
+        self,
+        source_nodes: Sequence[BaseNode[T]],
+    ) -> None:
+        super().__init__()
+
+        if not source_nodes:
+            raise ValueError("At least one source node must be provided")
+
+        self.source_nodes = source_nodes
+        self._total_items_yielded = 0
+        self._current_node_index = 0
+        self._active_nodes = list(range(len(self.source_nodes)))
+
+        # Initialize each node's item index to 0
+        # Keeps track of how many items have been yielded from each individual source node
+        self._node_item_indices = {i: 0 for i in range(len(self.source_nodes))}
+
+    def reset(self, initial_state: dict[str, Any] | None = None):
+        super().reset(initial_state)
+
+        if initial_state is not None:
+            self._total_items_yielded = initial_state[self.TOTAL_ITEMS_YIELDED_KEY]
+            self._active_nodes = initial_state[self.ACTIVE_NODES_KEY]
+            self._node_item_indices = initial_state[self.NODE_ITEM_INDICES_KEY]
+            self._current_node_index = initial_state[self.CURRENT_NODE_INDEX_KEY]
+
+            for i in range(len(self.source_nodes)):
+                self.source_nodes[i].reset(initial_state[self.SOURCE_STATES_KEY][i])
+        else:
+            # Force a fresh iterator from all source nodes
+            self._total_items_yielded = 0
+            self._active_nodes = list(range(len(self.source_nodes)))
+            self._node_item_indices = {i: 0 for i in range(len(self.source_nodes))}
+            self._current_node_index = 0
+
+            for node in self.source_nodes:
+                node.reset()
+
+    def next(self) -> T:
+        if not self._active_nodes:
+            raise StopIteration()
+
+        # Make sure we don't go out of bounds with the active nodes
+        if self._current_node_index >= len(self._active_nodes):
+            self._current_node_index = 0
+
+        # Get the actual source node index from active nodes
+        node_index = self._active_nodes[self._current_node_index]
+        node = self.source_nodes[node_index]
+
+        try:
+            item = next(node)
+
+            # Update state
+            self._total_items_yielded += 1
+            self._node_item_indices[node_index] += 1
+
+            # Move to the next node in the rotation
+            self._current_node_index = (self._current_node_index + 1) % len(self._active_nodes)
+
+            return item
+
+        except StopIteration:
+            # Remove this node from active nodes
+            self._active_nodes.pop(self._current_node_index)
+
+            # If we've removed all nodes, we're done
+            if not self._active_nodes:
+                raise StopIteration()
+
+            # Make sure the index stays valid (it might now be out of bounds)
+            if self._current_node_index >= len(self._active_nodes):
+                self._current_node_index = 0
+
+            # Try the next node
+            return self.next()
+
+    def get_state(self) -> dict[str, Any]:
+        return {
+            self.SOURCE_STATES_KEY: [node.state_dict() for node in self.source_nodes],
+            self.ACTIVE_NODES_KEY: copy.deepcopy(self._active_nodes),
+            self.NODE_ITEM_INDICES_KEY: copy.deepcopy(self._node_item_indices),
+            self.CURRENT_NODE_INDEX_KEY: self._current_node_index,
+            self.TOTAL_ITEMS_YIELDED_KEY: self._total_items_yielded,
+        }


### PR DESCRIPTION
### Changes
- Add a new `RoundRobinCyclerNode` that enables cycling through multiple datasets in a round-robin fashion, which is useful for balanced sampling across multiple data sources.
- Add corresponding tests


