### PR TITLE
Explicitly import packaging in validate_binaries.sh

### DIFF
--- a/.github/scripts/validate_binaries.sh
+++ b/.github/scripts/validate_binaries.sh
@@ -10,6 +10,9 @@ AWS_ENABLED=1
 # shellcheck disable=SC2086
 pip install ${PYTORCH_PIP_PREFIX:-} torchdata --extra-index-url "${PYTORCH_PIP_DOWNLOAD_URL}"
 
+# Fixes https://github.com/meta-pytorch/data/issues/1539
+pip install packaging
+
 
 case "${AWS_ENABLED}" in
     "0")


### PR DESCRIPTION
Fixes https://github.com/meta-pytorch/data/issues/1539

This might be a tmp fix for 3.14, but should be safe and no-op for other python builds.