### PR TITLE
[Nodes] MapStyleWrapper exposes ParallelMapper kwargs for parallelism

### DIFF
--- a/test/nodes/test_adapters.py
+++ b/test/nodes/test_adapters.py
@@ -119,6 +119,35 @@ class TestMapStyle(TestCase):
         run_test_save_load_state(self, node, midpoint)
 
 
+class TestMapStyleParallelMapper(TestCase):
+    @parameterized.expand([1, 4])
+    def test_parallel_workers(self, num_workers: int):
+        n = 20
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n), num_workers=num_workers)
+        for _ in range(2):
+            node.reset()
+            result = list(node)
+            self.assertEqual(len(result), n)
+            self.assertEqual({row["step"] for row in result}, set(range(n)))
+
+    @parameterized.expand([1, 4])
+    def test_parallel_workers_in_order(self, num_workers: int):
+        n = 20
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n), num_workers=num_workers, in_order=True)
+        for _ in range(2):
+            node.reset()
+            result = list(node)
+            self.assertEqual(len(result), n)
+            for i, row in enumerate(result):
+                self.assertEqual(row["step"], i)
+
+    @parameterized.expand([0, 7])
+    def test_save_load_state_parallel(self, midpoint: int):
+        n = 20
+        node = MapStyleWrapper(DummyMapDataset(n), sampler=range(n), num_workers=2)
+        run_test_save_load_state(self, node, midpoint)
+
+
 class TestSamplerWrapper(TestCase):
     def test_sampler_wrapper(self):
         n = 20

--- a/torchdata/nodes/adapters.py
+++ b/torchdata/nodes/adapters.py
@@ -11,7 +11,7 @@ from torch.utils.data import Sampler
 
 from torchdata.nodes.base_node import BaseNode, T
 
-from .map import Mapper
+from .map import ParallelMapper
 
 from .types import Stateful
 
@@ -75,16 +75,20 @@ class IterableWrapper(BaseNode[T]):
         return state_dict
 
 
-def MapStyleWrapper(map_dataset: Mapping[K, T], sampler: Sampler[K]) -> BaseNode[T]:
-    """Thin Wrapper that converts any MapDataset in to a torchdata.node
-    If you want parallelism, copy this and replace Mapper with ParallelMapper.
+def MapStyleWrapper(map_dataset: Mapping[K, T], sampler: Sampler[K], **parallel_mapper_kwargs) -> BaseNode[T]:
+    """Thin Wrapper that converts any MapDataset in to a torchdata.node.
 
     Args:
-        map_dataset (Mapping[K, T]): - Apply map_dataset.__getitem__ to the outputs of sampler.
-        sampler (Sampler[K]):
+        map_dataset (Mapping[K, T]): Apply map_dataset.__getitem__ to the outputs of sampler.
+        sampler (Sampler[K]): Sampler to generate indices for map_dataset.
+        **parallel_mapper_kwargs: Optional kwargs forwarded to :class:`ParallelMapper`.
+            Supported kwargs include ``num_workers`` (default 0), ``in_order``,
+            ``method``, ``multiprocessing_context``, ``max_concurrent``,
+            ``snapshot_frequency``, and ``prebatch``.
     """
+    parallel_mapper_kwargs.setdefault("num_workers", 0)
     sampler_node: SamplerWrapper[K] = SamplerWrapper(sampler)
-    mapper_node = Mapper(sampler_node, map_dataset.__getitem__)
+    mapper_node = ParallelMapper(sampler_node, map_dataset.__getitem__, **parallel_mapper_kwargs)
     return mapper_node
 
 

--- a/torchdata/nodes/map.py
+++ b/torchdata/nodes/map.py
@@ -162,6 +162,7 @@ class _ParallelMapperIter(Iterator[T]):
         self._sem = threading.BoundedSemaphore(value=self._max_tasks)
 
         self._done = False
+        self._pool_shutdown = False
 
         self._stop = threading.Event()
         self._mp_stop = mp_context.Event()
@@ -296,7 +297,8 @@ class _ParallelMapperIter(Iterator[T]):
     def _shutdown(self, cancel_futures=False):
         self._stop.set()
         self._mp_stop.set()
-        if hasattr(self, "pool"):
+        if hasattr(self, "pool") and not self._pool_shutdown:
+            self._pool_shutdown = True
             if cancel_futures:
                 # Wait for all threads to finish before returning, but cancel any
                 # futures that are pending. This is used when calling _shutdown()


### PR DESCRIPTION
Allow MapStyleWrapper to accept **parallel_mapper_kwargs forwarded to ParallelMapper, defaulting num_workers=0 for backwards compatibility. Users can now enable parallel data loading by passing num_workers > 0 (and any other ParallelMapper kwargs such as in_order, method, etc.) without having to manually compose SamplerWrapper + ParallelMapper.

Fixes #1387

Also fixes a flaky test (test_thread_pool_executor_cancel_futures_shutdown):

_ParallelMapperIter._shutdown had no idempotency guard, so pool.shutdown() could be called twice on the same instance — once explicitly with cancel_futures=False, and again when _ParallelMapperImpl.__del__ raced in and called _shutdown(cancel_futures=True) before GC finished. Since mock.patch intercepts all ThreadPoolExecutor.shutdown calls class-wide, the second call with cancel_futures=True became the last recorded call and broke the assertion.

Fixed by adding a _pool_shutdown flag to _ParallelMapperIter.__init__ so pool.shutdown() is only ever invoked once per iterator instance.


Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- If you are adding a new node, ensure you read that section in the contribution guide, as it includes requirements for
  functionality and testing.

Fixes #{issue number}

### Changes

-
-
