### PR TITLE
Add missing copyright headers to __init__.py files

### DIFF
--- a/test/nodes/__init__.py
+++ b/test/nodes/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.

--- a/torchdata/nodes/io/__init__.py
+++ b/torchdata/nodes/io/__init__.py
@@ -1,3 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
 from .file_list import FileLister
 from .file_read import FileReader
 

--- a/torchdata/nodes/samplers/__init__.py
+++ b/torchdata/nodes/samplers/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Adds the standard Meta Platforms BSD-style copyright header to three files that were missing it, consistent with the rest of the codebase.
