### PR TITLE
[Nodes] Add Compose utility for chaining callables

### DIFF
--- a/test/nodes/test_snapshot_store.py
+++ b/test/nodes/test_snapshot_store.py
@@ -82,7 +82,7 @@ class TestQueueSnapshotStore(TestCase):
             thread = threading.Thread(target=_worker_raises_after, args=(QUEUE_TIMEOUT * 3.0,))
             thread.start()
             with self.assertRaisesRegex(RuntimeError, r"thread.is_alive\(\)=False"):
-                store.get_initial_snapshot(thread, QUEUE_TIMEOUT * 5.0)
+                store.get_initial_snapshot(thread, QUEUE_TIMEOUT * 10.0)
             thread.join()
 
     def test_future_dead_error(self) -> None:

--- a/test/nodes/test_transforms.py
+++ b/test/nodes/test_transforms.py
@@ -1,0 +1,79 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from torch.testing._internal.common_utils import TestCase
+from torchdata.nodes import Compose, Mapper, ParallelMapper
+from torchdata.nodes.adapters import IterableWrapper
+
+
+class TestCompose(TestCase):
+    def test_basic_composition(self):
+        compose = Compose([lambda x: x + 1, lambda x: x * 2])
+        self.assertEqual(compose(3), 8)  # (3 + 1) * 2
+
+    def test_single_function(self):
+        compose = Compose([lambda x: x ** 2])
+        self.assertEqual(compose(4), 16)
+
+    def test_order_is_sequential(self):
+        # Functions applied left to right: first divide then add, not add then divide
+        compose = Compose([lambda x: x / 2, lambda x: x + 10])
+        self.assertAlmostEqual(compose(4), 12.0)  # 4/2=2, 2+10=12
+
+    def test_empty_fns_raises(self):
+        with self.assertRaises(ValueError):
+            Compose([])
+
+    def test_with_mapper_node(self):
+        n = 10
+        source = IterableWrapper(range(n))
+        node = Mapper(source, Compose([lambda x: x + 1, lambda x: x * 3]))
+        for _ in range(2):
+            node.reset()
+            result = list(node)
+            self.assertEqual(result, [(i + 1) * 3 for i in range(n)])
+
+    def test_with_parallel_mapper_node(self):
+        n = 10
+        source = IterableWrapper(range(n))
+        node = ParallelMapper(
+            source,
+            Compose([lambda x: x + 1, lambda x: x * 3]),
+            num_workers=2,
+            in_order=True,
+        )
+        for _ in range(2):
+            node.reset()
+            result = list(node)
+            self.assertEqual(result, [(i + 1) * 3 for i in range(n)])
+
+    def test_fns_attribute(self):
+        fns = [lambda x: x, lambda x: x]
+        compose = Compose(fns)
+        self.assertEqual(len(compose.fns), 2)
+        # fns is a copy, not the original list
+        fns.append(lambda x: x)
+        self.assertEqual(len(compose.fns), 2)
+
+    def test_repr(self):
+        compose = Compose([lambda x: x])
+        r = repr(compose)
+        self.assertIn("Compose", r)
+
+    def test_string_transforms(self):
+        compose = Compose([str.strip, str.upper])
+        self.assertEqual(compose("  hello  "), "HELLO")
+
+    def test_dict_transforms(self):
+        def scale(d):
+            return {k: v * 2 for k, v in d.items()}
+
+        def shift(d):
+            return {k: v + 1 for k, v in d.items()}
+
+        compose = Compose([scale, shift])
+        result = compose({"a": 3, "b": 5})
+        self.assertEqual(result, {"a": 7, "b": 11})  # scale: {6, 10}, shift: {7, 11}

--- a/torchdata/nodes/__init__.py
+++ b/torchdata/nodes/__init__.py
@@ -17,12 +17,14 @@ from .prefetch import Prefetcher
 from .samplers.multi_node_weighted_sampler import MultiNodeWeightedSampler
 from .samplers.stop_criteria import StopCriteria
 from .shuffler import Shuffler
+from .transforms import Compose
 from .types import Stateful
 
 
 __all__ = [
     "BaseNode",
     "Batcher",
+    "Compose",
     "Cycler",
     "Filter",
     "Header",

--- a/torchdata/nodes/transforms.py
+++ b/torchdata/nodes/transforms.py
@@ -39,5 +39,5 @@ class Compose:
         return x
 
     def __repr__(self) -> str:
-        fns_str = ",\n    ".join(repr(fn) for fn in self.fns)
-        return f"Compose([\n    {fns_str}\n])"
+        fns_str = ", ".join(repr(fn) for fn in self.fns)
+        return f"Compose([{fns_str}])"

--- a/torchdata/nodes/transforms.py
+++ b/torchdata/nodes/transforms.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Any, Callable, Sequence
+
+
+class Compose:
+    """Composes multiple callables into a single callable that applies them sequentially.
+
+    Useful for fusing multiple mapping functions into a single :class:`Mapper` or
+    :class:`ParallelMapper` node instead of chaining multiple nodes.
+
+    Args:
+        fns (Sequence[Callable]): Sequence of callables to apply in order.
+            Each callable receives the output of the previous one as its input.
+
+    Raises:
+        ValueError: If ``fns`` is empty.
+
+    Example::
+
+        >>> from torchdata.nodes import Mapper, Compose
+        >>> def normalize(x): return x / 255.0
+        >>> def to_float(x): return float(x)
+        >>> node = Mapper(source, Compose([to_float, normalize]))
+    """
+
+    def __init__(self, fns: Sequence[Callable[[Any], Any]]) -> None:
+        if not fns:
+            raise ValueError("Compose requires at least one function, got an empty sequence.")
+        self.fns = list(fns)
+
+    def __call__(self, x: Any) -> Any:
+        for fn in self.fns:
+            x = fn(x)
+        return x
+
+    def __repr__(self) -> str:
+        fns_str = ",\n    ".join(repr(fn) for fn in self.fns)
+        return f"Compose([\n    {fns_str}\n])"


### PR DESCRIPTION
Adds a Compose class that applies a sequence of callables in order, allowing users to fuse multiple mapping functions into a single Mapper or ParallelMapper node rather than chaining multiple nodes.

    node = Mapper(source, Compose([normalize, augment, to_tensor]))

Closes #1399


Fix flaky test_thread_dead_error on Windows:

test_thread_dead_error creates a thread that sleeps for QUEUE_TIMEOUT * 3.0 (0.3s) and expects get_initial_snapshot to raise with thread.is_alive()=False before its timeout of QUEUE_TIMEOUT * 5.0 (0.5s). On Windows, time.sleep has ~15ms timer resolution, so each queue.get(timeout=QUEUE_TIMEOUT) call can overshoot by ~15ms. Across 4–5 loop iterations this accumulates enough to push the total elapsed time past the 0.5s timeout before the thread's is_alive() check fires — causing the error to report thread.is_alive()=True instead. Increased the timeout to QUEUE_TIMEOUT * 10.0 (1.0s), giving 3× headroom over the thread's sleep. The loop still exits early as soon as is_alive() returns False, so there's no impact on test runtime in the normal case.
