### PR TITLE
Fix incorrect behaviour of loader when load_state_dict is after state…

### DIFF
--- a/torchdata/nodes/loader.py
+++ b/torchdata/nodes/loader.py
@@ -42,7 +42,8 @@ class Loader(Generic[T]):
             self._it = LoaderIterator(self)
         elif self._iter_for_state_dict:
             self._iter_for_state_dict = False
-            return self._it  # This was already pre-called to get a state dict
+            if self._next_iter_state_dict is None:
+                return self._it  # This was already pre-called to get a state dict
 
         if self._next_iter_state_dict is not None:
             self._it.reset(initial_state=self._next_iter_state_dict)


### PR DESCRIPTION
…_dict() call

Fixes when load_state_dict and iter are called after state_dict()

Example:

```python
import torchdata.nodes as tn

n = tn.IterableWrapper(range(10))
l = tn.Loader(n)
it = iter(l)
for i in range(5):
    assert i == next(it)

sd = l.state_dict()
n = tn.IterableWrapper(range(10))
l = tn.Loader(n)
l.state_dict()  # Critical line
l.load_state_dict(sd)
# Now, we should have continued from 5
it = iter(l)
# But it continues from 0, not respecting load_state_dict 
for i in range(5):
    assert i == next(it)  # Should have been i + 5 == next(it)
```


I did not open an issue on that, but it's pretty obvious what the problem is.
load_state_dict specifies that this behaviour is incorrect: https://meta-pytorch.org/data/main/torchdata.nodes.html#torchdata.nodes.Loader.load_state_dict
"Loads a state_dict which will be used to initialize the next iter() requested from this loader."

It makes sense to add tests for this behaviour, did not do that yet

Please read through our [contribution guide](https://github.com/pytorch/data/blob/main/CONTRIBUTING.md) prior to
creating your pull request.

- If you are adding a new node, ensure you read that section in the contribution guide, as it includes requirements for
  functionality and testing.

### Changes

- Fix incorrect iterator when called state_dict before load_state_dict
-
